### PR TITLE
network_needed should be optional

### DIFF
--- a/src/autoyast-rnc/scripts.rnc
+++ b/src/autoyast-rnc/scripts.rnc
@@ -57,7 +57,7 @@ autoinstall-post-script = element script {
   debug? &
   feedback? &
   element notification { text }? &
-  element network_needed { BOOLEAN }
+  element network_needed { BOOLEAN }?
 }
 
 autoinstall-init-script = element script {
@@ -91,4 +91,3 @@ feedback_type = element feedback_type { text }
 filename = element filename { text }
 interpreter = element interpreter { text }
 source = element source { text }
-network_needed = element network_needed { BOOLEAN }


### PR DESCRIPTION
network_needed is supposed to be optional, as stated in the documentation.

I'm not updating the changes or spec file as it was changed in a previous commit and I haven't updated the devel project in IBS yet (I'll do it after this change is merged).