### PR TITLE
[Review] Request from 'schubi2' @ 'yast/yast-autoinstallation/review_151217_cleanup_service_dependencies'

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 17 16:00:43 CET 2015 - schubi@suse.de
+
+- Network services can be restarted again, because they do not
+  depend on YaST2-Second-Stage.service anymore. (bnc#954908)
+- 3.1.107
+
+-------------------------------------------------------------------
 Fri Nov 27 16:32:46 CET 2015 - schubi@suse.de
 
 - Added "cobbler" to the obsolete profile section.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.106
+Version:        3.1.107
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -57,7 +57,7 @@ Requires:       yast2-schema
 Requires:       yast2-storage >= 3.1.59
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml
-Conflicts:      yast2-installation < 3.1.158
+Conflicts:      yast2-installation < 3.1.166
 
 Provides:       yast2-config-autoinst
 Provides:       yast2-module-autoinst

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -298,21 +298,13 @@ module Yast
         "autoyast-initscripts.service",
         # Do not restart dbus. Otherwise some services will hang.
         # bnc#937900
-        "dbus.service",
-        # Do not restart wickedd* services
-        # bnc#944349
-        "^wickedd",
-        # Do not restart NetworkManager* services
-        # bnc#955260
-        "^NetworkManager"
+        "dbus.service"
       ]
       if final_restart_services
         logStep(_("Restarting all running services"))
-        @cmd = "systemctl --type=service list-units | grep \" running \" | sed s/[[:space:]].*//"
+        @cmd = "systemctl --type=service list-units | grep \" running \""
         @out = Convert.to_map(SCR.Execute(path(".target.bash_output"), @cmd))
-        @sl = Builtins.filter(
-          Builtins.splitstring(Ops.get_string(@out, "stdout", ""), "\n")
-        ) { |s| Ops.greater_than(Builtins.size(s), 0) }
+        @sl = Ops.get_string(@out, "stdout", "").split("\n").collect { |c| c.split(" ").first }
         Builtins.y2milestone("running services \"%1\"", @sl)
 
         # Filtering out all services which must not to be restarted


### PR DESCRIPTION
Please review the following changes:
  * 81b09eb packaging
  * b71ef56 network services has to be restarted again because there is no dependencies on YaST2-Seconde-Stage.service anymore. This should be much easier now
