### PR TITLE
schema fixes for <files>

### DIFF
--- a/src/schema/files.rnc
+++ b/src/schema/files.rnc
@@ -6,14 +6,11 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 file_src = file_contents
   | file_location
-y2_files =
-  file_permissions
-  | file_owner
-  | file_script
 files =
   element files {
     LIST,
-    element file { file_src? & file_path & y2_files* }+
+    element file { file_src? & file_path & file_permissions?
+	& file_owner? & file_script? }+
   }
 file_contents = element file_contents { text }
 file_location = element file_location { text }


### PR DESCRIPTION
Add file_location to schema, and update the schema to enforce what YaST expects.

(Either file_location or file_contents, not both; file_path mandatory; everything else optional.)
