### PR TITLE
AutoYaST error reporting

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 20 11:17:48 UTC 2017 - igonzalezsosa@suse.com
+
+- Add basic support for error handling when creating the
+  partition plan (fate#318196).
+- 4.0.3
+
+-------------------------------------------------------------------
 Fri Oct 20 11:11:17 UTC 2017 - igonzalezsosa@suse.com
 
 - Add missing require of Y2Package::Product class (bsc#1064396)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -288,6 +288,9 @@ rmdir $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/autoyast2/html/autoyast
 %dir %{yast_libdir}/autoinstall
 %{yast_libdir}/autoinstall/*.rb
 
+%dir %{yast_libdir}/autoinstall/dialogs
+%{yast_libdir}/autoinstall/dialogs/*.rb
+
 # scripts
 %{_prefix}/lib/YaST2/bin/fetch_image.sh
 %{_prefix}/lib/YaST2/bin/autoyast-initscripts.sh

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,7 +72,8 @@ ylibdir = @ylibdir@/autoinstall
 ylib_DATA = \
   lib/autoinstall/module_config_builder.rb \
   lib/autoinstall/pkg_gpg_check_handler.rb \
-  lib/autoinstall/storage_proposal.rb
+  lib/autoinstall/storage_proposal.rb \
+  lib/autoinstall/storage_proposal_issues_presenter.rb
 
 ydialogsdir = @ylibdir@/autoinstall/dialogs
 ydialogs_DATA = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,6 +74,10 @@ ylib_DATA = \
   lib/autoinstall/pkg_gpg_check_handler.rb \
   lib/autoinstall/storage_proposal.rb
 
+ydialogsdir = @ylibdir@/autoinstall/dialogs
+ydialogs_DATA = \
+  lib/autoinstall/dialogs/question.rb
+
 scrconf_DATA = \
   scrconf/cfg_autoinstall.scr \
   scrconf/autoinstall.scr
@@ -104,6 +108,6 @@ desktop_DATA = \
 fillup_DATA = \
   fillup/sysconfig.autoinstall
 
-EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(ybin_SCRIPTS) $(desktop_DATA) $(fillup_DATA) $(ylib_DATA)
+EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(ybin_SCRIPTS) $(desktop_DATA) $(fillup_DATA) $(ylib_DATA) $(ydialogs_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -275,6 +275,8 @@ module Yast
         write_storage = AutoinstStorage.Import(Profile.current["partitioning"])
       end
 
+      return :abort unless write_storage
+
       semiauto_partitions = general_section["semi-automatic"] &&
         general_section["semi-automatic"].include?("partitioning")
 

--- a/src/lib/autoinstall/dialogs/question.rb
+++ b/src/lib/autoinstall/dialogs/question.rb
@@ -35,7 +35,7 @@ module Y2Autoinstallation
     # * Display a message and only offer an 'Abort' button.
     #
     # In order to integrate nicely with AutoYaST, a timeout can be set.
-    # Bear in mind that the timeout will not be respected when a showing only
+    # Bear in mind that the timeout will not be respected when showing only
     # the 'Abort' button.
     #
     # This dialog could be extended in the future in order to support other

--- a/src/lib/autoinstall/dialogs/question.rb
+++ b/src/lib/autoinstall/dialogs/question.rb
@@ -1,0 +1,179 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "ui/dialog"
+
+Yast.import "HTML"
+Yast.import "Label"
+Yast.import "UI"
+
+module Y2Autoinstallation
+  module Dialogs
+    # Generic dialog for AutoYaST questions supporting RichText.
+    #
+    # It can behave in two different ways:
+    #
+    # * Ask the user if she/he wants to continue or abort the installation.
+    # * Display a message and only offer an 'Abort' button.
+    #
+    # In order to integrate nicely with AutoYaST, a timeout can be set.
+    # Bear in mind that the timeout will not be respected when a showing only
+    # the 'Abort' button.
+    #
+    # This dialog could be extended in the future in order to support other
+    # AutoYaST interaction which are not covered in the {Yast::Report} module.
+    class Question < UI::Dialog
+
+      # @return [String] Dialog's content
+      attr_reader :content
+
+      # Constructor
+      #
+      # @param content     [String]  Dialog's content
+      # @param timeout     [Integer] Countdown (in seconds); 0 means no timeout.
+      # @param buttons_set [Symbol]  Buttons set (:abort, :question)
+      def initialize(content, timeout: 10, buttons_set: :question)
+        @content = content
+        @remaining_time = timeout
+        @timed = timeout > 0
+        @buttons_set = buttons_set
+      end
+
+      # Return YaST terms for dialog's content
+      #
+      # @return [Yast::Term] Dialog's content
+      # @see UI::Dialog#dialog_content
+      def dialog_content
+        HBox(
+          VSpacing(20),
+          VBox(
+            HSpacing(70),
+            Left(Heading("Partitioning issues")),
+            VSpacing(1),
+            RichText(content),
+            timed? ? ReplacePoint(Id(:counter_replace), counter) : Empty(),
+            ButtonBox(*buttons)
+          )
+        )
+      end
+
+      # 'Continue' button handler
+      #
+      # When the 'Continue' button is pressed, the dialog will return the {:ok} value.
+      def ok_handler
+        finish_dialog(:ok)
+      end
+
+      # 'Abort' button handler
+      #
+      # When the 'Abort' button is pressed, the dialog will return the {:abort} value.
+      def abort_handler
+        finish_dialog(:abort)
+      end
+
+      # 'Stop' button handler
+      #
+      # When the 'Stop' button is pressed, the countdown will stop.
+      def stop_handler
+        @remaining_time = nil
+        Yast::UI.ChangeWidget(Id(:stop), :Enabled, false)
+      end
+
+      def timeout_handler
+        return finish_dialog(:ok) if @remaining_time.zero?
+        @remaining_time -= 1
+        Yast::UI.ReplaceWidget(Id(:counter_replace), counter)
+      end
+
+    private
+      # @return [Integer] Timeout
+      attr_reader :timeout
+
+      # @return [Symbol] Buttons set (:abort, :question)
+      attr_reader :buttons_set
+
+      # Determine whether it is a timed dialog or not
+      #
+      # @return [Boolean] True if the timeout is running; false otherwise
+      def timed?
+        @timed
+      end
+
+      # Return dialog buttons
+      #
+      # @see question_buttons
+      # @see abort_buttons
+      def buttons
+        send("#{buttons_set}_buttons")
+      end
+
+      # Return buttons to show when the user should be asked about what to do
+      #
+      # @return [Array<Yast::Term>]
+      def question_buttons
+        set = [
+          PushButton(Id(:ok), Opt(:okButton, :key_F9, :default), Yast::Label.ContinueButton),
+          abort_button
+        ]
+
+        if timed?
+          set.unshift(
+            PushButton(Id(:stop), Opt(:customButton), Yast::Label.StopButton),
+          )
+        end
+
+        set
+      end
+
+      # Return buttons to show when abort is the only option
+      #
+      # @return [Array<Yast::Term>]
+      def abort_buttons
+        [abort_button]
+      end
+
+      # Return an 'Abort' button
+      #
+      # @return Yast::Term
+      def abort_button
+        PushButton(Id(:abort), Opt(:cancel_button, :key_F10), Yast::Label.AbortButton)
+      end
+
+      # Timeout counter
+      #
+      # @return [Yast::Term]
+      def counter
+        Label(Id(:counter), @remaining_time.to_s)
+      end
+
+      # Handle user input
+      #
+      # @return [Symbol] User input (:ok, :stop, :abort or :timeout)
+      def user_input
+        if timed? && @remaining_time
+          Yast::UI.TimeoutUserInput(1000)
+        else
+          Yast::UI.UserInput
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/dialogs/question.rb
+++ b/src/lib/autoinstall/dialogs/question.rb
@@ -21,7 +21,6 @@
 
 require "ui/dialog"
 
-Yast.import "HTML"
 Yast.import "Label"
 Yast.import "UI"
 
@@ -130,7 +129,7 @@ module Y2Autoinstallation
       # @return [Array<Yast::Term>]
       def question_buttons
         set = [
-          PushButton(Id(:ok), Opt(:okButton, :key_F9, :default), Yast::Label.ContinueButton),
+          PushButton(Id(:ok), Opt(:okButton, :key_F10, :default), Yast::Label.ContinueButton),
           abort_button
         ]
 
@@ -154,7 +153,7 @@ module Y2Autoinstallation
       #
       # @return Yast::Term
       def abort_button
-        PushButton(Id(:abort), Opt(:cancel_button, :key_F10), Yast::Label.AbortButton)
+        PushButton(Id(:abort), Opt(:cancel_button, :key_F9), Yast::Label.AbortButton)
       end
 
       # Timeout counter

--- a/src/lib/autoinstall/storage_proposal.rb
+++ b/src/lib/autoinstall/storage_proposal.rb
@@ -34,7 +34,7 @@ module Y2Autoinstallation
     # @return [Y2Storage::GuidedProposal,Y2Storage::AutoinstProposal] Y2Storage proposal instance
     attr_reader :proposal
 
-    # @return [Y2Storage::AutoinstIssues::List] Problems list
+    # @return [Y2Storage::AutoinstIssues::List] Storage proposal issues list
     attr_reader :issues_list
 
     # Constructor
@@ -94,7 +94,7 @@ module Y2Autoinstallation
     # * {Y2Storage::GuidedProposal} if {partitioning} is nil or empty;
     # * {Y2Storage::AutoinstProposal} in any other case.
     #
-    # @return [Y2Storage::GuidedPropoal,Y2Storage::AutoinstProposal] Proposal instance
+    # @return [Y2Storage::GuidedProposal,Y2Storage::AutoinstProposal] Proposal instance
     def build_proposal(partitioning)
       if partitioning.nil? || partitioning.empty?
         @proposal = guided_proposal

--- a/src/lib/autoinstall/storage_proposal_issues_presenter.rb
+++ b/src/lib/autoinstall/storage_proposal_issues_presenter.rb
@@ -1,0 +1,96 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+Yast.import "HTML"
+Yast.import "RichText"
+
+module Y2Autoinstallation
+  # This class converts a list of issues into a message to be shown to users
+  #
+  # The message will summarize the list of issues, separating them into non-fatal
+  # and fatal issues.
+  class StorageProposalIssuesPresenter
+    include Yast::I18n
+
+    # @return [Y2Storage::AutoinstIssues::List] List of issues
+    attr_reader :issues_list
+
+    # Constructor
+    #
+    # @param issues_list [Y2Storage::AutoinstIssues::List] List of issues
+    def initialize(issues_list)
+      textdomain "autoinst"
+      @issues_list = issues_list
+    end
+
+    # Return the text to be shown to the user regarding the list of issues
+    #
+    # @return [String] Plain text
+    def to_plain
+      Yast::RichText.Rich2Plain(to_html)
+    end
+
+    # Return the text to be shown to the user regarding the list of issues
+    #
+    # @return [String] HTML formatted text
+    def to_html
+      fatal, non_fatal = issues_list.partition(&:fatal?)
+
+      parts = []
+      parts << error_text(fatal) unless fatal.empty?
+      parts << warning_text(non_fatal) unless non_fatal.empty?
+
+      parts <<
+      if fatal.empty?
+        _("Do you want to continue?")
+      else
+        _("Please, correct these problems and try again.")
+      end
+
+      parts.join
+    end
+
+    # Return warning message with a list of issues
+    #
+    # @param issues [Array<Y2Storage::AutoinstIssues::Issue>] Array containing issues
+    # @return [String] Message
+    def warning_text(issues)
+      Yast::HTML.Para(
+        _("Some minor problems were detected while creating the partitioning plan:")
+      ) + issues_list_text(issues)
+    end
+
+    # Return error message with a list of issues
+    #
+    # @param issues [Array<Y2Storage::AutoinstIssues::Issue>] Array containing issues
+    # @return [String] Message
+    def error_text(issues)
+      Yast::HTML.Para(
+        _("Some important problems were detected while creating the partitioning plan:")
+      ) + issues_list_text(issues)
+    end
+
+    # Return an HTML representation for a list of issues
+    def issues_list_text(issues)
+      Yast::HTML.List(issues.map(&:message))
+    end
+  end
+end

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -441,7 +441,7 @@ module Yast
     # @param level   [Symbol] Message level (:error, :warn)
     # @param content [String] Text to log
     def log_proposal_issues(level, content)
-      settings_name = level == :error ? :error : :warning
+      settings_name = (level == :error) ? :error : :warning
       log.send(level, content)
     end
 

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -398,7 +398,7 @@ module Yast
     #
     # When proposal is not valid:
     #
-    # * If it only contain warnings: asks the user for confirmation.
+    # * If it only contains warnings: asks the user for confirmation.
     # * If it contains some important problem, inform the user.
     #
     # @param [StorageProposal] Storage proposal to check

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,7 +19,8 @@ TESTS = \
     include/ask_test.rb \
     lib/module_config_builder_test.rb \
     lib/pkg_gpg_check_handler_test.rb \
-    lib/storage_proposal_test.rb
+    lib/storage_proposal_test.rb \
+    lib/dialogs/question_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,6 +19,7 @@ TESTS = \
     include/ask_test.rb \
     lib/module_config_builder_test.rb \
     lib/pkg_gpg_check_handler_test.rb \
+    lib/storage_proposal_issues_presenter_test.rb \
     lib/storage_proposal_test.rb \
     lib/dialogs/question_test.rb
 

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -56,7 +56,6 @@ describe Yast::AutoinstStorage do
 
       before do
         issues_list.add(:missing_root)
-        allow(subject.log).to receive(:error).and_call_original
       end
 
       it "shows errors to the user with not timeout" do

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -58,7 +58,7 @@ describe Yast::AutoinstStorage do
         issues_list.add(:missing_root)
       end
 
-      it "shows errors to the user with not timeout" do
+      it "shows errors to the user without timeout" do
         expect(Y2Autoinstallation::Dialogs::Question).to receive(:new)
           .with(/Some important problems/, timeout: 0, buttons_set: :abort)
           .and_return(issues_dialog)

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -8,10 +8,13 @@ describe Yast::AutoinstStorage do
 
   describe "#Import" do
     let(:storage_proposal) do
-      instance_double(Y2Autoinstallation::StorageProposal, failed?: failed)
+      instance_double(
+        Y2Autoinstallation::StorageProposal, valid?: valid?, problems_list: problems_list
+      )
     end
 
-    let(:failed) { false }
+    let(:problems_list) { Y2Storage::AutoinstProblems::List.new }
+    let(:valid?) { true }
 
     before do
       allow(Y2Autoinstallation::StorageProposal).to receive(:new)
@@ -24,19 +27,77 @@ describe Yast::AutoinstStorage do
       subject.Import({})
     end
 
-    context "when the proposal succeeds" do
-      let(:failed) { false }
+    context "when the proposal is valid" do
+      let(:valid?) { true }
 
       it "returns true" do
         expect(subject.Import({})).to eq(true)
       end
+
+      it "saves the proposal" do
+        expect(storage_proposal).to receive(:save)
+        subject.Import({})
+      end
     end
 
-    context "when the proposal fails" do
-      let(:failed) { true }
+    context "when the proposal is not valid" do
+      let(:valid?) { false }
+      let(:continue) { true }
 
-      it "returns false" do
-        expect(subject.Import({})).to eq(false)
+      before do
+        allow(Yast::Report).to receive(:ErrorAnyQuestion)
+          .and_return(continue)
+      end
+
+      context "and there are no fatal errors" do
+        it "asks the user to continue" do
+          expect(Yast::Report).to receive(:ErrorAnyQuestion)
+          subject.Import({})
+        end
+
+        context "and the user decides to continue" do
+          it "returns true" do
+            expect(subject.Import({})).to eq(true)
+          end
+
+          it "saves the proposal" do
+            expect(storage_proposal).to receive(:save)
+            subject.Import({})
+          end
+        end
+
+        context "and the user decides to abort" do
+          let(:continue) { false }
+
+          it "returns false" do
+            expect(subject.Import({})).to eq(false)
+          end
+
+          it "does not save the proposal" do
+            expect(storage_proposal).to_not receive(:save)
+            subject.Import({})
+          end
+        end
+      end
+
+      context "and there are fatal errors" do
+        before do
+          problems_list.add(:missing_root)
+        end
+
+        it "returns false" do
+          expect(subject.Import({})).to eq(false)
+        end
+
+        it "notifies the user" do
+          expect(Yast::Popup).to receive(:LongError)
+            .with(/No root partition/)
+          subject.Import({})
+        end
+
+        it "does not save the proposal" do
+          expect(storage_proposal).to_not receive(:save)
+        end
       end
     end
   end

--- a/test/lib/dialogs/question_test.rb
+++ b/test/lib/dialogs/question_test.rb
@@ -1,0 +1,130 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "autoinstall/dialogs/question"
+require "y2storage/autoinst_issues"
+
+describe Y2Autoinstallation::Dialogs::Question do
+  subject(:dialog) { described_class.new(content, timeout: timeout, buttons_set: buttons_set) }
+
+  let(:timeout) { 0 }
+  let(:content) { "some content" }
+  let(:buttons_set) { :abort }
+
+  before do
+    allow(Yast::UI).to receive(:OpenDialog).and_return(true)
+    allow(Yast::UI).to receive(:CloseDialog).and_return(true)
+  end
+
+  describe "#dialog_content" do
+    it "displays the given content" do
+      expect(dialog.dialog_content.to_s).to include(content)
+    end
+
+    context "when buttons_set is set to :abort" do
+      let(:buttons_set) { :abort }
+
+      it "only shows the 'Abort' button" do
+        expect(dialog).to receive(:PushButton).with(Yast::Term.new(:id, :abort), anything, anything)
+        dialog.dialog_content
+      end
+
+      context "and a timeout was given" do
+        it "ignores the timeout" do
+          expect(dialog).to receive(:PushButton).with(Yast::Term.new(:id, :abort), anything, anything)
+          expect(dialog).to_not receive(:Id).with(:counter)
+          allow(dialog).to receive(:Id).and_call_original
+          dialog.dialog_content
+        end
+      end
+    end
+
+    context "when buttons_set is set to :question" do
+      let(:buttons_set) { :question }
+
+      it "shows the 'Continue' and 'Abort' buttons" do
+        expect(dialog).to receive(:PushButton).with(Yast::Term.new(:id, :abort), anything, anything)
+        expect(dialog).to receive(:PushButton).with(Yast::Term.new(:id, :ok), anything, anything)
+        dialog.dialog_content
+      end
+
+      context "and a timeout was given" do
+        let(:timeout) { 10 }
+
+        it "shows the 'Stop' button" do
+          expect(dialog).to receive(:PushButton).with(Yast::Term.new(:id, :stop), anything, anything)
+          allow(dialog).to receive(:PushButton).and_call_original
+          dialog.dialog_content
+        end
+      end
+    end
+  end
+
+  describe "#run" do
+    let(:timeout) { 10 }
+
+    context "when no timeout was given" do
+      let(:timeout) { 0 }
+
+      it "does not use a timeout when asking for user input" do
+        expect(Yast::UI).to receive(:UserInput).and_return(:ok)
+        dialog.run
+      end
+    end
+
+    context "when user pushes 'Abort'" do
+      let(:input) { :abort }
+
+      it "returns :abort" do
+        allow(Yast::UI).to receive(:TimeoutUserInput).and_return(:abort)
+        expect(dialog.run).to eq(:abort)
+      end
+    end
+
+    context "when user pushes 'Continue'" do
+      it "returns :ok" do
+        allow(Yast::UI).to receive(:TimeoutUserInput).and_return(:ok)
+        expect(dialog.run).to eq(:ok)
+      end
+    end
+
+    context "when user pushes 'Stop'" do
+      it "stops the countdown" do
+        allow(Yast::UI).to receive(:TimeoutUserInput).and_return(:stop)
+        allow(Yast::UI).to receive(:UserInput).and_return(:ok)
+        expect(Yast::UI).to receive(:ChangeWidget)
+          .with(Id(:stop), :Enabled, false)
+        dialog.run
+      end
+    end
+
+    context "when user input times-out" do
+      let(:timeout) { 1 }
+
+      it "returns :ok" do
+        allow(Yast::UI).to receive(:TimeoutUserInput).and_return(:timeout)
+        expect(dialog.run).to eq(:ok)
+      end
+    end
+  end
+end

--- a/test/lib/dialogs/question_test.rb
+++ b/test/lib/dialogs/question_test.rb
@@ -118,7 +118,7 @@ describe Y2Autoinstallation::Dialogs::Question do
       end
     end
 
-    context "when user input times-out" do
+    context "when user input times out" do
       let(:timeout) { 1 }
 
       it "returns :ok" do

--- a/test/lib/storage_proposal_issues_presenter_test.rb
+++ b/test/lib/storage_proposal_issues_presenter_test.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2storage/autoinst_issues"
+require "autoinstall/storage_proposal_issues_presenter"
+
+describe Y2Autoinstallation::StorageProposalIssuesPresenter do
+  subject(:presenter) { described_class.new(list) }
+
+  let(:list) { Y2Storage::AutoinstIssues::List.new }
+
+  describe "#to_html" do
+    context "when some fatal issue was found" do
+      before do
+        list.add(:missing_root)
+      end
+
+      it "includes issues messages" do
+        issue = list.to_a.first
+        expect(presenter.to_html.to_s).to include "<li>#{issue.message}</li>"
+      end
+
+      it "includes an introduction to fatal issues list" do
+        expect(presenter.to_html.to_s).to include "<p>Some important problems"
+      end
+    end
+
+    context "when some non fatal issue was found" do
+      before do
+        list.add(:invalid_value, "/", :size, "auto")
+      end
+
+      it "includes issues messages" do
+        issue = list.to_a.first
+        expect(presenter.to_html.to_s).to include "<li>#{issue.message}</li>"
+      end
+
+      it "includes an introduction to fatal issues list" do
+        expect(presenter.to_html.to_s).to include "<p>Some minor problems"
+      end
+    end
+  end
+
+  describe "#to_plain" do
+    context "when some fatal issue was found" do
+      before do
+        list.add(:missing_root)
+      end
+
+      it "includes issues messages" do
+        issue = list.to_a.first
+        expect(presenter.to_plain.to_s).to include "* #{issue.message}\n"
+      end
+
+      it "includes an introduction to fatal issues list" do
+        expect(presenter.to_plain.to_s).to include "Some important problems"
+      end
+    end
+
+    context "when some non fatal issue was found" do
+      before do
+        list.add(:invalid_value, "/", :size, "auto")
+      end
+
+      it "includes issues messages" do
+        issue = list.to_a.first
+        expect(presenter.to_plain.to_s).to include "* #{issue.message}\n"
+      end
+
+      it "includes an introduction to fatal issues list" do
+        expect(presenter.to_plain.to_s).to include "Some minor problems"
+      end
+    end
+  end
+end

--- a/test/lib/storage_proposal_test.rb
+++ b/test/lib/storage_proposal_test.rb
@@ -9,6 +9,7 @@ describe Y2Autoinstallation::StorageProposal do
   let(:storage_manager) { double(Y2Storage::StorageManager) }
   let(:guided_proposal) { instance_double(Y2Storage::GuidedProposal, propose: nil, proposed?: true) }
   let(:autoinst_proposal) { instance_double(Y2Storage::AutoinstProposal, propose: nil, proposed?: true) }
+  let(:profile) { [{ "device" => "/dev/sda" }] }
 
   before do
     allow(Y2Storage::StorageManager).to receive(:instance)
@@ -44,7 +45,7 @@ describe Y2Autoinstallation::StorageProposal do
 
       it "creates an autoinstall proposal" do
         expect(Y2Storage::AutoinstProposal).to receive(:new)
-          .with(partitioning: profile).and_return(autoinst_proposal)
+          .with(partitioning: profile, issues_list: anything).and_return(autoinst_proposal)
         expect(autoinst_proposal).to receive(:propose)
         expect(storage_proposal.proposal).to be(autoinst_proposal)
       end
@@ -71,7 +72,7 @@ describe Y2Autoinstallation::StorageProposal do
       let(:failed) { true }
 
       it "returns true" do
-        expect(storage_proposal.failed?).to be(true)
+        expect(storage_proposal.failed?).to eq(true)
       end
     end
 
@@ -79,7 +80,75 @@ describe Y2Autoinstallation::StorageProposal do
       let(:failed) { false }
 
       it "returns false" do
-        expect(storage_proposal.failed?).to be(false)
+        expect(storage_proposal.failed?).to eq(false)
+      end
+    end
+  end
+
+  describe "#valid?" do
+    let(:profile) { [{ "device" => "/dev/sda" }] }
+    let(:failed?) { false }
+    let(:partition) { Y2Storage::Planned::Partition.new("/", nil) }
+    let(:planned_devices) { [partition] }
+
+    let(:proposal) do
+      instance_double(
+        Y2Storage::AutoinstProposal, planned_devices: planned_devices, failed?: failed?
+      )
+    end
+
+    before do
+      allow(proposal).to receive(:failed?).and_return(failed?)
+      allow(storage_proposal).to receive(:proposal).and_return(proposal)
+      allow(proposal).to receive(:planned_devices).and_return(planned_devices)
+    end
+
+    context "when the proposal was successful" do
+      it "returns true" do
+        expect(storage_proposal).to be_valid
+      end
+
+      context "when no root partition is found in the proposal" do
+        let(:partition) { Y2Storage::Planned::Partition.new("/home", nil) }
+
+        it "returns false" do
+          expect(storage_proposal).to_not be_valid
+        end
+
+        it "registers the error" do
+          storage_proposal.valid?
+          expect(storage_proposal.issues?).to eq(true)
+        end
+      end
+    end
+
+    context "when the proposal failed" do
+      let(:failed?) { true }
+
+      it "returns false" do
+        expect(storage_proposal).to_not be_valid
+      end
+    end
+  end
+
+  describe "#issues?" do
+    let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+    before do
+      allow(storage_proposal).to receive(:issues_list).and_return(issues_list)
+    end
+
+    context "when no issues were found" do
+      it "returns false" do
+        expect(storage_proposal.issues?).to eq(false)
+      end
+    end
+
+    context "when issues were found" do
+      before { issues_list.add(:missing_root) }
+
+      it "returns true" do
+        expect(storage_proposal.issues?).to eq(true)
       end
     end
   end

--- a/test/lib/storage_proposal_test.rb
+++ b/test/lib/storage_proposal_test.rb
@@ -116,8 +116,8 @@ describe Y2Autoinstallation::StorageProposal do
         end
 
         it "registers the error" do
-          storage_proposal.valid?
-          expect(storage_proposal.issues?).to eq(true)
+          expect { storage_proposal.valid? }.to change { storage_proposal.issues? }
+            .from(false).to(true)
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
 root_location = File.expand_path("../../", __FILE__)
 ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
 
+# make sure we run the tests in English locale
+# (some tests check the output which is marked for translation)
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 require "yast"
 require "yast/rspec"
 require "fileutils"


### PR DESCRIPTION
This PR adds error reporting capabilities to AutoYaST when creating the partitioning plan during installation.

## The old way

In SLE 12, when something goes wrong, you have always something like this:

![autoyast-old-errors](https://user-images.githubusercontent.com/15836/31817965-1760fd1c-b58e-11e7-86ac-6de5fbc79009.png)

## The new way

In SLE 15, AutoYaST:

* will provide better error messages.
* if some non-critical setting is wrong, it will warn the user if she/he wants to continue the installation.

Finally, this feature honors the "reporting" section of an AutoYaST profile, so you can hide the warning messages or apply a timeout to them.

![autoyast-errors-abort](https://user-images.githubusercontent.com/15836/31818086-812fd484-b58e-11e7-878c-aa541773aaae.png)
![autoyast-errors-timeout](https://user-images.githubusercontent.com/15836/31818087-8151489e-b58e-11e7-9f54-9dcead641391.png)
![autoyast-errors-no-timeout](https://user-images.githubusercontent.com/15836/31818088-817429ae-b58e-11e7-9e5e-60352193773a.png)
