### PR TITLE
Add a missing dependency on yast2-pkg-bindings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  3 10:11:10 UTC 2015 - igonzalezsosa@suse.com
+
+- Add dependency on yast2-pkg-bindings 3.1.20.1 (or newer)
+  (bsc#953162)
+- 3.1.69.9
+
+-------------------------------------------------------------------
 Thu Oct  8 21:39:50 UTC 2015 - igonzalezsosa@suse.com
 
 - Handle pkgGpgCheck callback introduced in libzypp 14.39.0

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.69.8
+Version:        3.1.69.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -105,6 +105,8 @@ Requires:       yast2-storage
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-update >= 2.18.3
 Requires:       yast2-xml
+# pkgGpgCheck callback
+Requires:       yast2-pkg-bindings >= 3.1.20.1
 Provides:       yast2-trans-autoinst
 Obsoletes:      yast2-trans-autoinst
 


### PR DESCRIPTION
It should solve [bsc#953162](https://bugzilla.suse.com/show_bug.cgi?id=953162).