### PR TITLE
Fix building in s390 architectures

### DIFF
--- a/test/AutoinstPartPlan_test.rb
+++ b/test/AutoinstPartPlan_test.rb
@@ -17,6 +17,9 @@ def devicegraph_from(file_name)
 end
 
 describe "Yast::AutoinstPartPlan" do
+  before do
+    allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
+  end
 
   subject do
     # Postpone AutoinstPartPlan.main until it is needed.


### PR DESCRIPTION
It should fix https://build.suse.de/package/live_build_log/Devel:YaST:Head/autoyast2/SUSE_SLE-15_GA/s390x

It looks like, on s390 architectures, we rely on udev links. See https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/autoinst_profile/drive_section.rb#L155