### PR TITLE
Clone hidden

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -3,6 +3,9 @@ Mon Nov 14 13:22:49 UTC 2016 - igonzalezsosa@suse.com
 
 - Hiding a module in its .desktop file (Hidden=true) won't prevent
   it from being cloned anymore (bsc#1008301)
+- Add support to specify resource aliases using the key
+  X-SuSE-YaST-AutoInstResourceAliases in desktop files (related
+  to bsc#887115)
 - 3.1.153
 
 -------------------------------------------------------------------

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 14 13:22:49 UTC 2016 - igonzalezsosa@suse.com
+
+- Hiding a module in its .desktop file (Hidden=true) won't prevent
+  it from being cloned anymore (bsc#1008301)
+- 3.1.153
+
+-------------------------------------------------------------------
 Fri Sep 30 10:21:45 CEST 2016 - schubi@suse.de
 
 - Adding missed desktop file for "clone_system" in order to show

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.152
+Version:        3.1.153
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -367,9 +367,6 @@ module Yast
       e = []
 
       Builtins.foreach(@ModuleMap) do |p, d|
-        # bnc#887115 Hidden modules cannot be cloned
-        next if d["Hidden"] == "true"
-
         #
         # Set resource name, if not using default value
         #

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -909,6 +909,8 @@ module Yast
       end
     end
 
+  protected
+
     # Merge resource aliases in the profile
     #
     # When a resource is aliased, the configuration with the aliased name will
@@ -930,16 +932,17 @@ module Yast
 
     # Module aliases map
     #
+    # This method delegates on Y2ModuleConfig#resource_aliases_map
+    # and exists just to avoid a circular dependency between
+    # Y2ModuleConfig and Profile (as the former depends on the latter).
+    #
     # @return [Hash] Map of resource aliases where the key is the alias and the
     #                value is the resource ({alias => resource})
+    #
+    # @see Y2ModuleConfig#resource_aliases_map
     def resource_aliases_map
-      ModuleMap().each_with_object({}) do |resource, map|
-        name, def_resource = resource
-        next if def_resource["X-SuSE-YaST-AutoInstResourceAliases"].nil?
-        resource_name = def_resource["X-SuSE-YaST-AutoInstResource"] || name
-        aliases = def_resource["X-SuSE-YaST-AutoInstResourceAliases"].split(",").map(&:strip)
-        aliases.each { |a| map[a] = resource_name }
-      end
+      Yast.import "Y2ModuleConfig"
+      Y2ModuleConfig.resource_aliases_map
     end
 
     publish :variable => :current, :type => "map <string, any>"

--- a/src/modules/Y2ModuleConfig.rb
+++ b/src/modules/Y2ModuleConfig.rb
@@ -13,6 +13,7 @@ module Yast
     # Key for AutoYaST client name in desktop file
     RESOURCE_NAME_KEY = "X-SuSE-YaST-AutoInstResource"
     RESOURCE_NAME_MERGE_KEYS = "X-SuSE-YaST-AutoInstMerge"
+    RESOURCE_ALIASES_NAME_KEY = "X-SuSE-YaST-AutoInstResourceAliases"
     MODES = %w(all configure write)
 
     include Yast::Logger
@@ -52,6 +53,7 @@ module Yast
         "Hidden",
         "X-SuSE-YaST-AutoInst",
         RESOURCE_NAME_KEY,
+        RESOURCE_ALIASES_NAME_KEY,
         "X-SuSE-YaST-AutoInstClient",
         "X-SuSE-YaST-Group",
         RESOURCE_NAME_MERGE_KEYS,
@@ -399,6 +401,20 @@ module Yast
         { "res" => name, "data" => entry.last }
       else
         nil
+      end
+    end
+
+    # Module aliases map
+    #
+    # @return [Hash] Map of resource aliases where the key is the alias and the
+    #                value is the resource ({alias => resource})
+    def resource_aliases_map
+      ModuleMap().each_with_object({}) do |resource, map|
+        name, def_resource = resource
+        next if def_resource[RESOURCE_ALIASES_NAME_KEY].nil?
+        resource_name = def_resource[RESOURCE_NAME_KEY] || name
+        aliases = def_resource[RESOURCE_ALIASES_NAME_KEY].split(",").map(&:strip)
+        aliases.each { |a| map[a] = resource_name }
       end
     end
 

--- a/test/Y2ModuleConfig_test.rb
+++ b/test/Y2ModuleConfig_test.rb
@@ -93,4 +93,47 @@ describe Yast::Y2ModuleConfig do
       end
     end
   end
+
+  describe "#resource_aliases_map" do
+    let(:module_map) { { "custom" => custom_module } }
+
+    before do
+      allow(subject).to receive(:ModuleMap).and_return(module_map)
+    end
+
+    context "when some module is aliased" do
+      let(:custom_module) do
+        { "Name" => "Custom module",
+          "X-SuSE-YaST-AutoInstResourceAliases" => "alias1,alias2" }
+      end
+
+      it "maps aliases to the resource" do
+        expect(subject.resource_aliases_map)
+          .to eq({ "alias1" => "custom", "alias2" => "custom" })
+      end
+    end
+
+    context "when some module is aliased and an alternative name was specified" do
+      let(:custom_module) do
+        { "Name" => "Custom module",
+          "X-SuSE-YaST-AutoInstResource" => "custom-resource",
+          "X-SuSE-YaST-AutoInstResourceAliases" => "alias1,alias2" }
+      end
+
+      it "maps aliases to the alternative resource name" do
+        expect(subject.resource_aliases_map)
+          .to eq({ "alias1" => "custom-resource", "alias2" => "custom-resource" })
+      end
+    end
+
+    context "when no module is aliased" do
+      let(:custom_module) do
+        { "Name" => "Custom module" }
+      end
+
+      it "returns an empty map" do
+        expect(subject.resource_aliases_map).to eq({})
+      end
+    end
+  end
 end

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -197,7 +197,7 @@ describe Yast::Profile do
       end
 
       before do
-        allow(Yast::Profile).to receive(:ModuleMap)
+        allow(Yast::Y2ModuleConfig).to receive(:ModuleMap)
           .and_return("custom" => custom_module)
       end
 

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -263,9 +263,9 @@ describe Yast::Profile do
     context "when a module is 'hidden'" do
       let(:custom_module) { CUSTOM_MODULE.merge("Hidden" => "true") }
 
-      it "does not include the 'hidden' module" do
+      it "does includes the 'hidden' module" do
         subject.Prepare
-        expect(subject.current.keys).to_not include("custom")
+        expect(subject.current.keys).to include("custom")
       end
     end
 


### PR DESCRIPTION
This PR allow hidden modules to be cloned ([bsc#1008301](https://bugzilla.suse.com/show_bug.cgi?id=1008301)).

Additionally, it adds a new `X-SuSE-YaST-AutoInstResourceAliases` element to desktop files so [bsc#887115](https://bugzilla.suse.com/show_bug.cgi?id=887115) can be fixed. The idea is that we can get rid of `runlevel.desktop` and just specify `X-SuSE-YaST-AutoInstResourceAliases=runlevel` in `services-manager.desktop` (implemented in https://github.com/yast/yast-services-manager/pull/114).