### PR TITLE
Fix ssh_import schema

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun  3 15:22:02 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix AutoYaST2 schema regarding SSH keys/configuration import
+  feature (fate#319624)
+- 3.1.130
+
+-------------------------------------------------------------------
 Wed May 25 13:50:40 CEST 2016 - schubi@suse.de
 
 - AutoYaST support for ssh_import module.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.129
+Version:        3.1.130
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/ssh-import.rnc
+++ b/src/autoyast-rnc/ssh-import.rnc
@@ -4,7 +4,7 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 ssh_import =
   element ssh_import {
-    element import { BOOLEAN }? &
-    element config { BOOLEAN }? &
-    element device { text }?
+    element import      { BOOLEAN }? &
+    element copy_config { BOOLEAN }? &
+    element device      { text }?
   }


### PR DESCRIPTION
* The latest version uses 'copy_config' instead of only 'config'.