### PR TITLE
"Copy" second_stage_required? to AutoInstall

### DIFF
--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -45,7 +45,6 @@ module Yast
       Yast.import "Console"
       Yast.import "ServicesManager"
       Yast.import "Y2ModuleConfig"
-      Yast.import "InstFunctions"
 
       Yast.include self, "bootloader/routines/autoinstall.rb"
       Yast.include self, "autoinstall/ask.rb"
@@ -375,7 +374,7 @@ module Yast
 
       Progress.Finish
 
-      add_yast2_dependencies if InstFunctions.second_stage_required?
+      add_yast2_dependencies if AutoInstall.second_stage_required?
 
       @ret = ProductControl.RunFrom(
         Ops.add(ProductControl.CurrentStep, 1),

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -55,7 +55,7 @@ module Yast
       Yast.import "Directory"
       Yast.import "FileUtils"
       Yast.import "PackageSystem"
-      Yast.import "InstFunctions"
+      Yast.import "AutoInstall"
 
       Yast.include self, "autoinstall/xml.rb"
 
@@ -144,7 +144,7 @@ module Yast
       # to check if 2nd stage is required (chicken-and-egg problem).
       mode = @current.fetch("general", {}).fetch("mode", {})
       second_stage_enabled = mode.has_key?("second_stage") ? mode["second_stage"] : true
-      if InstFunctions.second_stage_required? && second_stage_enabled
+      if AutoInstall.second_stage_required? && second_stage_enabled
         add_autoyast_packages
       end
 

--- a/test/AutoInstall_test.rb
+++ b/test/AutoInstall_test.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "AutoInstall"
+Yast.import "Stage"
+Yast.import "Mode"
+Yast.import "AutoinstConfig"
+
+describe Yast::AutoInstall do
+  subject { Yast::AutoInstall }
+
+  let(:stage) { "initial" }
+  let(:mode) { "autoinst" }
+  let(:second_stage) { true }
+
+  before do
+    Yast::Mode.SetMode(mode)
+    Yast::Stage.Set(stage)
+    allow(Yast::AutoinstConfig).to receive(:second_stage).and_return(second_stage)
+  end
+
+  describe "#second_stage_required?" do
+    context "when not in initial stage" do
+      let(:stage) { "continue" }
+
+      it "returns false" do
+        expect(subject.second_stage_required?).to eq(false)
+      end
+    end
+
+    context "when not in autoinst or autoupgrade mode" do
+      let(:mode) { "normal" }
+
+      it "returns false" do
+        expect(subject.second_stage_required?).to eq(false)
+      end
+    end
+
+    context "when second stage is disabled" do
+      let(:second_stage) { false }
+
+      it "returns false" do
+        expect(subject.second_stage_required?).to eq(false)
+      end
+    end
+
+    context "when in autoinst mode and second stage is enabled" do
+      it "relies on ProductControl.RunRequired" do
+        expect(Yast::ProductControl).to receive(:RunRequired)
+          .with("continue", mode).and_return(true)
+        expect(subject.second_stage_required?).to eq(true)
+      end
+    end
+
+    context "when in autoupgrade mode and second stage is enabled" do
+      let(:mode) { "autoupgrade" }
+
+      it "relies on ProductControl.RunRequired" do
+        expect(Yast::ProductControl).to receive(:RunRequired)
+          .with("continue", mode).and_return(true)
+        expect(subject.second_stage_required?).to eq(true)
+      end
+    end
+  end
+end

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -22,7 +22,7 @@ describe Yast::Profile do
   describe "#softwareCompat" do
     before do
       Yast::Profile.current = profile
-      allow(Yast::InstFunctions).to receive(:second_stage_required?).and_return(second_stage_required)
+      allow(Yast::AutoInstall).to receive(:second_stage_required?).and_return(second_stage_required)
     end
 
     let(:second_stage_required) { true }


### PR DESCRIPTION
* To fix a circular dependency problem, defines the second_stage_required? function in AutoInstall.