### PR TITLE
Stop generating autodocs

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,0 @@
-#
-# Makefile.am for autoinstallation/doc
-#
-# $Id$
-#
-
-SUBDIRS = autodocs

--- a/doc/autodocs/Makefile.am
+++ b/doc/autodocs/Makefile.am
@@ -1,5 +1,0 @@
-#
-# Makefile.am for .../doc/autodocs
-#
-
-include $(top_srcdir)/autodocs-ycp.ami

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -3,6 +3,7 @@ Fri Jun  3 15:22:02 UTC 2016 - igonzalezsosa@suse.com
 
 - Fix AutoYaST2 schema regarding SSH keys/configuration import
   feature (fate#319624)
+- Stop generating autodocs (fate#320356)
 - 3.1.130
 
 -------------------------------------------------------------------


### PR DESCRIPTION
I'm not releasing a new version because 3.1.130 was rejected by Jenkins.