### PR TITLE
Fix btrfs_set_default_subvolume_name

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 20 15:57:48 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: fix btrfs_set_default_subvolume_name handling
+  (bsc#1073548)
+- 4.0.16
+
+-------------------------------------------------------------------
 Mon Dec 14 13:43:12 CET 2017 - schubi@suse.de
 
 - Warn the user if the infrastructure is not available for running

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.15
+Version:        4.0.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -189,6 +189,10 @@ module Yast
           ["Import", Ops.get_map(Profile.current, "add-on", {})]
         )
         Call.Function("add-on_auto", ["Write"])
+
+        # Recover partitioning settings that were removed by the add-on_auto client (bsc#1073548)
+        Yast::AutoinstStorage.import_general_settings(general_section["storage"])
+
         # The entry "kexec_reboot" in the Product description can be set
         # by the AutoYaST configuration setting (general/forceboot) and should
         # not be reset by any other Product description file.

--- a/src/clients/inst_autosetup_upgrade.rb
+++ b/src/clients/inst_autosetup_upgrade.rb
@@ -128,6 +128,9 @@ module Yast
           ["Import", Ops.get_map(Profile.current, "add-on", {})]
         )
         Call.Function("add-on_auto", ["Write"])
+
+        # Recover partitioning settings that were removed by the add-on_auto client (bsc#1073548)
+        Yast::AutoinstStorage.import_general_settings(general_section["storage"])
       end
 
       @use_utf8 = true # utf8 is default

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -79,9 +79,10 @@ module Yast
       self.general_settings = settings.clone
 
       # Backward compatibility
-      if general_settings["btrfs_set_default_subvolume_name"]
-        general_settings["btrfs_default_subvolume"] = general_settings.delete("btrfs_set_default_subvolume_name")
+      if general_settings["btrfs_set_default_subvolume_name"] == false
+        general_settings["btrfs_default_subvolume"] = ""
       end
+      general_settings.delete("btrfs_set_default_subvolume_name")
 
       # Override product settings from control file
       Yast::ProductFeatures.SetOverlay("partitioning" => general_settings)

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -137,16 +137,6 @@ describe "Yast::AutoinstGeneral" do
       expect(subject.Export).to include("storage" => profile["storage"])
     end
 
-    context "when the old 'btrfs_set_default_subvolume_name' is used" do
-      let(:profile) do
-        { "storage" => { "btrfs_set_default_subvolume_name" => "@" } }
-      end
-
-      it "exports that option renamed to 'btrfs_default_subvolume'" do
-        expect(subject.Export).to include("storage" => { "btrfs_default_subvolume" => "@" })
-      end
-    end
-
     it "exports mode settings" do
       expect(subject.Export).to include("mode" => profile["mode"])
     end
@@ -161,10 +151,6 @@ describe "Yast::AutoinstGeneral" do
 
     it "exports proposals settings" do
       expect(subject.Export).to include("proposals" => profile["proposals"])
-    end
-
-    context "when btrfs default subvolume name is different from the default" do
-      it "includes btrfs_set_default_subvolume_name"
     end
   end
 end

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -205,14 +205,32 @@ describe Yast::AutoinstStorage do
       it "does not set multipath"
     end
 
-    context "when btrfs default subvolume name is set" do
-      let(:profile) { { "btrfs_set_default_subvolume_name" => "@@" } }
+    context "when btrfs default subvolume name is set to false" do
+      let(:profile) { { "btrfs_set_default_subvolume_name" => false } }
 
-      it "sets the default subvolume"
+      it "disables the btrfs default subvolume" do
+        expect(Yast::ProductFeatures).to receive(:SetOverlay)
+          .with("partitioning" => { "btrfs_default_subvolume" => "" })
+        subject.import_general_settings(profile)
+      end
     end
 
     context "when btrfs default subvolume name is not set" do
-      it "uses the default name"
+      let(:profile) { {} }
+
+      it "uses the default for the product" do
+        expect(Yast::ProductFeatures).to receive(:SetOverlay).with("partitioning" => {})
+        subject.import_general_settings(profile)
+      end
+    end
+
+    context "when btrfs default subvolume name is set to true" do
+      let(:profile) { { "btrfs_set_default_subvolume_name" => true } }
+
+      it "uses the default for the product" do
+        expect(Yast::ProductFeatures).to receive(:SetOverlay).with("partitioning" => {})
+        subject.import_general_settings(profile)
+      end
     end
   end
 end


### PR DESCRIPTION
It fixes [bsc#1073548](https://bugzilla.suse.com/show_bug.cgi?id=1073548).There were two problems which prevented `this setting to work:

* When add-ons are reintegrated, the overly in ProductFeatures is destroyed. So now we are applying the overly after the add-ons are reintegrated.
* The setting was not interpreted correctly (it is suppose to be a boolean, not the real subvolume name).