### PR TITLE
added build dependency to systemd

### DIFF
--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -31,6 +31,13 @@ BuildRequires:  yast2-installation-control
 # xmllint
 BuildRequires:  libxml2-tools
 
+# %%{_unitdir} macro definition is in a separate package since 13.1
+%if 0%{?suse_version} >= 1310
+BuildRequires:  systemd-rpm-macros
+%else
+BuildRequires:  systemd
+%endif
+
 Requires:       autoyast2-installation = %{version}
 Requires:       libxslt
 Requires:       yast2


### PR DESCRIPTION
needed because of `%{_unitdir}` RPM macro definition (otherwise it's not expanded and is used literally)

Fixes this build error in 12.3 target:

```
error: Installed (but unpackaged) file(s) found:
    /%{_unitdir}/autoyast-initscripts.service
```
