### PR TITLE
Reintroduced autoyast=usb as a valid URL to AutoYaST profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-storage yast2-xml yast2-transfer yast2-services-manager yast2-installation yast2-installation-control yast2-packager trang" -g "rspec:3.3.0 yast-rake gettext"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-storage yast2-xml yast2-transfer yast2-services-manager yast2-installation yast2-installation-control yast2-packager yast2-slp trang" -g "rspec:3.3.0 yast-rake gettext"
 script:
     - rake check:syntax
     - rake check:pot

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug  5 15:37:30 CEST 2016 - locilka@suse.com
+
+- Reintroduced autoyast=usb as a valid URL to AutoYaST profile
+  (bsc#987858)
+- 3.1.144
+
+-------------------------------------------------------------------
 Tue Aug  2 12:28:29 CEST 2016 - schubi@suse.de
 
 - Added missed flag "install_recommended" in software section.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -40,6 +40,7 @@ BuildRequires:  yast2-transfer
 BuildRequires:  yast2-services-manager
 BuildRequires:  yast2-packager
 BuildRequires:  yast2-update >= 3.1.36
+BuildRequires:  yast2-slp
 
 # %%{_unitdir} macro definition is in a separate package since 13.1
 %if 0%{?suse_version} >= 1310

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.143
+Version:        3.1.144
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -232,6 +232,10 @@ module Yast
 
       slpData = SLP.FindSrvs("autoyast", "")
 
+      # SLP data returned by SLP server contain the service ID, colon
+      # and then the URL of that service
+      url_starts_at = "service.autoyast:".size
+
       # More providers to choose from
       if Ops.greater_than(Builtins.size(slpData), 1)
         dummy = []
@@ -240,7 +244,7 @@ module Yast
           attrList = SLP.FindAttrs(Ops.get_string(m, "srvurl", ""))
 
           if Ops.greater_than(Builtins.size(attrList), 0)
-            url = Builtins.substring(Ops.get_string(m, "srvurl", ""), 17)
+            url = Builtins.substring(Ops.get_string(m, "srvurl", ""), url_starts_at)
             # FIXME: that's really lazy coding here but I allow only one attribute currently anyway
             #        so it's lazy but okay. No reason to be too strict here with the checks
             #        As soon as more than one attr is possible, I need to iterate over the attr list
@@ -276,7 +280,7 @@ module Yast
             dummy = Builtins.add(dummy, Item(comment, false))
             Ops.set(comment2url, comment, url)
           else
-            url = Builtins.substring(Ops.get_string(m, "srvurl", ""), 17)
+            url = Builtins.substring(Ops.get_string(m, "srvurl", ""), url_starts_at)
             dummy = Builtins.add(dummy, Item(url, false))
             Ops.set(comment2url, url, url)
           end
@@ -315,8 +319,6 @@ module Yast
     # @param [String] AutoYast profile location as defined on commandline
     # @return [String] updated profile location
     def update_profile_location(profile_location)
-      profile_location = deep_copy(profile_location)
-
       if profile_location.nil? || profile_location == ""
         # FIXME: reevaluate this statement
         #
@@ -332,10 +334,9 @@ module Yast
         profile_location = "usb:///#{DEFAULT_PROFILE_NAME}"
       elsif profile_location == "slp"
         profile_location = find_slp_autoyast
-        return if profile_location.nil?
+      else
+        profile_location
       end
-
-      profile_location
     end
 
     # Processes location of the profile given as a parameter.

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -17,6 +17,10 @@ module Yast
       include ServicesManagerTargetClass::BaseTargets
     end
 
+    DEFAULT_PROFILE_NAME = "autoinst.xml".freeze
+
+    include Yast::Logger
+
     def main
       Yast.import "UI"
       textdomain "autoinst"
@@ -28,6 +32,7 @@ module Yast
       Yast.import "SLP"
       Yast.import "Stage"
       Yast.import "Label"
+      Yast.import "Report"
 
       Yast.include self, "autoinstall/xml.rb"
 
@@ -214,114 +219,157 @@ module Yast
       nil
     end
 
+    # Searches for 'autoyast' via SLP and returns the full URL of
+    # the profile. If more providers are found, user is asked to
+    # select one.
+    #
+    # FIXME: This function has been intentionally left (almost) intact
+    # and needs refactoring
+    #
+    # @return [String] profile location or 'nil' if nothing is found
+    def find_slp_autoyast
+      profile_location = nil
 
-    # Return location of profile from command line.
-    # @return [Hash] with protocol, server, path
-    # @example autoyast=http://www.server.com/profiles/
-    def ParseCmdLine(autoinstall)
-      Yast.import "URL"
+      slpData = SLP.FindSrvs("autoyast", "")
 
-      result = {}
-      cmdLine = ""
+      # More providers to choose from
+      if Ops.greater_than(Builtins.size(slpData), 1)
+        dummy = []
+        comment2url = {}
+        Builtins.foreach(slpData) do |m|
+          attrList = SLP.FindAttrs(Ops.get_string(m, "srvurl", ""))
 
-      if Ops.greater_than(Builtins.size(autoinstall), 0)
-        cmdLine = autoinstall
-        if cmdLine == "default"
-          Ops.set(result, "scheme", "file")
-          Ops.set(result, "path", "/autoinst.xml")
-        else
-          if cmdLine == "slp"
-            slpData = SLP.FindSrvs("autoyast", "")
-            if Ops.greater_than(Builtins.size(slpData), 1)
-              dummy = []
-              comment2url = {}
-              Builtins.foreach(slpData) do |m|
-                attrList = SLP.FindAttrs(Ops.get_string(m, "srvurl", ""))
-                if Ops.greater_than(Builtins.size(attrList), 0)
-                  url = Builtins.substring(Ops.get_string(m, "srvurl", ""), 17)
-                  # FIXME: that's really lazy coding here but I allow only one attribute currently anyway
-                  #        so it's lazy but okay. No reason to be too strict here with the checks
-                  #        As soon as more than one attr is possible, I need to iterate over the attr list
-                  #
-                  comment = Ops.get(attrList, 0, "")
-                  # The line above needs to be fixed when we have more attributes
+          if Ops.greater_than(Builtins.size(attrList), 0)
+            url = Builtins.substring(Ops.get_string(m, "srvurl", ""), 17)
+            # FIXME: that's really lazy coding here but I allow only one attribute currently anyway
+            #        so it's lazy but okay. No reason to be too strict here with the checks
+            #        As soon as more than one attr is possible, I need to iterate over the attr list
+            #
+            comment = Ops.get(attrList, 0, "")
+            # The line above needs to be fixed when we have more attributes
 
-                  # comment will look like this: "(description=BLA BLA)"
-                  startComment = Builtins.findfirstof(comment, "=")
-                  endComment = Builtins.findlastof(comment, ")")
-                  if startComment != nil && endComment != nil &&
-                      Ops.greater_than(
-                        Ops.subtract(Ops.subtract(endComment, startComment), 1),
-                        0
-                      )
-                    comment = Builtins.substring(
-                      comment,
-                      Ops.add(startComment, 1),
-                      Ops.subtract(Ops.subtract(endComment, startComment), 1)
-                    )
-                  else
-                    comment = ""
-                  end
-                  if Ops.less_than(Builtins.size(comment), 1)
-                    comment = Builtins.sformat(
-                      "bad description in SLP for %1",
-                      url
-                    )
-                  end
-                  dummy = Builtins.add(dummy, Item(comment, false))
-                  Ops.set(comment2url, comment, url)
-                else
-                  url = Builtins.substring(Ops.get_string(m, "srvurl", ""), 17)
-                  dummy = Builtins.add(dummy, Item(url, false))
-                  Ops.set(comment2url, url, url)
-                end
-              end
-              dlg = Left(ComboBox(Id(:choose), _("Choose Profile"), dummy))
-              UI.OpenDialog(VBox(dlg, PushButton(Id(:ok), Label.OKButton)))
-              UI.UserInput
-              cmdLine = Ops.get(
-                comment2url,
-                Convert.to_string(UI.QueryWidget(Id(:choose), :Value)),
-                ""
+            # comment will look like this: "(description=BLA BLA)"
+            startComment = Builtins.findfirstof(comment, "=")
+            endComment = Builtins.findlastof(comment, ")")
+
+            if startComment != nil && endComment != nil &&
+              Ops.greater_than(
+                Ops.subtract(Ops.subtract(endComment, startComment), 1),
+                0
               )
-              UI.CloseDialog
-            elsif Builtins.size(slpData) == 1
-              cmdLine = Builtins.substring(
-                Ops.get_string(slpData, [0, "srvurl"], ""),
-                17
+              comment = Builtins.substring(
+                comment,
+                Ops.add(startComment, 1),
+                Ops.subtract(Ops.subtract(endComment, startComment), 1)
               )
             else
-              cmdLine = "slp query for 'autoyast' failed"
+              comment = ""
             end
+
+            if Ops.less_than(Builtins.size(comment), 1)
+              comment = Builtins.sformat(
+                "bad description in SLP for %1",
+                url
+              )
+            end
+
+            dummy = Builtins.add(dummy, Item(comment, false))
+            Ops.set(comment2url, comment, url)
+          else
+            url = Builtins.substring(Ops.get_string(m, "srvurl", ""), 17)
+            dummy = Builtins.add(dummy, Item(url, false))
+            Ops.set(comment2url, url, url)
           end
-          result = URL.Parse(cmdLine)
-          @OriginalURI = cmdLine
         end
+
+        dlg = Left(ComboBox(Id(:choose), _("Choose Profile"), dummy))
+
+        UI.OpenDialog(VBox(dlg, PushButton(Id(:ok), Label.OKButton)))
+        UI.UserInput
+
+        profile_location = Ops.get(
+          comment2url,
+          Convert.to_string(UI.QueryWidget(Id(:choose), :Value)),
+          ""
+        )
+
+        UI.CloseDialog
+
+      # just one provider
+      elsif Builtins.size(slpData) == 1
+        profile_location = Builtins.substring(
+          Ops.get_string(slpData, [0, "srvurl"], ""),
+          17
+        )
+
+      # Nothing returned by SLP query
+      else
+        log.error "slp query for 'autoyast' failed"
+        Report.Error(_("No 'autoyast' provider has been found via SLP."))
       end
 
+      profile_location
+    end
 
-      if Ops.get_string(result, "scheme", "") == ""
+    # Updates or extends the profile location according to defaults
+    # @param [String] AutoYast profile location as defined on commandline
+    # @return [String] updated profile location
+    def update_profile_location(profile_location)
+      profile_location = deep_copy(profile_location)
+
+      if profile_location.nil? || profile_location == ""
+        # FIXME: reevaluate this statement
+        #
         # Autoinstall mode was not activated from command line.
         # There must be a floppy with an 'autoinst.xml' in order
         # to be able to reach this point, so we set floppy with
         # autoinst.xml as the control file.
-
-        result = Builtins.add(result, "scheme", "floppy")
-        result = Builtins.add(result, "path", "/autoinst.xml")
+        profile_location = "floppy:///#{DEFAULT_PROFILE_NAME}"
+      elsif profile_location == "default"
+        profile_location = "file:///#{DEFAULT_PROFILE_NAME}"
+      # bsc#987858: autoyast=usb checks for the default profile
+      elsif profile_location == "usb"
+        profile_location = "usb:///#{DEFAULT_PROFILE_NAME}"
+      elsif profile_location == "slp"
+        profile_location = find_slp_autoyast
+        return if profile_location.nil?
       end
-      @urltok = deep_copy(result)
 
-      @scheme = Ops.get_string(@urltok, "scheme", "default")
-      @host = Ops.get_string(@urltok, "host", "")
-      @filepath = Ops.get_string(@urltok, "path", "")
-      @port = Ops.get_string(@urltok, "port", "")
-      @user = Ops.get_string(@urltok, "user", "")
-      @pass = Ops.get_string(@urltok, "pass", "")
+      profile_location
+    end
 
-      if @scheme == "default" || @scheme == "file" || @scheme == "floppy"
-        @remoteProfile = false
+    # Processes location of the profile given as a parameter.
+    # @param [String] AutoYast profile location as defined on commandline
+    # @example autoyast=http://www.server.com/profiles/
+    # Fills internal variables
+    def ParseCmdLine(profile_location)
+
+      log.info "AutoYast profile location #{profile_location}"
+
+      profile_location = update_profile_location(profile_location)
+      # There is no profile defined/found anywhere
+      return false if profile_location.nil?
+
+      parsed_url = URL.Parse(profile_location)
+
+      if parsed_url["scheme"].nil? || parsed_url["scheme"] == ""
+        Report.Error(_("Invalid AutoYaST profile URL\n%{url}") % {:url => profile_location})
+        return false
       end
-      Builtins.y2milestone("urltok = %1", @urltok)
+
+      @OriginalURI = profile_location
+      @urltok = deep_copy(parsed_url)
+
+      @scheme   = parsed_url["scheme"] || "default"
+      @host     = parsed_url["host"]   || ""
+      @filepath = parsed_url["path"]   || ""
+      @port     = parsed_url["port"]   || ""
+      @user     = parsed_url["user"]   || ""
+      @pass     = parsed_url["pass"]   || ""
+
+      @remoteProfile = !["default", "file", "floppy", "usb", "device"].include?(@scheme)
+
+      log.info "urltok = #{URL.HidePassword(profile_location)}"
       true
     end
 

--- a/test/AutoinstConfig_tests.rb
+++ b/test/AutoinstConfig_tests.rb
@@ -22,7 +22,7 @@ describe Yast::AutoinstConfig do
 
     context "when only one 'autoyast' provider returned by SLP" do
       let(:service_url) { "https://192.168.0.1/autoinst.xml" }
-      let(:slp_server_reply) { [{"srvurl" => "service:autoyast:#{service_url}" }] }
+      let(:slp_server_reply) { [{ "srvurl" => "service:autoyast:#{service_url}" }] }
 
       it "returns the service URL" do
         expect(subject.find_slp_autoyast).to eq(service_url)
@@ -101,12 +101,12 @@ describe Yast::AutoinstConfig do
       it "parses the given profile location and fill internal structures and returns boolean whether it succeded" do
         expect(subject.ParseCmdLine(autoyast_profile_url)).to eq(true)
 
-        expect(subject.scheme).to   eq("https")
-        expect(subject.host).to     eq("192.168.0.1")
+        expect(subject.scheme).to eq("https")
+        expect(subject.host).to eq("192.168.0.1")
         expect(subject.filepath).to eq("/path/auto-installation.xml")
-        expect(subject.port).to     eq("8080")
-        expect(subject.user).to     eq("moo")
-        expect(subject.pass).to     eq("woo")
+        expect(subject.port).to eq("8080")
+        expect(subject.user).to eq("moo")
+        expect(subject.pass).to eq("woo")
       end
     end
   end

--- a/test/AutoinstConfig_tests.rb
+++ b/test/AutoinstConfig_tests.rb
@@ -1,0 +1,113 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "AutoinstConfig"
+
+describe Yast::AutoinstConfig do
+  subject { Yast::AutoinstConfig }
+
+  describe "#find_slp_autoyast" do
+    before do
+      allow(Yast::SLP).to receive(:FindSrvs).with("autoyast", "").and_return(slp_server_reply)
+    end
+
+    context "when no 'autoyast' provider returned by SLP" do
+      let(:slp_server_reply) { [] }
+
+      it "returns nil" do
+        expect(subject.find_slp_autoyast).to eq(nil)
+      end
+    end
+
+    context "when only one 'autoyast' provider returned by SLP" do
+      let(:service_url) { "https://192.168.0.1/autoinst.xml" }
+      let(:slp_server_reply) { [{"srvurl" => "service:autoyast:#{service_url}" }] }
+
+      it "returns the service URL" do
+        expect(subject.find_slp_autoyast).to eq(service_url)
+      end
+    end
+
+    context "when two or more 'autoyast' services are returned by SLP" do
+      before do
+        allow(Yast::UI).to receive(:OpenDialog).and_return(true)
+        allow(Yast::UI).to receive(:UserInput).and_return(:ok)
+        allow(Yast::UI).to receive(:CloseDialog).and_return(true)
+        expect(Yast::UI).to receive(:QueryWidget).and_return(service_url_2)
+      end
+
+      let(:service_url_1) { "https://192.168.0.1/autoinst.xml" }
+      let(:service_url_2) { "https://192.168.0.2/autoinst.xml" }
+
+      let(:slp_server_reply) {
+        [
+          {"srvurl" => "service:autoyast:#{service_url_1}" },
+          {"srvurl" => "service:autoyast:#{service_url_2}" }
+        ]
+      }
+
+      context "when no additional SLP attributes are found" do
+        it "asks user to choose one URL and returns the selected one" do
+          allow(Yast::SLP).to receive(:FindAttrs).and_return([])
+
+          expect(subject.find_slp_autoyast).to eq(service_url_2)
+        end
+      end
+    end
+  end
+
+  describe "#update_profile_location" do
+    context "when profile location is not defined" do
+      it "returns 'floppy' with path to a profile as the new location" do
+        expect(subject.update_profile_location("")).to match(/floppy:\/+.*xml/)
+      end
+    end
+
+    context "when profile location is 'default'" do
+      it "returns 'file' with path to a profile as the new location" do
+        expect(subject.update_profile_location("default")).to match(/file:\/+.*xml/)
+      end
+    end
+
+    context "when profile location is 'usb'" do
+      it "returns 'usb' with path to a profile as the new location" do
+        expect(subject.update_profile_location("usb")).to match(/usb:\/+.*xml/)
+      end
+    end
+
+    context "when profile location is 'slp'" do
+      let(:url_from_slp) { "https://user@pass:server/path/to/profile.xml" }
+
+      it "returns the URL found using SLP search" do
+        allow(subject).to receive(:find_slp_autoyast).and_return(url_from_slp)
+        expect(subject.update_profile_location("slp")).to eq(url_from_slp)
+      end
+    end
+  end
+
+  describe "#ParseCmdLine" do
+    context "when the profile url is invalid" do
+      let(:autoyast_profile_url) { "//file:8080/path/auto-installation.xml" }
+      it "reports an error and returns false" do
+        expect(Yast::Report).to receive(:Error).with(/Invalid.*/).and_call_original
+        expect(subject.ParseCmdLine(autoyast_profile_url)).to eq(false)
+      end
+    end
+
+    context "when the autoyast profile url is valid" do
+      let(:autoyast_profile_url) { "https://moo:woo@192.168.0.1:8080/path/auto-installation.xml" }
+
+      it "parses the given profile location and fill internal structures and returns boolean whether it succeded" do
+        expect(subject.ParseCmdLine(autoyast_profile_url)).to eq(true)
+
+        expect(subject.scheme).to   eq("https")
+        expect(subject.host).to     eq("192.168.0.1")
+        expect(subject.filepath).to eq("/path/auto-installation.xml")
+        expect(subject.port).to     eq("8080")
+        expect(subject.user).to     eq("moo")
+        expect(subject.pass).to     eq("woo")
+      end
+    end
+  end
+end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,6 +6,7 @@ TESTS = \
     AutoInstallRules_test.rb \
     AutoInstall_test.rb \
     AutoinstClass_test.rb \
+    AutoinstConfig_tests.rb \
     AutoinstFunctions_test.rb \
     AutoinstGeneral_test.rb \
     AutoinstSoftware_test.rb \


### PR DESCRIPTION
# AutoYast=usb is now (again) valid Linuxrc commandline option

- [bsc#987858](https://bugzilla.suse.com/show_bug.cgi?id=987858)
- It has been reported that `autoyast=usb` has been working since
  SLE9, but stopped working in SLE12. This patch reintorduces
  this possibility again
- `autoyast=usb` is internally converted into `autoyast=usb:///autoinst.xml`
- Manually tested
- Patch contains a new test-case
- Refactoring included