### PR TITLE
Fix require of y2packager/product

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Oct 20 11:11:17 UTC 2017 - igonzalezsosa@suse.com
+
+- Add missing require of Y2Package::Product class (bsc#1064396)
+
+-------------------------------------------------------------------
 Mon Oct 16 08:33:35 UTC 2017 - mfilka@suse.com
 
 - fate#323450 

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -7,6 +7,7 @@
 #
 # $Id$
 require "yast"
+require "y2packager/product"
 
 module Yast
   import "ServicesManagerTarget"

--- a/test/AutoinstConfig_tests.rb
+++ b/test/AutoinstConfig_tests.rb
@@ -2,8 +2,6 @@
 
 require_relative "test_helper"
 
-require "y2packager/product"
-
 Yast.import "AutoinstConfig"
 Yast.import "Profile"
 


### PR DESCRIPTION
Unit tests were working because the class was loaded in the test itself.

I am not increasing version number because I plan to merge #358 today too.