### PR TITLE
Installation optimize

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 28 10:29:38 UTC 2016 - jreidinger@suse.com
+
+- Speed up installation (bnc#986649)
+- 3.1.134
+
+-------------------------------------------------------------------
 Tue Jun 21 06:16:12 UTC 2016 - igonzalezsosa@suse.com
 
 - Consider AutoYaST keep_install_network as set to 'true'

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.133
+Version:        3.1.134
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autoinit.rb
+++ b/src/clients/inst_autoinit.rb
@@ -58,28 +58,6 @@ module Yast
       Progress.Title(_("Preprobing stage"))
       Builtins.y2milestone("pre probing")
 
-      # // moved to autoset to fulfill fate #301193
-      #    // the DASD section in an autoyast profile can't be changed via pre-script
-      #    //
-      #     if( Arch::s390 () && AutoinstConfig::remoteProfile == true ) {
-      #         y2milestone("arch=s390 and remote_profile=true");
-      #         symbol ret = processProfile();
-      #         if( ret != `ok ) {
-      #             return ret;
-      #         }
-      #         y2milestone("processProfile=ok");
-      #         profileFetched = true;
-      #
-      #         // FIXME: the hardcoded stuff should be in the control.xml later
-      #         if( haskey(Profile::current, "dasd") ) {
-      #             y2milestone("dasd found");
-      #             Call::Function("dasd_auto", ["Import", Profile::current["dasd"]:$[] ]);
-      #         }
-      #         if( haskey(Profile::current, "zfcp") ) {
-      #             y2milestone("zfcp found");
-      #             Call::Function("zfcp_auto", ["Import", Profile::current["zfcp"]:$[] ]);
-      #         }
-      #     }
       @tmp = Convert.to_string(
         SCR.Read(path(".target.string"), "/etc/install.inf")
       )
@@ -132,8 +110,6 @@ module Yast
 
       return :abort if Popup.ConfirmAbort(:painless) if UI.PollInput == :abort
 
-      # AutoInstall::ProcessSpecialResources();
-
       :next
     end
 
@@ -180,13 +156,6 @@ module Yast
           end
         end
       end
-
-      # if (!ProfileLocation::Process())
-      # {
-      # 	y2error("Aborting...");
-      # 	return `abort;
-      # }
-
 
       return :abort if Popup.ConfirmAbort(:painless) if UI.PollInput == :abort
 

--- a/src/clients/inst_autoinit.rb
+++ b/src/clients/inst_autoinit.rb
@@ -105,7 +105,6 @@ module Yast
         return @ret if @ret != :ok
       end
 
-      Builtins.sleep(1000)
       Progress.Finish
 
       if !(Mode.autoupgrade && AutoinstConfig.ProfileInRootPart)
@@ -187,8 +186,6 @@ module Yast
       # 	y2error("Aborting...");
       # 	return `abort;
       # }
-
-      Builtins.sleep(1000)
 
 
       return :abort if Popup.ConfirmAbort(:painless) if UI.PollInput == :abort


### PR DESCRIPTION
during profiling installation I found these two sleep which looks useless and it is in fact called twice, so it safe 4 second when removed and autoyast installation pass.