### PR TITLE
Fix AutoInstallRules#ProbeRules to not crash when .content.DISTRO is nil

### DIFF
--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -36,6 +36,14 @@ module Yast
 
       Yast.include self, "autoinstall/io.rb"
 
+      reset
+      AutoInstallRules()
+    end
+
+    # Reset the module's state
+    #
+    # @return nil
+    def reset
       @userrules = false
       @dontmergeIsDefault = true
       @dontmergeBackup = []
@@ -50,19 +58,12 @@ module Yast
       @ATTR = {}
 
       @installed_product = ""
-
       @installed_product_version = ""
-
       @hostname = ""
-
       @hostaddress = ""
-
       @network = ""
-
       @domain = ""
-
       @arch = ""
-
       @karch = ""
 
       # Taken from smbios
@@ -78,31 +79,19 @@ module Yast
       @board = ""
 
       @memsize = 0
-
       @disksize = []
-
       @totaldisk = 0
-
       @hostid = ""
-
       @mac = ""
-
       @linux = 0
-
       @others = 0
-
       @xserver = ""
-
       @haspcmcia = "0"
 
       #///////////////////////////////////////////
       #///////////////////////////////////////////
-
       @NonLinuxPartitions = []
-
       @LinuxPartitions = []
-
-
       @UserRules = {}
 
       # Local Variables
@@ -110,9 +99,8 @@ module Yast
       @env = {}
 
       @tomerge = []
-
       @element2file = {}
-      AutoInstallRules()
+      nil
     end
 
     # Cleanup XML file from namespaces put by xslt
@@ -322,8 +310,8 @@ module Yast
       distro_str = SCR.Read(path(".content.DISTRO"))
       log.info "DISTRO: #{distro_str}"
 
-      distro = distro_map(distro_str)
-      cpe = distro ? cpeid_map(distro["cpeid"]) : {}
+      distro = distro_map(distro_str) || {}
+      cpe = cpeid_map(distro["cpeid"]) || {}
 
       @installed_product = distro["name"] || ""
       @installed_product_version = cpe["version"] || ""

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -96,6 +96,21 @@ describe "Yast::AutoInstallRules" do
       expect(Yast::AutoInstallRules.installed_product).to eq("SUSE Linux Enterprise Server 12")
       expect(Yast::AutoInstallRules.installed_product_version).to eq("12")
     end
+
+    context "when .content.DISTRO is not found" do
+      before(:each) do
+        subject.reset
+        allow(Yast::SCR).to receive(:Read).with(any_args)
+      end
+
+      it 'set installed_product and installed_product_version to blank string' do
+        expect(Yast::SCR).to receive(:Read).with(Yast::Path.new(".content.DISTRO")).
+          and_return(nil)
+        subject.ProbeRules
+        expect(Yast::AutoInstallRules.installed_product).to eq('')
+        expect(Yast::AutoInstallRules.installed_product_version).to eq('')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
`#ProbeRules` crashes when `SCR.Read(path(".content.DISTRO")` returns nil. In openSUSE 13.2, Tumbleweed and SLES 12, calling `yast2 ayast_probe` exhibits this behaviour. Hopefully this PR fix that issue.

BTW, I've moved the initialization of instance variable to a `#reset` method so I could test `#ProbeRules` with different scenarios (it does nothing when `@ATTR` is not empty). I dunno if I must write a test for that new method (it contains just a bunch of initializations).