### PR TITLE
[Review] Request from 'schubi2' @ 'yast/yast-autoinstallation/review_160223_no_network_restart'

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Feb 23 17:01:09 CET 2016 - schubi@suse.de
+
+- As network configuration will be moved to first installation
+  stage and wickedd should not be restarted in the second stage,
+  all wickedd and network services will not be restarted at all
+  by AutoYaST.
+  (bnc#944349,  bnc#955260)
+- 3.1.116
+
+-------------------------------------------------------------------
 Wed Feb 17 10:01:02 UTC 2016 - mvidner@suse.com
 
 - Moved the body of AutoinstallIoInclude#Get to yast2-update

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -18,7 +18,7 @@
 
 Name:           autoyast2
 
-Version:        3.1.115
+Version:        3.1.116
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -294,7 +294,7 @@ module Yast
         30
       )
 
-@ser_ignore = [
+      @ser_ignore = [
         "YaST2-Second-Stage.service",
         "autoyast-initscripts.service",
         # Do not restart dbus. Otherwise some services will hang.

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -293,13 +293,21 @@ module Yast
         ["general", "mode", "max_systemd_wait"],
         30
       )
-      @ser_ignore = [
+
+@ser_ignore = [
         "YaST2-Second-Stage.service",
         "autoyast-initscripts.service",
         # Do not restart dbus. Otherwise some services will hang.
         # bnc#937900
-        "dbus.service"
+        "dbus.service",
+        # Do not restart wickedd* services
+        # bnc#944349
+        "^wickedd",
+        # Do not restart NetworkManager* services
+        # bnc#955260
+        "^NetworkManager"
       ]
+
       if final_restart_services
         logStep(_("Restarting all running services"))
         @cmd = "systemctl --type=service list-units | grep \" running \""

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -71,6 +71,10 @@ describe Yast::AutoInstallRules do
   end
 
   describe "#ProbeRules" do
+    before(:each) do
+      subject.reset
+    end
+
     it "reads installed product properties from content file" do
       expect(Yast::SCR).to receive(:Read).with(Yast::Path.new(".probe.bios")).and_return([])
       expect(Yast::SCR).to receive(:Read).with(Yast::Path.new(".probe.memory")).and_return([])
@@ -98,7 +102,6 @@ describe Yast::AutoInstallRules do
 
     context "when .content.DISTRO is not found" do
       before(:each) do
-        subject.reset
         allow(Yast::SCR).to receive(:Read).with(any_args)
         allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
       end

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 
 Yast.import "AutoinstSoftware"
+Yast.import "AutoinstData"
 Yast.import "Profile"
 
 describe Yast::AutoinstSoftware do


### PR DESCRIPTION
The error has been seen in the integration test. Network has not been available anymore with the keep_install flag. After rebooting network has been available. So I added the previous fix again, with which all network services will not be restarted after second stage. After that everything has worked again.


Please review the following changes:
  * cb5c5f2 packaging
  * a7d4945 layout
  * 1185617 enable ignoring restart of networking services
