### PR TITLE
Profile Location: Use Report instead of Popup to not block AutoYast

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 26 09:39:55 UTC 2016 - kanderssen@suse.com
+
+- Profile Location: Use Report instead of Popup to not block
+  AutoYast if not configured to. (bnc#988949)
+- 3.1.149
+
+-------------------------------------------------------------------
 Thu Aug 25 14:10:57 CEST 2016 - schubi@suse.de
 
 - Fixed: Setting timeout for error popups has not been possible.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.148
+Version:        3.1.149
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/autoinst_dialogs.rb
+++ b/src/include/autoinstall/autoinst_dialogs.rb
@@ -12,6 +12,7 @@ module Yast
       textdomain "autoinst"
       Yast.import "Label"
       Yast.import "Storage"
+      Yast.import "Popup"
     end
 
     # Shows a dialog when 'control file' can't be found

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -153,7 +153,7 @@ module Yast
           raise Break if AutoinstConfig.scheme == "device"
         end
         if AutoinstConfig.scheme == "label"
-          Popup.Error(_("label not found while looking for autoyast profile"))
+          Report.Error(_("label not found while looking for autoyast profile"))
         end
       end
       filename = basename(AutoinstConfig.filepath)
@@ -177,7 +177,7 @@ module Yast
         if !ret
           # autoyast hit an error while fetching it's config file
           error = _("An error occurred while fetching the profile:\n")
-          Popup.Error(Ops.add(error, @GET_error))
+          Report.Error(Ops.add(error, @GET_error))
           return false
         end
         tmp = Convert.to_string(SCR.Read(path(".target.string"), localfile))

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -20,7 +20,7 @@ module Yast
       Yast.import "StorageControllers"
       Yast.import "Mode"
       Yast.import "Installation"
-      Yast.import "Popup"
+      Yast.import "Report"
       Yast.import "Label"
       Yast.import "URL"
 


### PR DESCRIPTION
This change is part of this PR https://github.com/yast/yast-installation/pull/424 and in general part of the new update installer refactorization https://github.com/yast/yast-installation/pull/422