### PR TITLE
Fix subvolumes export

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct 18 14:09:07 UTC 2017 - igonzalezsosa@suse.com
+
+- When using Btrfs but without subvolumes, export an empty list
+  instead of removing them from the profile (related to
+  bsc#1059617)
+- 3.1.168
+
+-------------------------------------------------------------------
 Mon Oct  9 10:22:08 CEST 2017 - schubi@suse.de
 
 - Adding default subvolumes to root partition only if the user

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.167
+Version:        3.1.168
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstPartition.rb
+++ b/src/modules/AutoinstPartition.rb
@@ -279,7 +279,7 @@ module Yast
         newPart["subvolumes"] = part["subvolumes"].reject do |subvolume|
           subvolume["path"].start_with?(".snapshots")
         end
-      else
+      elsif newPart["filesystem"] != :btrfs
         newPart = Builtins.remove(newPart, "subvolumes")
       end
       if !Builtins.isempty(Ops.get_string(part, "used_pool", ""))

--- a/test/AutoinstPartition_test.rb
+++ b/test/AutoinstPartition_test.rb
@@ -22,7 +22,6 @@ describe "Yast::AutoinstPartition" do
 
     it "filters out snapper snapshots" do
       parsed = subject.parsePartition(partition)
-
       expect(parsed["subvolumes"]).to eq(
         [{ "path" => "var/lib/machines" }]
       )
@@ -33,7 +32,6 @@ describe "Yast::AutoinstPartition" do
 
       it "exports them as an empty array" do
         parsed = subject.parsePartition(partition)
-
         expect(parsed["subvolumes"]).to eq([])
       end
 
@@ -42,7 +40,6 @@ describe "Yast::AutoinstPartition" do
 
         it "does not export the subvolumes list" do
           parsed = subject.parsePartition(partition)
-
           expect(parsed).to_not have_key("subvolumes")
         end
       end

--- a/test/AutoinstPartition_test.rb
+++ b/test/AutoinstPartition_test.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "AutoinstPartition"
+
+describe "Yast::AutoinstPartition" do
+  subject { Yast::AutoinstPartition }
+
+  describe "#parsePartition" do
+    let(:filesystem) { :btrfs }
+    let(:subvolumes) do
+      [
+        { "path" => ".snapshots/1" },
+        { "path" => "var/lib/machines" }
+      ]
+    end
+
+    let(:partition) do
+      { "filesystem" => filesystem, "subvolumes" => subvolumes }
+    end
+
+    it "filters out snapper snapshots" do
+      parsed = subject.parsePartition(partition)
+
+      expect(parsed["subvolumes"]).to eq(
+        [{ "path" => "var/lib/machines" }]
+      )
+    end
+
+    context "when there are no Btrfs subvolumes" do
+      let(:subvolumes) { [] }
+
+      it "exports them as an empty array" do
+        parsed = subject.parsePartition(partition)
+
+        expect(parsed["subvolumes"]).to eq([])
+      end
+
+      context "and filesystem is not Btrfs" do
+        let(:filesystem) { :ext4 }
+
+        it "does not export the subvolumes list" do
+          parsed = subject.parsePartition(partition)
+
+          expect(parsed).to_not have_key("subvolumes")
+        end
+      end
+    end
+  end
+end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,7 @@ TESTS = \
     AutoinstConfig_tests.rb \
     AutoinstFunctions_test.rb \
     AutoinstGeneral_test.rb \
+    AutoinstPartition_test.rb \
     AutoinstPartPlan_test.rb \
     AutoinstSoftware_test.rb \
     profile_test.rb \


### PR DESCRIPTION
If there are not subvolumes, export an empty subvolumes list instead of removing it completely.