### PR TITLE
Improve the check_schema.sh script

### DIFF
--- a/check_schema.sh
+++ b/check_schema.sh
@@ -1,9 +1,16 @@
 #! /bin/sh
 
+# This script checks that all RNC files can be converted to RNG without errors.
+
+# Fail if trang is missing
+if ! which trang > /dev/null; then
+  echo 'ERROR: "trang" tool is missing'
+  exit 1
+fi
+
 # explicitly check the RNC schema files for errors
 # (the files are defined here, but converted in yast2-schema)
-find . -name "*.rnc" -exec trang -I rnc -O rng \{\} test.rng \; 2> trang.log
-rm -f test.rng
+find . -name "*.rnc" -exec sh -c "echo 'Checking {}...'; trang -I rnc -O rng {} /dev/null" \; 2> trang.log
 
 # grep for "error" in the output, "trang" returns 0 exit status
 # even on an error :-(
@@ -15,4 +22,4 @@ if grep -i -q error trang.log; then
 fi
 
 rm -f trang.log
-
+echo "OK"


### PR DESCRIPTION
## Improvements

- check that `trang` is actually installed
- be more verbose (print progress and the result)
- save the RNG files to /dev/null (not needed anyway, avoid save&remove)

See this example output: https://travis-ci.org/yast/yast-autoinstallation/builds/189202776#L1819