### PR TITLE
Remove forgotten runlevel dependency

### DIFF
--- a/src/clients/inst_autosetup_upgrade.rb
+++ b/src/clients/inst_autosetup_upgrade.rb
@@ -27,7 +27,6 @@ module Yast
       Yast.import "Bootloader"
       Yast.import "BootCommon"
       Yast.import "Popup"
-      Yast.import "RunlevelEd"
       Yast.import "Arch"
       Yast.import "AutoinstLVM"
       Yast.import "AutoinstRAID"


### PR DESCRIPTION
No code in the client file seems to reference the `RunlevelEd` module, so this change should be enough.
