### PR TITLE
Fix PReP format.

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 11 14:39:27 CEST 2015 - dvaleev@suse.com
+
+- Don't try to format PReP partitions (bsc#927748)
+- 3.1.80
+
+-------------------------------------------------------------------
 Fri May  8 09:45:27 CEST 2015 - schubi@suse.de
 
 - Added new section "restricts" for ntp configuration

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.79
+Version:        3.1.80
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/autopart.rb
+++ b/src/include/autoinstall/autopart.rb
@@ -130,6 +130,12 @@ module Yast
       valid_fsids.include?(partition["filesystem_id"])
     end
 
+    def raw_partition?(partition)
+      valid_fsids = [Partitions.fsid_bios_grub,
+                     Partitions.fsid_prep_chrp_boot,
+                     Partitions.fsid_gpt_prep]
+      valid_fsids.include?(partition["filesystem_id"])
+    end
     # Read partition data from XML control file
     # @return [Hash] flexible propsal map
     def preprocess_partition_config(xmlflex)
@@ -228,8 +234,8 @@ module Yast
             end
           end
 
-          # Do not format BIOS Grup partitions
-          partition["format"] = false if partition["filesystem_id"] == Partitions.fsid_bios_grub
+          # Do not format raw partitions
+          partition["format"] = false if raw_partition?(partition)
 
           if Ops.get_integer(partition, "size", 0) == -1
             Ops.set(partition, "size", 0)
@@ -292,6 +298,7 @@ module Yast
         Ops.set(pb, "fsid", Partitions.FsidBoot(dlabel)) # FIXME: might be useless
         Ops.set(pb, "filesystem_id", Partitions.FsidBoot(dlabel))
         Ops.set(pb, "id", Partitions.FsidBoot(dlabel)) # FIXME: might be useless
+        Ops.set(pb, "format", false) if raw_partition?(pb)
         Ops.set(pb, "auto_added", true)
         Ops.set(pb, "type", :primary) # FIXME: might be useless
         Ops.set(pb, "partition_type", "primary")


### PR DESCRIPTION
PReP partitions are raw partitions, and shouldn't be formated.
Extend fsid_bios_grub check with GPT and DOS PReP partitions.

bsc#927748

Signed-off-by: Dinar Valeev <dvaleev@suse.com>