### PR TITLE
Fix premature loading of AutoInstall

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  7 22:32:50 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix premature loading of AutoInstall which prevented running
+  configuration clients during 2nd stage (bsc#944770)
+- 3.1.93
+
+-------------------------------------------------------------------
 Tue Sep  1 15:25:44 UTC 2015 - igonzalezsosa@suse.com
 
 - Move users creation to the first stage, so it is not needed

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.92
+Version:        3.1.93
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -266,6 +266,7 @@ rmdir $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/autoyast2/html/autoyast
 %{yast_moduledir}/AutoinstDrive.rb
 %{yast_moduledir}/AutoinstPartPlan.rb
 %{yast_moduledir}/AutoinstPartition.rb
+%{yast_moduledir}/AutoinstFunctions.rb
 
 #clients
 %{yast_clientdir}/inst_autoinit.rb

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,8 @@ module_DATA = \
   modules/AutoinstGeneral.rb \
   modules/AutoinstSoftware.rb \
   modules/AutoinstDrive.rb \
-  modules/AutoinstClass.rb
+  modules/AutoinstClass.rb \
+  modules/AutoinstFunctions.rb
 
 client_DATA = \
   clients/classes_auto.rb \

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -45,6 +45,7 @@ module Yast
       Yast.import "Console"
       Yast.import "ServicesManager"
       Yast.import "Y2ModuleConfig"
+      Yast.import "AutoinstFunctions"
 
       Yast.include self, "bootloader/routines/autoinstall.rb"
       Yast.include self, "autoinstall/ask.rb"
@@ -374,7 +375,7 @@ module Yast
 
       Progress.Finish
 
-      add_yast2_dependencies if AutoInstall.second_stage_required?
+      add_yast2_dependencies if AutoinstFunctions.second_stage_required?
 
       @ret = ProductControl.RunFrom(
         Ops.add(ProductControl.CurrentStep, 1),

--- a/src/modules/AutoInstall.rb
+++ b/src/modules/AutoInstall.rb
@@ -20,8 +20,6 @@ module Yast
       Yast.import "AutoInstallRules"
       Yast.import "Report"
       Yast.import "TFTP"
-      Yast.import "ProductControl"
-      Yast.import "Mode"
 
       @autoconf = false
       AutoInstall()
@@ -303,27 +301,6 @@ module Yast
       true
     end
 
-    # Determines if the second stage should be executed
-    #
-    # Checks Mode, AutoinstConfig and ProductControl to decide if it's
-    # needed.
-    #
-    # FIXME: It's almost equal to InstFunctions.second_stage_required?
-    # defined in yast2-installation, but exists to avoid a circular dependency
-    # between packages (yast2-installation -> autoyast2-installation).
-    #
-    # @return [Boolean] 'true' if it's needed; 'false' otherwise.
-    def second_stage_required?
-      return false unless Stage.initial
-      if (Mode.autoinst || Mode.autoupgrade) && !AutoinstConfig.second_stage
-        Builtins.y2milestone("Autoyast: second stage is disabled")
-        false
-      else
-        ProductControl.RunRequired("continue", Mode.mode)
-      end
-    end
-    alias_method :second_stage_required, :second_stage_required?
-
     publish :variable => :autoconf, :type => "boolean"
     publish :function => :callbackTrue_boolean_string, :type => "boolean (string)"
     publish :function => :callbackFalse_boolean_string, :type => "boolean (string)"
@@ -347,7 +324,6 @@ module Yast
     publish :function => :Save, :type => "boolean ()"
     publish :function => :Finish, :type => "void (string)"
     publish :function => :PXELocalBoot, :type => "boolean ()"
-    publish function: :second_stage_required, type: "boolean ()"
   end
 
   AutoInstall = AutoInstallClass.new

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -1,0 +1,36 @@
+module Yast
+  # Helper methods to be used on autoinstallation.
+  class AutoinstFunctionsClass < Module
+    def main
+      textdomain "installation"
+
+      Yast.import "Stage"
+      Yast.import "Mode"
+      Yast.import "AutoinstConfig"
+      Yast.import "ProductControl"
+    end
+
+    # Determines if the second stage should be executed
+    #
+    # Checks Mode, AutoinstConfig and ProductControl to decide if it's
+    # needed.
+    #
+    # FIXME: It's almost equal to InstFunctions.second_stage_required?
+    # defined in yast2-installation, but exists to avoid a circular dependency
+    # between packages (yast2-installation -> autoyast2-installation).
+    #
+    # @return [Boolean] 'true' if it's needed; 'false' otherwise.
+    def second_stage_required?
+      return false unless Stage.initial
+      if (Mode.autoinst || Mode.autoupgrade) && !AutoinstConfig.second_stage
+        Builtins.y2milestone("Autoyast: second stage is disabled")
+        false
+      else
+        ProductControl.RunRequired("continue", Mode.mode)
+      end
+    end
+  end
+
+  AutoinstFunctions = AutoinstFunctionsClass.new
+  AutoinstFunctions.main
+end

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -55,7 +55,7 @@ module Yast
       Yast.import "Directory"
       Yast.import "FileUtils"
       Yast.import "PackageSystem"
-      Yast.import "AutoInstall"
+      Yast.import "AutoinstFunctions"
 
       Yast.include self, "autoinstall/xml.rb"
 
@@ -144,7 +144,7 @@ module Yast
       # to check if 2nd stage is required (chicken-and-egg problem).
       mode = @current.fetch("general", {}).fetch("mode", {})
       second_stage_enabled = mode.has_key?("second_stage") ? mode["second_stage"] : true
-      if AutoInstall.second_stage_required? && second_stage_enabled
+      if AutoinstFunctions.second_stage_required? && second_stage_enabled
         add_autoyast_packages
       end
 

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -2,13 +2,13 @@
 
 require_relative "test_helper"
 
-Yast.import "AutoInstall"
+Yast.import "AutoinstFunctions"
 Yast.import "Stage"
 Yast.import "Mode"
 Yast.import "AutoinstConfig"
 
-describe Yast::AutoInstall do
-  subject { Yast::AutoInstall }
+describe Yast::AutoinstFunctions do
+  subject { Yast::AutoinstFunctions }
 
   let(:stage) { "initial" }
   let(:mode) { "autoinst" }

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -22,7 +22,7 @@ describe Yast::Profile do
   describe "#softwareCompat" do
     before do
       Yast::Profile.current = profile
-      allow(Yast::AutoInstall).to receive(:second_stage_required?).and_return(second_stage_required)
+      allow(Yast::AutoinstFunctions).to receive(:second_stage_required?).and_return(second_stage_required)
     end
 
     let(:second_stage_required) { true }


### PR DESCRIPTION
* This bug prevented running configuration clients during 2nd stage.
* Move offending code to a new class AutoinstFunctions (analogue to InstFunctions in yast2-installation).
* Fixes [bsc#944770](https://bugzilla.suse.com/show_bug.cgi?id=944770).