### PR TITLE
Avoid yast2 ayast_probe crashing when finding the installed distro

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr  7 15:26:44 UTC 2015 - igonzalezsosa@suse.com
+
+- Avoid ayast_probe module crashing when called from an installed
+  system.
+  (bnc#926241)
+- 3.1.73
+
+-------------------------------------------------------------------
 Thu Mar 26 17:00:32 CET 2015 - schubi@suse.de
 
 - New autoinst flag in general/mode section: final_restart_services.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.72
+Version:        3.1.73
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -36,6 +36,15 @@ module Yast
 
       Yast.include self, "autoinstall/io.rb"
 
+      reset
+    end
+
+    # Reset the module's state
+    #
+    # @return nil
+    #
+    # @see #AutoInstallRules
+    def reset
       @userrules = false
       @dontmergeIsDefault = true
       @dontmergeBackup = []
@@ -50,19 +59,12 @@ module Yast
       @ATTR = {}
 
       @installed_product = ""
-
       @installed_product_version = ""
-
       @hostname = ""
-
       @hostaddress = ""
-
       @network = ""
-
       @domain = ""
-
       @arch = ""
-
       @karch = ""
 
       # Taken from smbios
@@ -78,31 +80,19 @@ module Yast
       @board = ""
 
       @memsize = 0
-
       @disksize = []
-
       @totaldisk = 0
-
       @hostid = ""
-
       @mac = ""
-
       @linux = 0
-
       @others = 0
-
       @xserver = ""
-
       @haspcmcia = "0"
 
       #///////////////////////////////////////////
       #///////////////////////////////////////////
-
       @NonLinuxPartitions = []
-
       @LinuxPartitions = []
-
-
       @UserRules = {}
 
       # Local Variables
@@ -110,7 +100,6 @@ module Yast
       @env = {}
 
       @tomerge = []
-
       @element2file = {}
       AutoInstallRules()
     end
@@ -322,8 +311,8 @@ module Yast
       distro_str = SCR.Read(path(".content.DISTRO"))
       log.info "DISTRO: #{distro_str}"
 
-      distro = distro_map(distro_str)
-      cpe = distro ? cpeid_map(distro["cpeid"]) : {}
+      distro = distro_map(distro_str) || {}
+      cpe = cpeid_map(distro["cpeid"]) || {}
 
       @installed_product = distro["name"] || ""
       @installed_product_version = cpe["version"] || ""

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -96,6 +96,21 @@ describe "Yast::AutoInstallRules" do
       expect(Yast::AutoInstallRules.installed_product).to eq("SUSE Linux Enterprise Server 12")
       expect(Yast::AutoInstallRules.installed_product_version).to eq("12")
     end
+
+    context "when .content.DISTRO is not found" do
+      before(:each) do
+        subject.reset
+        allow(Yast::SCR).to receive(:Read).with(any_args)
+      end
+
+      it 'set installed_product and installed_product_version to blank string' do
+        expect(Yast::SCR).to receive(:Read).with(Yast::Path.new(".content.DISTRO")).
+          and_return(nil)
+        subject.ProbeRules
+        expect(Yast::AutoInstallRules.installed_product).to eq('')
+        expect(Yast::AutoInstallRules.installed_product_version).to eq('')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Just porting the fix from SLES12 to master.