### PR TITLE
Fix a potential Id collision on password widgets

### DIFF
--- a/src/include/autoinstall/ask.rb
+++ b/src/include/autoinstall/ask.rb
@@ -233,7 +233,7 @@ module Yast
                 Ops.get_string(ask, "default", "")
               )
               widget2 = Password(
-                Id(:pass2), # FIXME: choose a better Id to avoid collisions
+                Id("#{entry_id}_pass2"),
                 Opt(:notify),
                 "",
                 Ops.get_string(ask, "default", "")
@@ -374,7 +374,7 @@ module Yast
                   val = Builtins.tointeger(Convert.to_string(val))
                 end
                 if Ops.get_boolean(ask, "password", false) == true
-                  pass2 = Convert.to_string(UI.QueryWidget(Id(:pass2), :Value))
+                  pass2 = Convert.to_string(UI.QueryWidget(Id("#{entry_id}_pass2"), :Value))
                   if pass2 != Convert.to_string(val)
                     Popup.Error("The two passwords mismatch.")
                     runAgain = 1 # Run the same dialog again.

--- a/test/include/ask_test.rb
+++ b/test/include/ask_test.rb
@@ -89,7 +89,7 @@ describe "Yast::AutoinstallAskInclude" do
             with(Id("0_0"), Opt(:notify), ask["question"], ask["default"]).
             and_call_original
           expect(client).to receive(:Password).
-            with(Id(:pass2), Opt(:notify), "", ask["default"]).
+            with(Id("0_0_pass2"), Opt(:notify), "", ask["default"]).
             and_call_original
           client.askDialog
         end
@@ -214,6 +214,17 @@ describe "Yast::AutoinstallAskInclude" do
               expect(Yast::SCR).to receive(:Write).
                 with(Yast::Path.new(".target.string"), file_path, "true").
                 and_return(true)
+              client.askDialog
+            end
+          end
+
+          context "when asking for a 'password' and values don't match" do
+            let(:ask) { BASE_ASK.merge("password" => true) }
+
+            it "shows an error message and try run the dialog again" do
+              expect(Yast::UI).to receive(:QueryWidget).
+                with(Id("0_0_pass2"), :Value).and_return("some-other-thing", response)
+              expect(Yast::Popup).to receive(:Error).with("The two passwords mismatch.")
               client.askDialog
             end
           end

--- a/test/include/ask_test.rb
+++ b/test/include/ask_test.rb
@@ -160,6 +160,21 @@ describe "Yast::AutoinstallAskInclude" do
           client.askDialog
         end
       end
+
+      context "when ask-list contains more than one password question" do
+        let(:first_pass_ask) { BASE_ASK.merge("password" => true)}
+        let(:second_pass_ask) { BASE_ASK.merge("password" => true, "element" => 1)}
+        let(:ask_list) { [first_pass_ask, second_pass_ask] }
+
+        it "creates two password widgets for each question without repeating the Ids" do
+          expect(Yast::UI).to receive(:OpenDialog)
+          ["0_0", "0_0_pass2", "0_1", "0_1_pass2"].each do |wid|
+            expect(client).to receive(:Password).
+              with(Id(wid), anything, anything, anything).and_call_original
+          end
+          client.askDialog
+        end
+      end
     end
 
     describe "dialogs actions" do


### PR DESCRIPTION
AutoinstallAskInclude#askDialog use always the same id for password fields (thanks @jreidinger for pointing that).