### PR TITLE
Bug 908271

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/SLE-12-GA/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-storage yast2-xml yast2-transfer yast2-services-manager yast2-installation-control" -g "rspec:2.14.1 yast-rake gettext"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-storage yast2-xml yast2-transfer yast2-services-manager yast2-installation-control yast2-packager" -g "rspec:2.14.1 yast-rake gettext"
 script:
     - rake check:syntax
     - rake check:pot

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 15 15:48:14 CET 2015 - schubi@suse.de
+
+- autoyast=file:///<autoinst.xml> : Mount the installation source
+  in order to copy AutoYaST configuration file into inst_sys.
+  (bnc#908271)
+- 3.1.69.2
+
+-------------------------------------------------------------------
 Thu Dec 18 10:54:01 CET 2014 - schubi@suse.de
 
 - Removed code which will be already done by service_manager.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -36,6 +36,7 @@ BuildRequires:  yast2-storage
 BuildRequires:  yast2-xml
 BuildRequires:  yast2-transfer
 BuildRequires:  yast2-services-manager
+BuildRequires:  yast2-packager
 
 # %%{_unitdir} macro definition is in a separate package since 13.1
 %if 0%{?suse_version} >= 1310

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.69.1
+Version:        3.1.69.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/io.rb
+++ b/src/include/autoinstall/io.rb
@@ -19,6 +19,7 @@ module Yast
       Yast.import "TFTP"
       Yast.import "AutoinstConfig"
       Yast.import "Storage"
+      Yast.import "InstURL"
 
       @GET_error = ""
     end
@@ -177,9 +178,11 @@ module Yast
             "Trying to find file on installation media: %1",
             Installation.boot
           )
-          cdrom = Convert.to_string(SCR.Read(path(".etc.install_inf.Cdrom")))
-          if Installation.boot == "cd" && cdrom
-            cdrom_device = Ops.add("/dev/", cdrom)
+          # The Cdrom entry in install.inf is obsolete. So we are using the
+          # entry which is defined in InstUrl module. (bnc#908271)
+          install_url = InstURL.installInf2Url("")
+          if Installation.boot == "cd" && install_url
+            cdrom_device = Builtins.regexpsub(install_url, "devices=(.*)$", "\\1")
             already_mounted = Ops.add(
               Ops.add("grep ", cdrom_device),
               " /proc/mounts ;"

--- a/src/include/autoinstall/io.rb
+++ b/src/include/autoinstall/io.rb
@@ -181,8 +181,8 @@ module Yast
           # The Cdrom entry in install.inf is obsolete. So we are using the
           # entry which is defined in InstUrl module. (bnc#908271)
           install_url = InstURL.installInf2Url("")
-          if Installation.boot == "cd" && install_url
-            cdrom_device = Builtins.regexpsub(install_url, "devices=(.*)$", "\\1")
+          cdrom_device = install_url ? Builtins.regexpsub(install_url, "devices=(.*)$", "\\1") : ""
+          if Installation.boot == "cd" && !cdrom_device.empty?
             already_mounted = Ops.add(
               Ops.add("grep ", cdrom_device),
               " /proc/mounts ;"

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -204,7 +204,7 @@ module Yast
     # Probe all system data to build  a set of rules
     # @return [void]
     def ProbeRules
-      return if !@ATTR || @ATTR.size>0
+      return if @ATTR.size>0
       # SMBIOS Data
       bios = Convert.to_list(SCR.Read(path(".probe.bios")))
 

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -204,7 +204,7 @@ module Yast
     # Probe all system data to build  a set of rules
     # @return [void]
     def ProbeRules
-      return if @ATTR.size>0
+      return if !@ATTR || @ATTR.size>0
       # SMBIOS Data
       bios = Convert.to_list(SCR.Read(path(".probe.bios")))
 


### PR DESCRIPTION
 autoyast=file:///<autoinst.xml> : Mount the installation source
 in order to copy AutoYaST configuration file into inst_sys.
(bnc#908271)