### PR TITLE
Fixing timeout issues in <ask> dialogs

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Fri Jul 29 16:12:42 CEST 2016 - locilka@suse.com
+
+- Added new [Stop] button for <ask> dialogs with timeout. The
+  button shows the current time in seconds till the automatic
+  timeout (bsc#990114).
+- More possible user actions can now stop the execution to prevent
+  from timeout (bsc#990114).
+- 3.1.142
+
+-------------------------------------------------------------------
 Mon Jul 25 12:50:20 CEST 2016 - schubi@suse.de
 
 - Check if AutoYaST "script" elements are hashes.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.141
+Version:        3.1.142
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/ask.rb
+++ b/src/include/autoinstall/ask.rb
@@ -44,7 +44,7 @@ module Yast
     #
     # @param [Integer] timeout in seconds
     # @return [Symbol] any user input or :timeout in case of timeout
-    def handle_ask_dialog(timeout)
+    def user_input_with_countdown(timeout)
       ret = nil
 
       if timeout == 0
@@ -176,7 +176,7 @@ module Yast
           title = Ops.get_string(ask, "title", "")
           back_label = Ops.get_string(ask, "back_label", back_label)
           ok_label = Ops.get_string(ask, "ok_label", ok_label)
-          timeout = ask["timeout"] if ask.key?("timeout")
+          timeout = Ops.get_integer(ask, "timeout", 0)
           mod = true
           if Ops.greater_than(Ops.get_integer(ask, "width", 0), min_width)
             min_width = Ops.get_integer(ask, "width", 0)
@@ -388,7 +388,7 @@ module Yast
         while true
           ret = nil
 
-          ret = handle_ask_dialog(timeout)
+          ret = user_input_with_countdown(timeout)
           # Any user action stops the timeout
           timeout = 0 if ret != :timeout
 

--- a/test/include/ask_test.rb
+++ b/test/include/ask_test.rb
@@ -54,8 +54,8 @@ describe "Yast::AutoinstallAskInclude" do
 
         it "creates a TextEntry widget" do
           expect(Yast::UI).to receive(:OpenDialog)
-          expect(client).to receive(:TextEntry).
-            with(Id("0_0"), Opt(:notify), ask["question"], ask["default"]).
+          expect(client).to receive(:InputField).
+            with(Id("0_0"), Opt(:hstretch, :notify, :notifyContextMenu), ask["question"], ask["default"]).
             and_call_original
           client.askDialog
         end
@@ -86,10 +86,10 @@ describe "Yast::AutoinstallAskInclude" do
         it "creates two Password widgets" do
           expect(Yast::UI).to receive(:OpenDialog)
           expect(client).to receive(:Password).
-            with(Id("0_0"), Opt(:notify), ask["question"], ask["default"]).
+            with(Id("0_0"), Opt(:notify, :notifyContextMenu), ask["question"], ask["default"]).
             and_call_original
           expect(client).to receive(:Password).
-            with(Id("0_0_pass2"), Opt(:notify), "", ask["default"]).
+            with(Id("0_0_pass2"), Opt(:notify, :notifyContextMenu), "", ask["default"]).
             and_call_original
           client.askDialog
         end
@@ -122,7 +122,7 @@ describe "Yast::AutoinstallAskInclude" do
             Item(Id(:server), "Server", false)
           ]
           expect(client).to receive(:ComboBox).
-            with(Id("0_0"), Opt(:notify), ask["question"], expected_options).
+            with(Id("0_0"), Opt(:notify, :immediate), ask["question"], expected_options).
             and_call_original
           client.askDialog
         end
@@ -151,8 +151,8 @@ describe "Yast::AutoinstallAskInclude" do
 
         it "creates one widget for each one of them" do
           expect(Yast::UI).to receive(:OpenDialog)
-          expect(client).to receive(:TextEntry).
-            with(Id("0_0"), Opt(:notify), string_ask["question"], string_ask["default"]).
+          expect(client).to receive(:InputField).
+            with(Id("0_0"), Opt(:hstretch, :notify, :notifyContextMenu), string_ask["question"], string_ask["default"]).
             and_call_original
           expect(client).to receive(:CheckBox).
             with(Id("0_1"), Opt(:notify), boolean_ask["question"], true).


### PR DESCRIPTION
## Changes
- Added new [Stop] button for <ask> dialogs with timeout. The button shows the current time in seconds till the automatic timeout ([bsc#990114](https://bugzilla.suse.com/show_bug.cgi?id=990114))
- More possible user actions can now stop the execution to prevent from timeout (also bsc#990114)
- Added new unit-test (3x)
- Adjusted old tests
- TextEntry is now InputField (since something like 2005)

## Screenshot
![ask-networking](https://cloud.githubusercontent.com/assets/463995/17251423/06449188-55a9-11e6-9461-dfc352fff8d8.png)
