### PR TITLE
Add 'init' to the list of generic AutoYaST sections

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Jan 19 11:40:38 UTC 2016 - igonzalezsosa@suse.com
 
-- Add 'init' to the list of generic AutoYaST sections
-  (bsc#962526)
+- Fix wrong warning message about the 'init' section
+  not being processed (bsc#962526)
 - 3.1.101.11
 
 -------------------------------------------------------------------

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 19 11:40:38 UTC 2016 - igonzalezsosa@suse.com
+
+- Add 'init' to the list of generic AutoYaST sections
+  (bsc#962526)
+- 3.1.101.11
+
+-------------------------------------------------------------------
 Fri Jan 15 10:30:58 CET 2016 - schubi@suse.de
 
 - Installation with "autoyast=default". Fixed nil exception error.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.101.10
+Version:        3.1.101.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -21,7 +21,10 @@ module Yast
       # Flags for setting the solver while the upgrade process with AutoYaST
       "upgrade",
       # Flags for controlling the update backups (see Installation module)
-      "backup"
+      "backup",
+      # init section used by Kickstart and to pass additional arguments
+      # to Linuxrc (bsc#962526)
+      "init"
     ]
 
     # Dropped YaST modules that used to provide AutoYaST functionality


### PR DESCRIPTION
This solves bug [bsc#962526](https://bugzilla.opensuse.org/show_bug.cgi?id=962526).