### PR TITLE
Bug 909349; Multipath in AutoYaST

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 19 09:10:15 CET 2015 - schubi@suse.de
+
+- Checking if the disk is -partitionable- instead of checking if it
+  is a real disk. Needed for Multipath disks. (bnc#909349)
+- 3.1.69.3
+
+-------------------------------------------------------------------
 Thu Jan 15 15:48:14 CET 2015 - schubi@suse.de
 
 - autoyast=file:///<autoinst.xml> : Mount the installation source

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.69.2
+Version:        3.1.69.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -1124,7 +1124,7 @@ module Yast
           )
           Builtins.y2milestone("device %1 not found in TargetMap", device)
         end
-         if Storage.IsPartitionable(data)
+        if Storage.IsPartitionable(data)
           @ZeroNewPartitions = data.fetch("zero_new_partitions",true)
           # that's not really nice. Just an undocumented fallback which should never be used
           Builtins.y2milestone("Creating partition plans for %1", device)

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -1079,7 +1079,7 @@ module Yast
       result = false
       changed = false
       Builtins.foreach(@AutoTargetMap) do |device, data|
-        if Storage.IsRealDisk(data) && data.fetch("initialize", false)
+        if Storage.IsPartitionable(data) && data.fetch("initialize", false)
           Ops.set(initial_target_map, [device, "delete"], true)
 	  changed = true
           if data.has_key?("disklabel")
@@ -1124,7 +1124,7 @@ module Yast
           )
           Builtins.y2milestone("device %1 not found in TargetMap", device)
         end
-        if Storage.IsRealDisk(data)
+         if Storage.IsPartitionable(data)
           @ZeroNewPartitions = data.fetch("zero_new_partitions",true)
           # that's not really nice. Just an undocumented fallback which should never be used
           Builtins.y2milestone("Creating partition plans for %1", device)


### PR DESCRIPTION
Checking if the disk is -partitionable- instead of checking if it is a real disk.