### PR TITLE
Reporting unknown and unsupported profile sections

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  5 15:05:18 CEST 2015 - locilka@suse.com
+
+- Reporting unknown and unsupported profile sections (bnc#925381)
+- 3.1.76
+
+-------------------------------------------------------------------
 Mon May  4 12:49:40 CEST 2015 - schubi@suse.de
 
 - Evaluate the correct host IP in order to read the proper

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.75
+Version:        3.1.76
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -78,13 +78,33 @@ module Yast
       Builtins.y2debug("Module map: %1", Y2ModuleConfig.ModuleMap)
       Builtins.y2debug("Current profile: %1", Profile.current)
 
-      unknown_sections = Y2ModuleConfig.unknown_profile_sections
+      unsupported_sections = Y2ModuleConfig.unsupported_profile_sections
+      if unsupported_sections.any?
+        log.error "Could not process these unsupported profile sections: #{unsupported_sections}"
+        Report.LongError(
+          # TRANSLATORS: Error message, %s is replaced by newline-separated
+          # list of unsupported sections of the profile
+          # Do not translate words in brackets
+          _(
+            "These sections of AutoYaST profile are not supported anymore:\n\n%s\n\n" \
+            "Please, use, e.g., <scripts/> or <files/> to change the configuration."
+          ) % unsupported_sections.map{|section| "<#{section}/>"}.join("\n")
+        )
+      end
+
+      # Report only those that are 'not unsupported', these were already reported
+      unknown_sections = Y2ModuleConfig.unhandled_profile_sections - unsupported_sections
       if unknown_sections.any?
-        log.error "Could not process these profile sections: #{unknown_sections}"
+        log.error "Could not process these unknown profile sections: #{unknown_sections}"
         Report.LongError(
           # TRANSLATORS: Error message, %s is replaced by newline-separated
           # list of unknown sections of the profile
-          _("These sections of AutoYaST profile cannot be processed on this system:\n%s") %
+          # Do not translate words in brackets
+          _(
+            "These sections of AutoYaST profile cannot be processed on this system:\n\n%s\n\n" \
+            "Maybe they were misspelled or your profile does not contain " \
+            "all the needed YaST packages in <software/> section."
+          ) %
             unknown_sections.map{|section| "<#{section}/>"}.join("\n")
         )
       end

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -31,6 +31,16 @@ module Yast
       "user_defaults",
     ]
 
+    # Dropped YaST modules that used to provide AutoYaST functionality
+    # bsc#925381
+    OBSOLETE_PROFILE_SECTIONS = [
+      # FATE#316185: Drop YaST AutoFS module
+      "autofs",
+      # FATE#308682: Drop yast2-backup and yast2-restore modules
+      "restore",
+      "sshd",
+    ]
+
     def main
       Yast.import "UI"
       textdomain "autoinst"

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -10,6 +10,27 @@ require "yast"
 
 module Yast
   class ProfileClass < Module
+    # All these sections are handled by AutoYaST (or Installer) itself,
+    # it doesn't use any external AutoYaST client for them
+    GENERIC_PROFILE_SECTIONS = [
+      # Bug: this is already in every auto-generated profile
+      "deploy_image",
+      # AutoYaST configuration - complete configuration files
+      "files",
+      # AutoYaST configuration - default values
+      "general",
+      # AutoYaST has its own partitioning
+      "partitioning",
+      # AutoYaST has its Preboot Execution Environment configuration
+      "pxe",
+      # AutoYaST configuration - pre and post-install scripts
+      "scripts",
+      # AutoYaST has also its own software selection
+      "software",
+      # Bug: This top-level entry belongs to users / groups
+      "user_defaults",
+    ]
+
     def main
       Yast.import "UI"
       textdomain "autoinst"

--- a/src/modules/Y2ModuleConfig.rb
+++ b/src/modules/Y2ModuleConfig.rb
@@ -340,11 +340,12 @@ module Yast
       true
     end
 
-    # Returns list of profile sections that do not have any handler (AutoYaST client)
-    # assigned at the current system and are not handled by AutoYaST itself
+    # Returns list of all profile sections from the current profile, including
+    # unsupported ones, that do not have any handler (AutoYaST client) assigned
+    # at the current system and are not handled by AutoYaST itself.
     #
     # @return [Array<String>] of unknown profile sections
-    def unknown_profile_sections
+    def unhandled_profile_sections
       profile_sections = Profile.current.keys
 
       profile_handlers = @ModuleMap.map{
@@ -358,6 +359,14 @@ module Yast
       } - Yast::ProfileClass::GENERIC_PROFILE_SECTIONS
     end
 
+    # Returns list of all profile sections from the current profile that are
+    # obsolete, e.g., we do not support them anymore.
+    #
+    # @return [Array<String>] of unsupported profile sections
+    def unsupported_profile_sections
+      unhandled_profile_sections & Yast::ProfileClass::OBSOLETE_PROFILE_SECTIONS
+    end
+
     publish :variable => :GroupMap, :type => "map <string, map>"
     publish :variable => :ModuleMap, :type => "map <string, map>"
     publish :variable => :MenuTreeData, :type => "list <map>"
@@ -366,7 +375,8 @@ module Yast
     publish :function => :getResourceData, :type => "any (map, string)"
     publish :function => :Deps, :type => "list <map> ()"
     publish :function => :SetDesktopIcon, :type => "boolean (string)"
-    publish :function => :unknown_profile_sections, :type => "list <string> ()"
+    publish :function => :unhandled_profile_sections, :type => "list <string> ()"
+    publish :function => :unsupported_profile_sections, :type => "list <string> ()"
   end
 
   Y2ModuleConfig = Y2ModuleConfigClass.new

--- a/src/modules/Y2ModuleConfig.rb
+++ b/src/modules/Y2ModuleConfig.rb
@@ -348,15 +348,17 @@ module Yast
     def unhandled_profile_sections
       profile_sections = Profile.current.keys
 
-      profile_handlers = @ModuleMap.map{
-        |name, desc|
+      profile_handlers = @ModuleMap.map do |name, desc|
         desc[RESOURCE_NAME_KEY] || name
-      }
+      end
 
-      profile_sections.reject{
-        |section|
+      profile_sections.reject! do |section|
         profile_handlers.include?(section)
-      } - Yast::ProfileClass::GENERIC_PROFILE_SECTIONS
+      end
+
+      # Generic sections are handled by AutoYast itself and not mentioned
+      # in any desktop file
+      profile_sections - Yast::ProfileClass::GENERIC_PROFILE_SECTIONS
     end
 
     # Returns list of all profile sections from the current profile that are

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,9 @@
 # Makefile.am for autoinstallation/test
 #
 
-TESTS = AutoInstallRules_test.rb
+TESTS = \
+    AutoInstallRules_test.rb \
+    Y2ModuleConfig_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/Y2ModuleConfig_test.rb
+++ b/test/Y2ModuleConfig_test.rb
@@ -7,12 +7,10 @@ Yast.import "Y2ModuleConfig"
 Yast.import "Desktop"
 Yast.import "Profile"
 
-include Yast::Logger
-
-FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
-DESKTOP_DATA = YAML::load_file(File.join(FIXTURES_PATH, 'desktop_files', 'desktops.yml'))
-
 describe Yast::Y2ModuleConfig do
+  FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
+  DESKTOP_DATA = YAML::load_file(File.join(FIXTURES_PATH, 'desktop_files', 'desktops.yml'))
+
   describe "#unhandled_profile_sections" do
     let(:profile_unhandled) { File.join(FIXTURES_PATH, 'profiles', 'unhandled_and_obsolete.xml') }
 

--- a/test/Y2ModuleConfig_test.rb
+++ b/test/Y2ModuleConfig_test.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "yaml"
+
+Yast.import "Y2ModuleConfig"
+Yast.import "Desktop"
+Yast.import "Profile"
+
+include Yast::Logger
+
+FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
+DESKTOP_DATA = YAML::load_file(File.join(FIXTURES_PATH, 'desktop_files', 'desktops.yml'))
+
+describe Yast::Y2ModuleConfig do
+  describe "#unhandled_profile_sections" do
+    let(:profile_unhandled) { File.join(FIXTURES_PATH, 'profiles', 'unhandled_and_obsolete.xml') }
+
+    it "returns all unsupported and unknown profile sections" do
+      Yast::Profile.ReadXML(profile_unhandled)
+      Yast::Y2ModuleConfig.instance_variable_set("@ModuleMap", DESKTOP_DATA)
+
+      expect(Yast::Y2ModuleConfig.unhandled_profile_sections.sort).to eq(
+        [
+          "audit-laf", "autofs", "ca_mgm", "firstboot", "language", "restore",
+          "runlevel", "sshd", "sysconfig", "unknown_profile_item_1",
+          "unknown_profile_item_2", "users"
+        ].sort
+      )
+    end
+  end
+
+  describe "#unsupported_profile_sections" do
+    let(:profile_unsupported) { File.join(FIXTURES_PATH, 'profiles', 'unhandled_and_obsolete.xml') }
+
+    it "returns all unsupported profile sections" do
+      Yast::Profile.ReadXML(profile_unsupported)
+      Yast::Y2ModuleConfig.instance_variable_set("@ModuleMap", DESKTOP_DATA)
+
+      expect(Yast::Y2ModuleConfig.unsupported_profile_sections.sort).to eq(
+        ["autofs", "restore", "sshd"].sort
+      )
+    end
+  end
+end

--- a/test/fixtures/desktop_files/desktops.yml
+++ b/test/fixtures/desktop_files/desktops.yml
@@ -1,0 +1,59 @@
+---
+firewall:
+  Name: Firewall
+  GenericName: Configure a firewall
+  Icon: yast-firewall
+  X-SuSE-YaST-AutoInst: all
+  X-SuSE-YaST-Group: Security
+  X-SuSE-YaST-AutoInstClonable: 'true'
+  X-SuSE-YaST-AutoInstRequires: lan
+  X-SuSE-DocTeamID: ycc_firewall
+  X-SuSE-YaST-AutoInstClient: firewall_auto
+host:
+  Name: Hostnames
+  GenericName: Assign hostnames and aliases to IP addresses
+  Icon: yast-host
+  X-SuSE-YaST-AutoInst: all
+  X-SuSE-YaST-AutoInstResource: host
+  X-SuSE-YaST-Group: Net_advanced
+  X-SuSE-YaST-AutoInstClonable: 'true'
+  X-SuSE-DocTeamID: ycc_host
+  X-SuSE-YaST-AutoInstClient: host_auto
+lan:
+  Name: Network Settings
+  GenericName: Configure network cards, hostname and routing
+  Icon: yast-lan
+  X-SuSE-YaST-AutoInst: all
+  X-SuSE-YaST-AutoInstResource: networking
+  X-SuSE-YaST-Group: Network
+  X-SuSE-YaST-AutoInstClonable: 'true'
+  X-SuSE-DocTeamID: ycc_lan
+  X-SuSE-YaST-AutoInstClient: lan_auto
+nfs:
+  Name: NFS Client
+  GenericName: Configure an NFS client
+  Icon: yast-nfs
+  X-SuSE-YaST-AutoInst: all
+  X-SuSE-YaST-Group: Net_advanced
+  X-SuSE-YaST-AutoInstDataType: map
+  X-SuSE-YaST-AutoInstClonable: 'true'
+  X-SuSE-YaST-AutoInstRequires: lan
+  X-SuSE-DocTeamID: ycc_nfs
+  X-SuSE-YaST-AutoInstClient: nfs_auto
+new:
+  Name: New Client
+  GenericName: Configure something
+  Icon: yast-new
+  X-SuSE-YaST-AutoInst: all
+  X-SuSE-YaST-AutoInstResource: new
+  X-SuSE-YaST-Group: Network
+  X-SuSE-YaST-AutoInstDataType: map
+  X-SuSE-YaST-AutoInstClonable: 'true'
+  X-SuSE-YaST-AutoInstRequires: new
+  X-SuSE-DocTeamID: ycc_new
+  X-SuSE-YaST-AutoInstClient: new_auto
+security:
+  Name: Security settings
+  GenericName: Configure secure defaults
+  X-SuSE-YaST-AutoInst: all
+  X-SuSE-YaST-AutoInstClient: security_auto

--- a/test/fixtures/profiles/unhandled_and_obsolete.xml
+++ b/test/fixtures/profiles/unhandled_and_obsolete.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!-- These are not supported anymore -->
+  <sshd>
+    <x config:type="boolean">false</x>
+  </sshd>
+  <autofs>
+    <x config:type="boolean">false</x>
+  </autofs>
+  <restore>
+    <x config:type="boolean">false</x>
+  </restore>
+
+  <!-- These are unknown -->
+  <unknown_profile_item_1>
+    <x config:type="boolean">false</x>
+  </unknown_profile_item_1>
+  <unknown_profile_item_2>
+    <x config:type="boolean">false</x>
+  </unknown_profile_item_2>
+
+  <!--
+    These are all supported and known (to make sure we do not report
+    them as unknown or unsupported)
+  -->
+  <audit-laf><x config:type="boolean">false</x></audit-laf>
+  <general><x config:type="boolean">false</x></general>
+  <runlevel><x config:type="boolean">false</x></runlevel>
+  <security><x config:type="boolean">false</x></security>
+  <firstboot><x config:type="boolean">false</x></firstboot>
+  <sysconfig><x config:type="boolean">false</x></sysconfig>
+  <scripts><x config:type="boolean">false</x></scripts>
+  <files><x config:type="boolean">false</x></files>
+  <pxe><x config:type="boolean">false</x></pxe>
+  <language><x config:type="boolean">false</x></language>
+  <ca_mgm><x config:type="boolean">false</x></ca_mgm>
+  <groups/>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+    <image/>
+    <instsource/>
+    <packages config:type="list">
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>openssh</package>
+      <package>mc</package>
+      <package>syslinux</package>
+      <package>kexec-tools</package>
+      <package>sles-release</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>laptop</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+  </software>
+
+
+  <user_defaults>
+    <expire/>
+    <group>100</group>
+    <groups/>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <no_groups config:type="boolean">true</no_groups>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0TfzIJLtYubi$13y4.XJeO082KRmhh8xSPw/ijYXbufIZpxqIB2/lwSVuPvsmol4kNTzO3vTVJyOucxGSSISE1DOX8lnvAybkH/</user_password>
+      <username>root</username>
+    </user>
+  </users>
+
+  <!-- Handler mocked in fixtures -->
+  <new><something config:type="boolean">true</something></new>
+</profile>


### PR DESCRIPTION
- We have dropped support of some Yast modules recently, e.g. *sshd* and we need to let users know that they should configure these pieces differently
- AutoYast now reports two types of sections: unsupported ~ those that we've dropped, and unknown ~ those that do not seem to be handled by any currently installed Yast module (this information is in particular desktop file)
- AutoYast handles some sections by itself, so they are excluded from the report
- This is a big change and I do not want to put it into SLE 12 (SP1 is fine)
- bnc#925381
