### PR TITLE
Move lib directory to autoyast2-install package

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct  9 15:03:43 UTC 2015 - igonzalezsosa@suse.com
+
+- Move lib/ directory to autoyast2-installation package
+  (bsc#949776)
+- 3.1.97
+
+-------------------------------------------------------------------
 Thu Oct  8 21:39:50 UTC 2015 - igonzalezsosa@suse.com
 
 - Handle pkgGpgCheck callback introduced in libzypp 14.39.0

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.96
+Version:        3.1.97
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -205,8 +205,6 @@ rmdir $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/autoyast2/html/autoyast
 %{yast_moduledir}/Kickstart.rb
 %dir %{yast_agentdir}
 %{yast_agentdir}/ag_ksimport
-%dir %{yast_libdir}/autoinstall
-%{yast_libdir}/autoinstall/*.rb
 
 # additional files
 
@@ -286,6 +284,9 @@ rmdir $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/autoyast2/html/autoyast
 
 %{yast_yncludedir}/autoinstall/xml.rb
 %{yast_yncludedir}/autoinstall/ask.rb
+
+%dir %{yast_libdir}/autoinstall
+%{yast_libdir}/autoinstall/*.rb
 
 # scripts
 %{_prefix}/lib/YaST2/bin/fetch_image.sh


### PR DESCRIPTION
lib directory contains `pkg_gpg_checker_handler`, which is used by `AutoInstall.rb`.