### PR TITLE
Storage-ng custom (level-3) partitioning

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,7 +1,16 @@
 -------------------------------------------------------------------
+Fri Jun 16 13:05:47 UTC 2017 - igonzalezsosa@suse.com
+
+- Add basic support for customized partitioning using the new
+  storage-ng layer. Currently, only plain partitions are supported
+  (bsc#1044697).
+- 3.3.3
+
+-------------------------------------------------------------------
 Mon May 15 09:53:54 UTC 2017 - igonzalezsosa@suse.com
 
 - Allow overriding of product's storage partitioning options
+  (bsc#1039481)
 - 3.3.2
 
 -------------------------------------------------------------------

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.3.2
+Version:        3.3.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -41,7 +41,7 @@ BuildRequires:  yast2-services-manager
 BuildRequires:  yast2-packager
 BuildRequires:  yast2-update >= 3.3.0
 BuildRequires:  yast2-slp
-BuildRequires:  yast2-storage-ng
+BuildRequires:  yast2-storage-ng >= 0.1.19
 
 # %%{_unitdir} macro definition is in a separate package since 13.1
 %if 0%{?suse_version} >= 1310
@@ -60,7 +60,7 @@ Requires:       yast2-network >= 3.1.145
 Requires:       yast2-schema
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml
-Requires:       yast2-storage-ng
+Requires:       yast2-storage-ng >= 0.1.19
 Conflicts:      yast2-installation < 3.1.166
 
 Provides:       yast2-config-autoinst
@@ -114,7 +114,7 @@ Requires:       yast2-update >= 3.3.0
 Requires:       yast2-xml
 # pkgGpgCheck callback
 Requires:       yast2-pkg-bindings >= 3.1.31
-Requires:       yast2-storage-ng
+Requires:       yast2-storage-ng >= 0.1.19
 Provides:       yast2-trans-autoinst
 Obsoletes:      yast2-trans-autoinst
 

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -41,7 +41,7 @@ BuildRequires:  yast2-services-manager
 BuildRequires:  yast2-packager
 BuildRequires:  yast2-update >= 3.3.0
 BuildRequires:  yast2-slp
-BuildRequires:  yast2-storage-ng >= 0.1.19
+BuildRequires:  yast2-storage-ng >= 0.1.20
 
 # %%{_unitdir} macro definition is in a separate package since 13.1
 %if 0%{?suse_version} >= 1310
@@ -60,7 +60,7 @@ Requires:       yast2-network >= 3.1.145
 Requires:       yast2-schema
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml
-Requires:       yast2-storage-ng >= 0.1.19
+Requires:       yast2-storage-ng >= 0.1.20
 Conflicts:      yast2-installation < 3.1.166
 
 Provides:       yast2-config-autoinst
@@ -114,7 +114,7 @@ Requires:       yast2-update >= 3.3.0
 Requires:       yast2-xml
 # pkgGpgCheck callback
 Requires:       yast2-pkg-bindings >= 3.1.31
-Requires:       yast2-storage-ng >= 0.1.19
+Requires:       yast2-storage-ng >= 0.1.20
 Provides:       yast2-trans-autoinst
 Obsoletes:      yast2-trans-autoinst
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,7 +72,8 @@ ynclude_DATA = \
 ylibdir = @ylibdir@/autoinstall
 ylib_DATA = \
   lib/autoinstall/module_config_builder.rb \
-  lib/autoinstall/pkg_gpg_check_handler.rb
+  lib/autoinstall/pkg_gpg_check_handler.rb \
+  lib/autoinstall/storage_proposal.rb
 
 scrconf_DATA = \
   scrconf/cfg_autoinstall.scr \

--- a/src/lib/autoinstall/storage_proposal.rb
+++ b/src/lib/autoinstall/storage_proposal.rb
@@ -1,7 +1,7 @@
 require "y2storage"
 require "y2storage/disk_analyzer"
 require "y2storage/guided_proposal"
-require "y2storage/auto_inst_proposal"
+require "y2storage/autoinst_proposal"
 
 module Y2Autoinstallation
   # Storage proposal for AutoYaST
@@ -54,17 +54,17 @@ module Y2Autoinstallation
       if partitioning.nil? || partitioning.empty?
         guided_proposal
       else
-        auto_inst_proposal(partitioning)
+        autoinst_proposal(partitioning)
       end
     end
 
-    # Return an AutoInstProposal according to the AutoYaST profile
+    # Return an AutoinstProposal according to the AutoYaST profile
     #
     # @param partitioning [Array<Hash>] Partitioning specification from AutoYaST profile
-    # @return [Y2Storage::AutoInstProposal]
-    def auto_inst_proposal(partitioning)
+    # @return [Y2Storage::AutoinstProposal]
+    def autoinst_proposal(partitioning)
       log.info "Initializing an autoinst proposal"
-      Y2Storage::AutoInstProposal.new(
+      Y2Storage::AutoinstProposal.new(
         partitioning:  partitioning,
         devicegraph:   devicegraph,
         disk_analyzer: disk_analyzer

--- a/src/lib/autoinstall/storage_proposal.rb
+++ b/src/lib/autoinstall/storage_proposal.rb
@@ -1,0 +1,99 @@
+require "y2storage"
+require "y2storage/disk_analyzer"
+require "y2storage/guided_proposal"
+require "y2storage/auto_inst_proposal"
+
+module Y2Autoinstallation
+  # Storage proposal for AutoYaST
+  #
+  # This class it is mainly a wrapper around proposal Y2Storage proposal classes.
+  # Depending on the profile, it will select the right class: if 'partitioning'
+  # section is missing (or empty), {Y2Storage::GuidedProposal} will be used. Otherwise,
+  # proposal will be handdled by {Y2Storage::AutoinstProposal}.
+  class StorageProposal
+    include Yast::Logger
+
+    # @return [Y2Storage::Proposal] Y2Storage proposal instance
+    attr_reader :proposal
+
+    # Constructor
+    #
+    # @param partitioning [Array<Hash>] Partitioning section from the AutoYaST profile
+    #
+    # @see https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Partitioning
+    def initialize(partitioning)
+      @proposal = build_proposal(partitioning)
+    end
+
+    # Perform the proposal
+    #
+    # It delegates on the Y2Storage proposal instance
+    def propose
+      proposal.propose
+    end
+
+    # Propose and set the proposal on the StorageManager
+    #
+    # @return [Boolean] true if operation was successful; false otherwise
+    def propose_and_store
+      propose
+      log.info "Storing successful proposal"
+      Y2Storage::StorageManager.instance.proposal = proposal
+      true
+    rescue Y2Storage::Error => e
+      log.warn "Proposal failed: #{e.inspect}"
+      false
+    end
+
+  private
+
+    # Initialize partition proposal
+    #
+    # @return [Boolean] true if proposal was successfully created; false otherwise.
+    def build_proposal(partitioning)
+      if partitioning.nil? || partitioning.empty?
+        guided_proposal
+      else
+        auto_inst_proposal(partitioning)
+      end
+    end
+
+    # Return an AutoInstProposal according to the AutoYaST profile
+    #
+    # @param partitioning [Array<Hash>] Partitioning specification from AutoYaST profile
+    # @return [Y2Storage::AutoInstProposal]
+    def auto_inst_proposal(partitioning)
+      log.info "Initializing an autoinst proposal"
+      Y2Storage::AutoInstProposal.new(
+        partitioning:  partitioning,
+        devicegraph:   devicegraph,
+        disk_analyzer: disk_analyzer
+      )
+    end
+
+    # Return a GuidedProposal according to product's proposal setting
+    #
+    # @return [Y2Storage::GuidedProposal]
+    def guided_proposal
+      log.info "Initializing a guided proposal"
+      proposal_settings = Y2Storage::ProposalSettings.new_for_current_product
+      Y2Storage::GuidedProposal.new(settings: proposal_settings)
+    end
+
+    # Return a DiskAnalyzer for the proposal's devicegraph
+    #
+    # @return [Y2Storage::DiskAnalyzer]
+    def disk_analyzer
+      @disk_analyzer ||= Y2Storage::DiskAnalyzer.new(devicegraph)
+    end
+
+    # Return the current devicegraph
+    #
+    # If no devicegraph was specified, the probed one will be used.
+    #
+    # @return [Y2Storage::Devicegraph]
+    def devicegraph
+      @devicegraph ||= Y2Storage::StorageManager.instance.y2storage_probed
+    end
+  end
+end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -17,7 +17,8 @@ TESTS = \
     include/autopart_test.rb \
     include/ask_test.rb \
     lib/module_config_builder_test.rb \
-    lib/pkg_gpg_check_handler_test.rb
+    lib/pkg_gpg_check_handler_test.rb \
+    lib/storage_proposal_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -7,80 +7,29 @@ describe Yast::AutoinstStorage do
   subject { Yast::AutoinstStorage }
 
   describe "#Import" do
-    let(:proposal_settings) { double("proposal_settings") }
-    let(:guided_proposal) { instance_double(Y2Storage::GuidedProposal, propose: nil, proposed?: true) }
-    let(:auto_inst_proposal) { instance_double(Y2Storage::AutoInstProposal, propose: nil, proposed?: true) }
-    let(:devicegraph) { instance_double(Y2Storage::Devicegraph) }
-    let(:storage_manager) { double("storage_manager", y2storage_probed: devicegraph) }
-    let(:disk_analyzer) { instance_double(Y2Storage::DiskAnalyzer) }
+    let(:storage_proposal) { instance_double(Y2Autoinstallation::StorageProposal) }
 
     before do
-      allow(Y2Storage::StorageManager).to receive(:instance)
-        .and_return(storage_manager)
-      allow(Y2Storage::GuidedProposal).to receive(:new)
-        .and_return(guided_proposal)
-      allow(Y2Storage::AutoInstProposal).to receive(:new)
-        .and_return(auto_inst_proposal)
-      allow(storage_manager).to receive(:proposal=)
+      allow(Y2Autoinstallation::StorageProposal).to receive(:new)
+        .and_return(storage_proposal)
     end
 
-    context "when no partitioning plan is given" do
-      let(:profile) { nil }
-
-      it "sets a proposal" do
-        expect(storage_manager).to receive(:proposal=).with(guided_proposal)
-        subject.Import(profile)
-      end
-
-      it "returns true" do
-        expect(subject.Import(profile)).to eq(true)
-      end
-
-      context "if proposal fails" do
-        before do
-          allow(guided_proposal).to receive(:propose).and_raise(Y2Storage::Error)
-        end
-
-        it "does not set the proposal" do
-          expect(storage_manager).to_not receive(:proposal=)
-          subject.Import(profile)
-        end
-
-        it "returns false" do
-          expect(storage_manager).to_not receive(:proposal=)
-          subject.Import(profile)
-        end
-      end
+    it "creates a proposal" do
+      expect(storage_proposal).to receive(:propose_and_store)
+        .and_return(true)
+      subject.Import({})
     end
 
-    context "when profile contains an empty set of partitions" do
-      let(:profile) { [] }
-
-      it "sets a proposal" do
-        expect(storage_manager).to receive(:proposal=).with(guided_proposal)
-        subject.Import(profile)
-      end
+    it "returns true if proposal succeeds" do
+      allow(storage_proposal).to receive(:propose_and_store)
+        .and_return(true)
+      expect(subject.Import({})).to eq(true)
     end
 
-    context "when a partition plan is given" do
-      let(:profile) { [{ "device" => "/dev/sda" }] }
-
-      before do
-        allow(Y2Storage::AutoInstProposal).to receive(:new).and_return(auto_inst_proposal)
-        allow(Y2Storage::DiskAnalyzer).to receive(:new).with(devicegraph).and_return(disk_analyzer)
-      end
-
-      it "asks for a proposal" do
-        expect(Y2Storage::AutoInstProposal).to receive(:new)
-          .with(partitioning: profile, devicegraph: devicegraph, disk_analyzer: disk_analyzer)
-          .and_return(auto_inst_proposal)
-        expect(auto_inst_proposal).to receive(:propose)
-        subject.Import(profile)
-      end
-
-      it "returns true" do
-        expect(subject.Import(profile)).to eq(true)
-      end
+    it "returns false if proposal fails" do
+      allow(storage_proposal).to receive(:propose_and_store)
+        .and_return(false)
+      expect(subject.Import({})).to eq(false)
     end
   end
 

--- a/test/lib/storage_proposal_test.rb
+++ b/test/lib/storage_proposal_test.rb
@@ -9,7 +9,7 @@ describe Y2Autoinstallation::StorageProposal do
   describe "#propose" do
     let(:proposal_settings) { double("proposal_settings") }
     let(:guided_proposal) { instance_double(Y2Storage::GuidedProposal, propose: nil, proposed?: true) }
-    let(:auto_inst_proposal) { instance_double(Y2Storage::AutoInstProposal, propose: nil, proposed?: true) }
+    let(:autoinst_proposal) { instance_double(Y2Storage::AutoinstProposal, propose: nil, proposed?: true) }
     let(:devicegraph) { instance_double(Y2Storage::Devicegraph) }
     let(:storage_manager) { double("storage_manager", y2storage_probed: devicegraph) }
     let(:disk_analyzer) { instance_double(Y2Storage::DiskAnalyzer) }
@@ -19,8 +19,8 @@ describe Y2Autoinstallation::StorageProposal do
         .and_return(storage_manager)
       allow(Y2Storage::GuidedProposal).to receive(:new)
         .and_return(guided_proposal)
-      allow(Y2Storage::AutoInstProposal).to receive(:new)
-        .and_return(auto_inst_proposal)
+      allow(Y2Storage::AutoinstProposal).to receive(:new)
+        .and_return(autoinst_proposal)
       allow(storage_manager).to receive(:proposal=)
     end
 
@@ -66,15 +66,15 @@ describe Y2Autoinstallation::StorageProposal do
       let(:profile) { [{ "device" => "/dev/sda" }] }
 
       before do
-        allow(Y2Storage::AutoInstProposal).to receive(:new).and_return(auto_inst_proposal)
+        allow(Y2Storage::AutoinstProposal).to receive(:new).and_return(autoinst_proposal)
         allow(Y2Storage::DiskAnalyzer).to receive(:new).with(devicegraph).and_return(disk_analyzer)
       end
 
       it "asks for a proposal" do
-        expect(Y2Storage::AutoInstProposal).to receive(:new)
+        expect(Y2Storage::AutoinstProposal).to receive(:new)
           .with(partitioning: profile, devicegraph: devicegraph, disk_analyzer: disk_analyzer)
-          .and_return(auto_inst_proposal)
-        expect(auto_inst_proposal).to receive(:propose)
+          .and_return(autoinst_proposal)
+        expect(autoinst_proposal).to receive(:propose)
         storage_proposal.propose_and_store
       end
 

--- a/test/lib/storage_proposal_test.rb
+++ b/test/lib/storage_proposal_test.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "autoinstall/storage_proposal"
+
+describe Y2Autoinstallation::StorageProposal do
+  subject(:storage_proposal) { described_class.new(profile) }
+
+  describe "#propose" do
+    let(:proposal_settings) { double("proposal_settings") }
+    let(:guided_proposal) { instance_double(Y2Storage::GuidedProposal, propose: nil, proposed?: true) }
+    let(:auto_inst_proposal) { instance_double(Y2Storage::AutoInstProposal, propose: nil, proposed?: true) }
+    let(:devicegraph) { instance_double(Y2Storage::Devicegraph) }
+    let(:storage_manager) { double("storage_manager", y2storage_probed: devicegraph) }
+    let(:disk_analyzer) { instance_double(Y2Storage::DiskAnalyzer) }
+
+    before do
+      allow(Y2Storage::StorageManager).to receive(:instance)
+        .and_return(storage_manager)
+      allow(Y2Storage::GuidedProposal).to receive(:new)
+        .and_return(guided_proposal)
+      allow(Y2Storage::AutoInstProposal).to receive(:new)
+        .and_return(auto_inst_proposal)
+      allow(storage_manager).to receive(:proposal=)
+    end
+
+    context "when no partitioning plan is given" do
+      let(:profile) { nil }
+
+      it "sets a guided proposal" do
+        expect(storage_manager).to receive(:proposal=).with(guided_proposal)
+        storage_proposal.propose_and_store
+      end
+
+      it "returns true" do
+        expect(subject.propose_and_store).to eq(true)
+      end
+
+      context "if proposal fails" do
+        before do
+          allow(guided_proposal).to receive(:propose).and_raise(Y2Storage::Error)
+        end
+
+        it "does not set the proposal" do
+          expect(storage_manager).to_not receive(:proposal=)
+          storage_proposal.propose_and_store
+        end
+
+        it "returns false" do
+          expect(storage_manager).to_not receive(:proposal=)
+          storage_proposal.propose_and_store
+        end
+      end
+    end
+
+    context "when profile contains an empty set of partitions" do
+      let(:profile) { [] }
+
+      it "sets a proposal" do
+        expect(storage_manager).to receive(:proposal=).with(guided_proposal)
+        storage_proposal.propose_and_store
+      end
+    end
+
+    context "when a partition plan is given" do
+      let(:profile) { [{ "device" => "/dev/sda" }] }
+
+      before do
+        allow(Y2Storage::AutoInstProposal).to receive(:new).and_return(auto_inst_proposal)
+        allow(Y2Storage::DiskAnalyzer).to receive(:new).with(devicegraph).and_return(disk_analyzer)
+      end
+
+      it "asks for a proposal" do
+        expect(Y2Storage::AutoInstProposal).to receive(:new)
+          .with(partitioning: profile, devicegraph: devicegraph, disk_analyzer: disk_analyzer)
+          .and_return(auto_inst_proposal)
+        expect(auto_inst_proposal).to receive(:propose)
+        storage_proposal.propose_and_store
+      end
+
+      it "returns true" do
+        expect(storage_proposal.propose_and_store).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a `partitioning` section is specified, the partitioning will be performed by `Y2Storage::AutoInstProposal`. Depends on https://github.com/yast/yast-storage-ng/pull/259.

Travis is failing because the docker image does not contain the latest yast2-storage-ng version.