### PR TITLE
Add support for performing fs snapshots at the end of install/upgrade

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  2 10:51:56 UTC 2015 - igonzalezsosa@suse.com
+
+- Enabled snapshots creation after auto-installation/upgrade
+  (fate #317973)
+- 3.1.82
+
+-------------------------------------------------------------------
 Tue May 12 11:28:00 CEST 2015 - schubi@suse.de
 
 - Regarding some corner cases of bsc#925381.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.81
+Version:        3.1.82
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -340,6 +340,9 @@ module Yast
 
       logStep(_("Finishing Configuration"))
 
+      # Invoke SnapshotsFinish client to perform snapshots (if needed)
+      WFM.CallFunction("snapshots_finish", ["Write"])
+
       :next
     end
 


### PR DESCRIPTION
Just use the `snapshots_finish` client (available in yast-installation) to perform the snapshot.