### PR TITLE
AutoYaST device=ask support

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 27 15:58:38 UTC 2017 - igonzalezsosa@suse.com
+
+- Bring back handling of device=ask (bsc#1069965)
+- Use a 1-based index when showing partitioning issues
+- 4.0.8
+
+-------------------------------------------------------------------
 Tue Nov 21 12:35:40 CET 2017 - schubi@suse.de
 
 - Cleanup spec file.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        4.0.7
+Version:        4.0.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,11 +71,13 @@ ylibdir = @ylibdir@/autoinstall
 ylib_DATA = \
   lib/autoinstall/module_config_builder.rb \
   lib/autoinstall/pkg_gpg_check_handler.rb \
+  lib/autoinstall/partitioning_preprocessor.rb \
   lib/autoinstall/storage_proposal.rb \
   lib/autoinstall/storage_proposal_issues_presenter.rb
 
 ydialogsdir = @ylibdir@/autoinstall/dialogs
 ydialogs_DATA = \
+  lib/autoinstall/dialogs/disk_selector.rb \
   lib/autoinstall/dialogs/question.rb
 
 yclientsdir = @ylibdir@/autoinstall/clients

--- a/src/lib/autoinstall/dialogs/disk_selector.rb
+++ b/src/lib/autoinstall/dialogs/disk_selector.rb
@@ -37,6 +37,8 @@ module Y2Autoinstallation
       attr_reader :devicegraph
       # @return [Array<String>] Device names that should be omitted
       attr_reader :blacklist
+      # @return [Integer] Drive section index
+      attr_reader :drive_index
 
       # Constructor
       #
@@ -44,8 +46,9 @@ module Y2Autoinstallation
       #   By default, the probed devicegraph is used.
       # @param blacklist   [Array<String>] Device names that should be omitted.
       #   These disks will be filtered out.
-      def initialize(devicegraph = nil, blacklist: [])
+      def initialize(devicegraph = nil, drive_index: 1, blacklist: [])
         @devicegraph = devicegraph || Y2Storage::StorageManager.instance.probed
+        @drive_index = drive_index
         @blacklist = blacklist
       end
 
@@ -63,11 +66,15 @@ module Y2Autoinstallation
       # @return [Yast::Term] Dialog content
       def disks_content
         VBox(
-          Label(_("Choose a hard disk")),
+          Heading(_("Disk Selection")),
+          VSpacing(1),
+          Label(help_text),
+          VSpacing(1),
           RadioButtonGroup(
             Id(:options),
             VBox(*options)
           ),
+          VSpacing(1),
           ButtonBox(*buttons)
         )
       end
@@ -139,6 +146,14 @@ module Y2Autoinstallation
       # @return [String] Label
       def label(disk)
         "#{disk.basename}, #{disk.hwinfo.model}"
+      end
+
+      # Help text
+      def help_text
+        # TRANSLATORS: %s will be replaced by a number
+        _("All hard disks automatically detected on your system are shown here.\n" \
+          "Please, select a hard disk to be used in the #%s drive section of the\n" \
+          "given AutoYaST profile.") % drive_index
       end
     end
   end

--- a/src/lib/autoinstall/dialogs/disk_selector.rb
+++ b/src/lib/autoinstall/dialogs/disk_selector.rb
@@ -31,7 +31,7 @@ module Y2Autoinstallation
     #
     # This dialog will be used by the partitioning section preprocessor (see
     # {Y2Autoinstallation::PartitioningPreprocessor}) in order to determine
-    # which device to use for a given <drive> section.
+    # which device to use for a given +<drive/>+ section.
     class DiskSelector < UI::Dialog
       # @return [Y2Storage::Devicegraph] Devicegraph used to find disks
       attr_reader :devicegraph
@@ -44,6 +44,7 @@ module Y2Autoinstallation
       #
       # @param devicegraph [Y2Storage::Devicegraph] Devicegraph used to find disks.
       #   By default, the probed devicegraph is used.
+      # @param drive_index [Integer] Drive section index.
       # @param blacklist   [Array<String>] Device names that should be omitted.
       #   These disks will be filtered out.
       def initialize(devicegraph = nil, drive_index: 1, blacklist: [])
@@ -103,6 +104,8 @@ module Y2Autoinstallation
 
       # Returns a list of options containing available disks
       #
+      # The first disk is preselected.
+      #
       # @return [Array<Yast::Term>] List of options
       def options
         return @options if @options
@@ -158,4 +161,3 @@ module Y2Autoinstallation
     end
   end
 end
-

--- a/src/lib/autoinstall/dialogs/disk_selector.rb
+++ b/src/lib/autoinstall/dialogs/disk_selector.rb
@@ -1,0 +1,152 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "ui/dialog"
+require "y2storage"
+
+Yast.import "Label"
+Yast.import "UI"
+
+module Y2Autoinstallation
+  module Dialogs
+    # Ask the user for which device to use
+    #
+    # This dialog will be used by the partitioning section preprocessor (see
+    # {Y2Autoinstallation::PartitioningPreprocessor}) in order to determine
+    # which device to use for a given <drive> section.
+    class DiskSelector < UI::Dialog
+      # @return [Y2Storage::Devicegraph] Devicegraph used to find disks
+      attr_reader :devicegraph
+      # @return [Array<String>] Device names that should be omitted
+      attr_reader :blacklist
+
+      # Constructor
+      #
+      # @param devicegraph [Y2Storage::Devicegraph] Devicegraph used to find disks.
+      #   By default, the probed devicegraph is used.
+      # @param blacklist   [Array<String>] Device names that should be omitted.
+      #   These disks will be filtered out.
+      def initialize(devicegraph = nil, blacklist: [])
+        @devicegraph = devicegraph || Y2Storage::StorageManager.instance.probed
+        @blacklist = blacklist
+      end
+
+      # Dialog content
+      #
+      # @return [Yast::Term] Dialog content
+      # @see #disks_content
+      # @see #empty_content
+      def dialog_content
+        options.empty? ? empty_content : disks_content
+      end
+
+      # Dialog content when some disks are available
+      #
+      # @return [Yast::Term] Dialog content
+      def disks_content
+        VBox(
+          Label(_("Choose a hard disk")),
+          RadioButtonGroup(
+            Id(:options),
+            VBox(*options)
+          ),
+          ButtonBox(*buttons)
+        )
+      end
+
+      # Dialog content when no disks are found
+      #
+      # @return [Yast::Term]
+      def empty_content
+        VBox(
+          Label(_("No disks found.")),
+          ButtonBox(abort_button)
+        )
+      end
+
+      # Handler for the `Continue` button
+      def ok_handler
+        finish_dialog(Yast::UI::QueryWidget(Id(:options), :Value))
+      end
+
+      # Handler for the `Abort` button
+      def abort_handler
+        finish_dialog(:abort)
+      end
+
+      # Handler for the `Skip` button
+      def skip_handler
+        finish_dialog(:skip)
+      end
+
+    protected
+
+      # Returns a list of options containing available disks
+      #
+      # @return [Array<Yast::Term>] List of options
+      def options
+        return @options if @options
+        first_disk = disks.first
+        @options = disks.each_with_index.map do |disk, idx|
+          Left(RadioButton(Id(disk.name), "#{idx + 1}: #{label(disk)}", first_disk == disk))
+        end
+      end
+
+      # Returns a list of available disks in the system
+      #
+      # Blacklisted disks are filtered out.
+      #
+      # @return [Array<Y2Storage::Device>] List of disks
+      def disks
+        @disks ||= devicegraph.disk_devices.reject do |disk|
+          blacklist.include?(disk.name)
+        end
+      end
+
+      # Dialog buttons
+      #
+      # @return [Array<Yast::Term>]
+      def buttons
+        [
+          PushButton(Id(:ok), Opt(:okButton, :key_F10, :default), Yast::Label.ContinueButton),
+          PushButton(Id(:skip), Yast::Label.SkipButton),
+          abort_button
+        ]
+      end
+
+      # Abort button
+      #
+      # @return [Yast::Term]
+      def abort_button
+        PushButton(Id(:abort), Opt(:cancel_button, :key_F9), Yast::Label.AbortButton)
+      end
+
+      # Disk label to show in the list of options
+      #
+      # @param [Y2Storage::Device] Disk
+      # @return [String] Label
+      def label(disk)
+        "#{disk.basename}, #{disk.hwinfo.model}"
+      end
+    end
+  end
+end
+

--- a/src/lib/autoinstall/dialogs/disk_selector.rb
+++ b/src/lib/autoinstall/dialogs/disk_selector.rb
@@ -92,11 +92,6 @@ module Y2Autoinstallation
         finish_dialog(:abort)
       end
 
-      # Handler for the `Skip` button
-      def skip_handler
-        finish_dialog(:skip)
-      end
-
     protected
 
       # Returns a list of options containing available disks
@@ -127,7 +122,6 @@ module Y2Autoinstallation
       def buttons
         [
           PushButton(Id(:ok), Opt(:okButton, :key_F10, :default), Yast::Label.ContinueButton),
-          PushButton(Id(:skip), Yast::Label.SkipButton),
           abort_button
         ]
       end

--- a/src/lib/autoinstall/partitioning_preprocessor.rb
+++ b/src/lib/autoinstall/partitioning_preprocessor.rb
@@ -1,0 +1,72 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage"
+require "autoinstall/dialogs/disk_selector"
+
+module Y2Autoinstallation
+  # This class is responsible for preprocessing the +<partitioning/>+ section
+  # of an AutoYaST profile.
+  #
+  # At this time, the only preprocessing is replacing +device=ask+ with a real
+  # device name.
+  class PartitioningPreprocessor
+    include Yast
+
+    # Preprocesses the partitioning section
+    #
+    # It returns a new object so the original section is not modified.
+    #
+    # @param original_drives [Array<Hash>] List of drives according to an AutoYaST
+    #   +partitioning+ section.
+    def run(drives)
+      return if drives.nil?
+      replace_ask(deep_copy(drives))
+    end
+
+  protected
+
+    # Replaces +ask+ for user selected values
+    #
+    # When +device+ is set to +ask+, ask the user about which device to use.
+    #
+    # @param [Array<Hash>]  Drives definition from an AutoYaST profile
+    # @return [Array<Hash>] Drives definition replacing +ask+ for user selected values
+    def replace_ask(drives)
+      blacklist = []
+      drives.each do |drive|
+        next unless drive["device"] == "ask"
+        selection = select_disk(blacklist)
+        return nil if selection == :abort
+        drive["device"] = selection
+        blacklist << drive["device"]
+      end
+    end
+
+    # Asks the user about which device should be used
+    #
+    # @param blacklist [Array<String>] List of device names that were already used
+    # @return [String,Symbol] Selected device name
+    def select_disk(blacklist)
+      Y2Autoinstallation::Dialogs::DiskSelector.new(blacklist: blacklist).run
+    end
+  end
+end

--- a/src/lib/autoinstall/partitioning_preprocessor.rb
+++ b/src/lib/autoinstall/partitioning_preprocessor.rb
@@ -52,9 +52,9 @@ module Y2Autoinstallation
     # @return [Array<Hash>] Drives definition replacing +ask+ for user selected values
     def replace_ask(drives)
       blacklist = []
-      drives.each do |drive|
+      drives.each_with_index do |drive, idx|
         next unless drive["device"] == "ask"
-        selection = select_disk(blacklist)
+        selection = select_disk(idx, blacklist)
         return nil if selection == :abort
         drive["device"] = selection
         blacklist << drive["device"]
@@ -65,8 +65,10 @@ module Y2Autoinstallation
     #
     # @param blacklist [Array<String>] List of device names that were already used
     # @return [String,Symbol] Selected device name
-    def select_disk(blacklist)
-      Y2Autoinstallation::Dialogs::DiskSelector.new(blacklist: blacklist).run
+    def select_disk(drive_index, blacklist)
+      Y2Autoinstallation::Dialogs::DiskSelector.new(
+        drive_index: drive_index, blacklist: blacklist
+      ).run
     end
   end
 end

--- a/src/lib/autoinstall/storage_proposal_issues_presenter.rb
+++ b/src/lib/autoinstall/storage_proposal_issues_presenter.rb
@@ -141,7 +141,7 @@ module Y2Autoinstallation
       text =
         if value.is_a?(Array)
           index = value.index(section)
-          "#{section.section_name}[#{index}]"
+          "#{section.section_name}[#{index+1}]"
         else
           section.section_name
         end

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -10,6 +10,7 @@ require "yast"
 require "autoinstall/storage_proposal"
 require "autoinstall/dialogs/question"
 require "autoinstall/storage_proposal_issues_presenter"
+require "autoinstall/partitioning_preprocessor"
 
 module Yast
   class AutoinstStorageClass < Module
@@ -48,20 +49,14 @@ module Yast
     # When called by inst_auto<module name> (preparing autoinstallation data)
     # the list may be empty.
     #
-    # @param  settings [Hash] Profile settings (list of drives for custom partitioning)
-    # @return	[Boolean] success
+    # @param  settings [Array<Hash>] Profile settings (list of drives for custom partitioning)
+    # @return [Boolean] success
     def Import(settings)
       log.info "entering Import with #{settings.inspect}"
-      proposal = Y2Autoinstallation::StorageProposal.new(settings)
-      if valid_proposal?(proposal)
-        log.info "Saving successful proposal: #{proposal.inspect}"
-        proposal.save
-        true
-      else # not needed
-        log.warn "Failed proposal: #{proposal.inspect}"
-        false
-      end
+      partitioning = preprocessed_settings(settings)
+      return false unless partitioning
 
+      build_proposal(partitioning)
     end
 
     # Import settings from the general/storage section
@@ -266,6 +261,22 @@ module Yast
 
   private
 
+    # Build the storage proposal if possible
+    #
+    # @param  partitioning [Array<Hash>] Profile settings (list of drives for custom partitioning)
+    # @return [Boolean] success
+    def build_proposal(partitioning)
+      proposal = Y2Autoinstallation::StorageProposal.new(partitioning)
+      if valid_proposal?(proposal)
+        log.info "Saving successful proposal: #{proposal.inspect}"
+        proposal.save
+        true
+      else # not needed
+        log.warn "Failed proposal: #{proposal.inspect}"
+        false
+      end
+    end
+
     # Determine whether the proposal is valid and inform the user if not valid
     #
     # When proposal is not valid:
@@ -313,10 +324,16 @@ module Yast
     # @param level   [Symbol] Message level (:error, :warn)
     # @param content [String] Text to log
     def log_proposal_issues(level, content)
-      settings_name = (level == :error) ? :error : :warning
       log.send(level, content)
     end
 
+    # Preprocess partitioning settings
+    #
+    # @param settings [Array<Hash>, nil] Profile settings (list of drives for custom partitioning)
+    def preprocessed_settings(settings)
+      preprocessor = Y2Autoinstallation::PartitioningPreprocessor.new
+      preprocessor.run(settings)
+    end
 
     attr_accessor :general_settings
   end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -17,9 +17,11 @@ TESTS = \
     include/ask_test.rb \
     lib/module_config_builder_test.rb \
     lib/pkg_gpg_check_handler_test.rb \
+    lib/partitioning_preprocessor_test.rb \
     lib/storage_proposal_issues_presenter_test.rb \
     lib/storage_proposal_test.rb \
     lib/clients/ayast_probe_test.rb \
+    lib/dialogs/disk_selector_test.rb \
     lib/dialogs/question_test.rb
 
 TEST_EXTENSIONS = .rb

--- a/test/lib/dialogs/disk_selector_test.rb
+++ b/test/lib/dialogs/disk_selector_test.rb
@@ -49,9 +49,8 @@ describe Y2Autoinstallation::Dialogs::DiskSelector do
       dialog.dialog_content
     end
 
-    it "displays ok, skip and abort buttons" do
+    it "displays ok and abort buttons" do
       expect(dialog).to receive(:PushButton).with(Id(:ok), anything, anything)
-      expect(dialog).to receive(:PushButton).with(Id(:skip), anything)
       expect(dialog).to receive(:PushButton).with(Id(:abort), anything, anything)
       dialog.dialog_content
     end
@@ -76,7 +75,6 @@ describe Y2Autoinstallation::Dialogs::DiskSelector do
 
       it "only shows the abort button" do
         expect(dialog).to_not receive(:PushButton).with(Id(:ok), anything, anything)
-        expect(dialog).to_not receive(:PushButton).with(Id(:skip), anything)
         expect(dialog).to receive(:PushButton).with(Id(:abort), anything, anything)
         dialog.dialog_content
       end
@@ -118,14 +116,6 @@ describe Y2Autoinstallation::Dialogs::DiskSelector do
 
       it "returns :abort" do
         expect(dialog.run).to eq(:abort)
-      end
-    end
-
-    context "when the user presses 'Skip'" do
-      let(:button) { :skip }
-
-      it "returns :skip" do
-        expect(dialog.run).to eq(:skip)
       end
     end
   end

--- a/test/lib/dialogs/disk_selector_test.rb
+++ b/test/lib/dialogs/disk_selector_test.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "autoinstall/dialogs/disk_selector"
+require "ostruct"
+
+describe Y2Autoinstallation::Dialogs::DiskSelector do
+  subject(:dialog) { described_class.new(devicegraph) }
+  extend Yast::I18n
+
+  let(:devicegraph) do
+    instance_double(Y2Storage::Devicegraph, disk_devices: disks)
+  end
+
+  let(:sda) { double("sda", name: "/dev/sda", basename: "sda", hwinfo: hwinfo) }
+  let(:sdb) { double("sdb", name: "/dev/sdb", basename: "sdb", hwinfo: hwinfo) }
+  let(:hwinfo) { OpenStruct.new(model: "Model") }
+  let(:disks) { [sda, sdb] }
+
+  before do
+    allow(Yast::UI).to receive(:OpenDialog).and_return(true)
+    allow(Yast::UI).to receive(:CloseDialog).and_return(true)
+  end
+
+  describe "#dialog_content" do
+    it "displays all options" do
+      expect(dialog).to receive(:RadioButton).with(Id("/dev/sda"), "1: sda, Model", true)
+      expect(dialog).to receive(:RadioButton).with(Id("/dev/sdb"), "2: sdb, Model", false)
+      dialog.dialog_content
+    end
+
+    it "displays ok, skip and abort buttons" do
+      expect(dialog).to receive(:PushButton).with(Id(:ok), anything, anything)
+      expect(dialog).to receive(:PushButton).with(Id(:skip), anything)
+      expect(dialog).to receive(:PushButton).with(Id(:abort), anything, anything)
+      dialog.dialog_content
+    end
+
+    context "when a disk must be omitted" do
+      subject(:dialog) { described_class.new(devicegraph, blacklist: ["/dev/sda"]) }
+
+      it "does not list the blacklisted disk" do
+        expect(dialog).to_not receive(:RadioButton).with(Id("/dev/sda"), anything)
+        expect(dialog).to receive(:RadioButton).with(Id("/dev/sdb"), "1: sdb, Model", true)
+        dialog.dialog_content
+      end
+    end
+
+    context "when no disk are found" do
+      let(:disks) { [] }
+
+      it "shows an error message" do
+        expect(dialog).to receive(:Label).with(_("No disks found."))
+        dialog.dialog_content
+      end
+
+      it "only shows the abort button" do
+        expect(dialog).to_not receive(:PushButton).with(Id(:ok), anything, anything)
+        expect(dialog).to_not receive(:PushButton).with(Id(:skip), anything)
+        expect(dialog).to receive(:PushButton).with(Id(:abort), anything, anything)
+        dialog.dialog_content
+      end
+    end
+
+    context "when no eligible disks are found" do
+      subject(:dialog) { described_class.new(devicegraph, blacklist: ["/dev/sda", "/dev/sdb"]) }
+
+      it "shows an error message" do
+        expect(dialog).to receive(:Label).with(_("No disks found."))
+        dialog.dialog_content
+      end
+
+      it "only shows the abort button" do
+        expect(dialog).to_not receive(:PushButton).with(Id(:ok), anything, anything)
+        expect(dialog).to receive(:PushButton).with(Id(:abort), anything, anything)
+        dialog.dialog_content
+      end
+    end
+  end
+
+  describe "#run" do
+    before do
+      allow(Yast::UI).to receive(:UserInput).and_return(button)
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:options), :Value)
+        .and_return("/dev/sda")
+    end
+
+    context "when the user presses 'Continue'" do
+      let(:button) { :ok }
+
+      it "returns the selected disk" do
+        expect(dialog.run).to eq("/dev/sda")
+      end
+    end
+
+    context "when the user presses 'Abort'" do
+      let(:button) { :abort }
+
+      it "returns :abort" do
+        expect(dialog.run).to eq(:abort)
+      end
+    end
+
+    context "when the user presses 'Skip'" do
+      let(:button) { :skip }
+
+      it "returns :skip" do
+        expect(dialog.run).to eq(:skip)
+      end
+    end
+  end
+end

--- a/test/lib/dialogs/disk_selector_test.rb
+++ b/test/lib/dialogs/disk_selector_test.rb
@@ -94,6 +94,20 @@ describe Y2Autoinstallation::Dialogs::DiskSelector do
         dialog.dialog_content
       end
     end
+
+    it "contains help text" do
+      expect(dialog).to receive(:Label).with(/All hard disks.*the #1 drive/m)
+      dialog.dialog_content
+    end
+
+    context "when a drive index is specified" do
+      subject(:dialog) { described_class.new(devicegraph, drive_index: 2) }
+
+      it "is included in the help text" do
+        expect(dialog).to receive(:Label).with(/All hard disks.*the #2 drive/m)
+        dialog.dialog_content
+      end
+    end
   end
 
   describe "#run" do

--- a/test/lib/partitioning_preprocessor_test.rb
+++ b/test/lib/partitioning_preprocessor_test.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "autoinstall/partitioning_preprocessor"
+
+describe Y2Autoinstallation::PartitioningPreprocessor do
+  subject(:preprocessor) { described_class.new }
+
+  let(:profile) do
+    [sda, undefined]
+  end
+
+  let(:sda) { { "device" => "/dev/sda" } }
+  let(:selected) { "/dev/sdb" }
+  let(:undefined) { { "device" => "ask" } }
+
+  let(:disk_selector) do
+    instance_double(Y2Autoinstallation::Dialogs::DiskSelector, run: selected)
+  end
+
+  before do
+    allow(Y2Autoinstallation::Dialogs::DiskSelector).to receive(:new).and_return(disk_selector)
+  end
+
+  describe "#run" do
+    it "sets disk devices when device=ask" do
+      expect(preprocessor.run(profile)).to eq([sda, { "device" => selected }])
+    end
+
+    it "asks the user about which device to use" do
+      expect(disk_selector).to receive(:run).and_return(selected)
+      preprocessor.run(profile)
+    end
+
+    context "when the user aborts" do
+      let(:selected) { :abort }
+
+      it "returns nil" do
+        expect(preprocessor.run(profile)).to be_nil
+      end
+    end
+  end
+end

--- a/test/lib/storage_proposal_issues_presenter_test.rb
+++ b/test/lib/storage_proposal_issues_presenter_test.rb
@@ -85,7 +85,7 @@ describe Y2Autoinstallation::StorageProposalIssuesPresenter do
       end
 
       it "includes the location information" do
-        expect(presenter.to_html).to include "<li>drives[0] > partitions[1] > raid_options:<ul>"
+        expect(presenter.to_html).to include "<li>drives[1] > partitions[2] > raid_options:<ul>"
       end
     end
 
@@ -132,7 +132,7 @@ describe Y2Autoinstallation::StorageProposalIssuesPresenter do
       end
 
       it "includes the location information" do
-        expect(presenter.to_plain).to include "* drives[0] > partitions[1] > raid_options:"
+        expect(presenter.to_plain).to include "* drives[1] > partitions[2] > raid_options:"
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,11 @@ require "yast/rspec"
 require "fileutils"
 require "pathname"
 
+RSpec.configure do |config|
+  config.extend Yast::I18n # available in context/describe
+  config.include Yast::I18n # available in it/let/before/around/after
+end
+
 if ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.start do


### PR DESCRIPTION
There is a nice (and undocumented feature) which allows the user to select which disk to use at installation time (setting `device` AutoYaST element to `ask`). The feature was removed as part of the old code clean-up and now we have brought it back using the new storage layer.

![ask-device-new](https://user-images.githubusercontent.com/15836/33277784-7c66b226-d391-11e7-8bd4-c03809a0d0e0.png)
