### PR TITLE
Create default subvolumes

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -2,7 +2,7 @@
 Wed Nov 30 09:30:26 UTC 2016 - igonzalezsosa@suse.com
 
 - If Btrfs subvolumes are not specified, the default set
-  is created
+  is created (bsc#1012328)
 - 3.1.156
 
 -------------------------------------------------------------------

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 30 09:30:26 UTC 2016 - igonzalezsosa@suse.com
+
+- If Btrfs subvolumes are not specified, the default set
+  is created
+- 3.1.156
+
+-------------------------------------------------------------------
 Tue Nov 22 15:23:44 UTC 2016 - igonzalezsosa@suse.com
 
 - Fix building on s390x (bsc#1011489)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.155
+Version:        3.1.156
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Fix [bsc#1012328](https://bugzilla.suse.com/show_bug.cgi?id=1012328). Covered by integration tests: https://github.com/yast/aytests-tests/pull/48.

When using Btrfs, if subvolumes are not specified, the default set will be created. But what if you do not want any subvolume to be created (an empty list will be removed when importing the profile)? You can work around that by setting the subvolumes list as this:

```xml
<subvolumes config:type="list">
  <subvolume>/</subvolume>
</subvolumes>
```