### PR TITLE
Improve errors reporting

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 31 14:13:40 UTC 2017 - igonzalezsosa@suse.com
+
+- When reporting issues with the partition plan, add in which
+  section of the profile were they found (related to bsc#1060637).
+- 4.0.5
+
+-------------------------------------------------------------------
 Tue Oct 24 16:24:36 UTC 2017 - igonzalezsosa@suse.com
 
 - Do not mangle partitioning information coming from

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -41,8 +41,8 @@ BuildRequires:  yast2-services-manager
 BuildRequires:  yast2-packager
 BuildRequires:  yast2-update >= 3.3.0
 BuildRequires:  yast2-slp
-# Y2Storage::AutoinstIssues API
-BuildRequires:  yast2-storage-ng >= 4.0.6
+# Y2Storage::AutoinstIssues containing section information
+BuildRequires:  yast2-storage-ng >= 4.0.15
 
 # %%{_unitdir} macro definition is in a separate package since 13.1
 %if 0%{?suse_version} >= 1310
@@ -61,8 +61,8 @@ Requires:       yast2-network >= 3.1.145
 Requires:       yast2-schema
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml
-# Y2Storage::AutoinstIssues API
-Requires:       yast2-storage-ng >= 4.0.6
+# Y2Storage::AutoinstIssues containing section information
+Requires:       yast2-storage-ng >= 4.0.15
 Conflicts:      yast2-installation < 3.1.166
 
 Provides:       yast2-config-autoinst
@@ -114,8 +114,8 @@ Requires:       yast2-update >= 3.3.0
 Requires:       yast2-xml
 # pkgGpgCheck callback
 Requires:       yast2-pkg-bindings >= 3.1.31
-# Y2Storage::AutoinstIssues API
-BuildRequires:  yast2-storage-ng >= 4.0.6
+# Y2Storage::AutoinstIssues containing section information
+BuildRequires:  yast2-storage-ng >= 4.0.15
 Provides:       yast2-trans-autoinst
 Obsoletes:      yast2-trans-autoinst
 

--- a/src/lib/autoinstall/storage_proposal.rb
+++ b/src/lib/autoinstall/storage_proposal.rb
@@ -75,14 +75,7 @@ module Y2Autoinstallation
     #
     # @return [Boolean] true if some problem was found; false otherwise
     def valid?
-      return @valid unless @valid.nil?
-      return false if failed?
-
-      if !proposal.planned_devices.any? { |d| d.respond_to?(:mount_point) && d.mount_point == "/" }
-        issues_list.add(:missing_root)
-      end
-
-      @valid = !issues?
+      !(failed? || issues?)
     end
 
   private

--- a/src/lib/autoinstall/storage_proposal_issues_presenter.rb
+++ b/src/lib/autoinstall/storage_proposal_issues_presenter.rb
@@ -91,7 +91,7 @@ module Y2Autoinstallation
 
     # Return an HTML representation for a list of issues
     #
-    # The issues are grouped by the section of the profile were they were detected.
+    # The issues are grouped by the section of the profile where they were detected.
     # General issues (with no section) are listed first.
     #
     # @return [String] Issues list content
@@ -106,7 +106,7 @@ module Y2Autoinstallation
         issues_map.delete(:nosection)
       end
 
-      issues_map.each_with_object(all_issues) do |(section, items), text|
+      issues_map.each do |section, items|
         messages = Yast::HTML.List(items.map(&:message))
         all_issues << "#{location(section)}:#{messages}"
       end

--- a/src/lib/autoinstall/storage_proposal_issues_presenter.rb
+++ b/src/lib/autoinstall/storage_proposal_issues_presenter.rb
@@ -57,6 +57,7 @@ module Y2Autoinstallation
       parts = []
       parts << error_text(fatal) unless fatal.empty?
       parts << warning_text(non_fatal) unless non_fatal.empty?
+      parts << Yast::HTML.Newline
 
       parts <<
       if fatal.empty?
@@ -74,8 +75,8 @@ module Y2Autoinstallation
     # @return [String] Message
     def warning_text(issues)
       Yast::HTML.Para(
-        _("Some minor problems were detected while creating the partitioning plan:")
-      ) + issues_list_text(issues)
+        _("Minor issues were detected while creating the partitioning plan:")
+      ) + issues_list_content(issues)
     end
 
     # Return error message with a list of issues
@@ -84,13 +85,70 @@ module Y2Autoinstallation
     # @return [String] Message
     def error_text(issues)
       Yast::HTML.Para(
-        _("Some important problems were detected while creating the partitioning plan:")
-      ) + issues_list_text(issues)
+        _("Important issues were detected while creating the partitioning plan:")
+      ) + issues_list_content(issues)
     end
 
     # Return an HTML representation for a list of issues
-    def issues_list_text(issues)
-      Yast::HTML.List(issues.map(&:message))
+    #
+    # The issues are grouped by the section of the profile were they were detected.
+    # General issues (with no section) are listed first.
+    #
+    # @return [String] Issues list content
+    #
+    # @see issues_by_section
+    def issues_list_content(issues)
+      all_issues = []
+      issues_map = issues_by_section(issues)
+
+      if issues_map[:nosection]
+        all_issues += issues_map[:nosection].map(&:message)
+        issues_map.delete(:nosection)
+      end
+
+      issues_map.each_with_object(all_issues) do |(section, items), text|
+        messages = Yast::HTML.List(items.map(&:message))
+        all_issues << "#{location(section)}:#{messages}"
+      end
+
+      Yast::HTML.List(all_issues)
+    end
+
+    # Return issues grouped by section where they were found
+    #
+    # @return [Hash<(#parent,#section_name),Y2Storage::AutoinstIssues::Issue>]
+    #         Issues grouped by AutoYaST profile section
+    def issues_by_section(issues)
+      issues.each_with_object({}) do |issue, all|
+        section = issue.section || :nosection
+        all[section] ||= []
+        all[section] << issue
+      end
+    end
+
+    # Return a human string identifying in which section was detected
+    #
+    # For instance: "drive[0] > partitions[2] > raid_options"
+    #
+    # @param section [#parent,#section_name] Section where the problem was detected
+    # @return [String]
+    #
+    # @see Y2Storage::AutoinstProfile
+    def location(section)
+      return "" if section.parent.nil?
+
+      value = section.parent.send(section.section_name)
+      text =
+        if value.is_a?(Array)
+          index = value.index(section)
+          "#{section.section_name}[#{index}]"
+        else
+          section.section_name
+        end
+
+      prefix = location(section.parent)
+      prefix << " > " unless prefix.empty?
+      prefix + text
     end
   end
 end

--- a/src/modules/AutoinstPartPlan.rb
+++ b/src/modules/AutoinstPartPlan.rb
@@ -17,7 +17,6 @@ module Yast
       Yast.import "UI"
       textdomain "autoinst"
 
-      Yast.include self, "autoinstall/autopart.rb"
       Yast.include self, "autoinstall/types.rb"
       Yast.include self, "autoinstall/common.rb"
       Yast.include self, "autoinstall/tree.rb"

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -58,7 +58,6 @@ module Yast
       # general/storage settings
       self.general_settings = {}
 
-      Yast.include self, "autoinstall/autopart.rb"
       Yast.include self, "autoinstall/autoinst_dialogs.rb"
     end
 

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env rspec
 
 require_relative "test_helper"
+require "y2storage"
+
 Yast.import "AutoinstStorage"
 
 describe Yast::AutoinstStorage do
@@ -14,6 +16,7 @@ describe Yast::AutoinstStorage do
     end
     let(:issues_dialog) { instance_double(Y2Autoinstallation::Dialogs::Question, run: :abort) }
     let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+    let(:profile_section) { Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes({}) }
     let(:valid?) { true }
     let(:errors_settings) { { "show" => false, "timeout" => 10 } }
     let(:warnings_settings) { { "show" => true, "timeout" => 5 } }
@@ -60,7 +63,7 @@ describe Yast::AutoinstStorage do
 
       it "shows errors to the user without timeout" do
         expect(Y2Autoinstallation::Dialogs::Question).to receive(:new)
-          .with(/Some important problems/, timeout: 0, buttons_set: :abort)
+          .with(/Important issues/, timeout: 0, buttons_set: :abort)
           .and_return(issues_dialog)
         expect(issues_dialog).to receive(:run)
         subject.Import({})
@@ -76,7 +79,7 @@ describe Yast::AutoinstStorage do
 
         it "logs the error" do
           expect(subject.log).to receive(:error)
-            .with(/Some important problems/)
+            .with(/Important issues/)
           subject.Import({})
         end
       end
@@ -86,7 +89,7 @@ describe Yast::AutoinstStorage do
 
         it "does not log the error" do
           expect(subject.log).to_not receive(:error)
-            .with(/Some important problems/)
+            .with(/Important issues/)
           subject.Import({})
         end
       end
@@ -97,14 +100,14 @@ describe Yast::AutoinstStorage do
       let(:continue) { true }
 
       before do
-        issues_list.add(:invalid_value, "/", :size, "auto")
+        issues_list.add(:invalid_value, profile_section, :size, "auto")
         allow(subject.log).to receive(:warn).and_call_original
       end
 
       context "and warnings reporting is enabled" do
         it "asks the user for confirmation" do
           expect(Y2Autoinstallation::Dialogs::Question).to receive(:new)
-            .with(/Some minor problems/, timeout: 5, buttons_set: :question)
+            .with(/Minor issues/, timeout: 5, buttons_set: :question)
             .and_return(issues_dialog)
           expect(issues_dialog).to receive(:run)
           subject.Import({})
@@ -144,7 +147,7 @@ describe Yast::AutoinstStorage do
 
         it "logs the warning" do
           expect(subject.log).to receive(:warn)
-            .with(/Some minor problems/)
+            .with(/Minor issues/)
           subject.Import({})
         end
       end

--- a/test/lib/storage_proposal_test.rb
+++ b/test/lib/storage_proposal_test.rb
@@ -90,7 +90,6 @@ describe Y2Autoinstallation::StorageProposal do
     let(:failed?) { false }
     let(:partition) { Y2Storage::Planned::Partition.new("/", nil) }
     let(:planned_devices) { [partition] }
-    let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
 
     let(:proposal) do
       instance_double(
@@ -111,11 +110,11 @@ describe Y2Autoinstallation::StorageProposal do
 
       context "but an issue was detected" do
         before do
-          issues_list.add(:missing_root)
+          storage_proposal.issues_list.add(:missing_root)
         end
 
         it "returns false" do
-          expect(storage_proposal).to be_valid
+          expect(storage_proposal).to_not be_valid
         end
       end
     end

--- a/test/lib/storage_proposal_test.rb
+++ b/test/lib/storage_proposal_test.rb
@@ -90,6 +90,7 @@ describe Y2Autoinstallation::StorageProposal do
     let(:failed?) { false }
     let(:partition) { Y2Storage::Planned::Partition.new("/", nil) }
     let(:planned_devices) { [partition] }
+    let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
 
     let(:proposal) do
       instance_double(
@@ -103,21 +104,18 @@ describe Y2Autoinstallation::StorageProposal do
       allow(proposal).to receive(:planned_devices).and_return(planned_devices)
     end
 
-    context "when the proposal was successful" do
+    context "when the proposal did not fail" do
       it "returns true" do
         expect(storage_proposal).to be_valid
       end
 
-      context "when no root partition is found in the proposal" do
-        let(:partition) { Y2Storage::Planned::Partition.new("/home", nil) }
-
-        it "returns false" do
-          expect(storage_proposal).to_not be_valid
+      context "but an issue was detected" do
+        before do
+          issues_list.add(:missing_root)
         end
 
-        it "registers the error" do
-          expect { storage_proposal.valid? }.to change { storage_proposal.issues? }
-            .from(false).to(true)
+        it "returns false" do
+          expect(storage_proposal).to be_valid
         end
       end
     end


### PR DESCRIPTION
This PR adds some improvements:

* Better error messages adding some information about which section failed.
* Do not add an error when the root partition is not proposed (it is already handled by yast2-storage-ng).

![autoyast-reuse](https://user-images.githubusercontent.com/15836/32227915-8907ab00-be44-11e7-8add-6e18eacc038e.png)
