### PR TITLE
Add missing yast2-pkg-bindings dependency

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  3 10:11:10 UTC 2015 - igonzalezsosa@suse.com
+
+- Add dependency on yast2-pkg-bindings 3.1.31 (or newer)
+  (bsc#953162)
+- 3.1.101
+
+-------------------------------------------------------------------
 Thu Oct 22 17:00:02 CEST 2015 - schubi@suse.de
 
 - Ingore restarting of all wickedd* services while finishing the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.100
+Version:        3.1.101
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -108,6 +108,8 @@ Requires:       yast2-storage >= 3.1.59
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-update >= 2.18.3
 Requires:       yast2-xml
+# pkgGpgCheck callback
+Requires:       yast2-pkg-bindings >= 3.1.31
 Provides:       yast2-trans-autoinst
 Obsoletes:      yast2-trans-autoinst
 


### PR DESCRIPTION
Fixes [bsc#953162](https://bugzilla.suse.com/show_bug.cgi?id=953162)