### PR TITLE
always upgrade system via equivalent of 'zypper dup', removing respective control from the profile (bsc#1071708)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan  5 07:36:01 UTC 2018 - jsrain@suse.cz
+
+- always upgrade system via equivalent of 'zypper dup', removing
+  respective control from the profile (bsc#1071708)
+- 4.0.17
+
+-------------------------------------------------------------------
 Wed Dec 20 15:57:48 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: fix btrfs_set_default_subvolume_name handling

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.16
+Version:        4.0.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autosetup_upgrade.rb
+++ b/src/clients/inst_autosetup_upgrade.rb
@@ -282,21 +282,12 @@ module Yast
         RootPart.previousRootPartition = RootPart.selectedRootPartition
 
         # check whether update is possible
-        # reset deleteOldPackages and onlyUpdateInstalled in respect to the selected system
+        # reset settings in respect to the selected system
         Update.Reset
         if !Update.IsProductSupportedForUpgrade
           Builtins.y2milestone("Upgrade is not supported")
           @update_not_possible = true
         end
-      end
-
-      # this is new - override the default upgrade mode
-      if Ops.get(Profile.current, ["upgrade", "only_installed_packages"]) != nil
-        Update.onlyUpdateInstalled = Ops.get_boolean(
-          Profile.current,
-          ["upgrade", "only_installed_packages"],
-          true
-        )
       end
 
       # connect target with package manager
@@ -309,8 +300,6 @@ module Yast
         # bnc #391785
         # Drops packages after PkgApplReset, not before (that would null that)
         Update.DropObsoletePackages
-
-        Update.SetDesktopPattern if !Update.onlyUpdateInstalled
 
         # make sure the packages needed for accessing the installation repository
         # are installed, e.g. "cifs-mount" for SMB or "nfs-client" for NFS repositories
@@ -403,7 +392,7 @@ module Yast
         Builtins.foreach(@packages) { |p| Pkg.ResolvableInstall(p, :package) }
         Builtins.foreach(@products) { |p| Pkg.ResolvableInstall(p, :product) }
         # old stuff again here
-        if Pkg.PkgSolve(!Update.onlyUpdateInstalled)
+        if Pkg.PkgSolve(false)
           Update.solve_errors = 0
         else
           Update.solve_errors = Pkg.PkgSolveErrors

--- a/test_xml/upgrade.xml
+++ b/test_xml/upgrade.xml
@@ -61,7 +61,6 @@ echo "jo script was run" > /tmp/init-script-works
     </init-scripts>
   </scripts>
   <upgrade>  
-    <only_installed_packages config:type="boolean">false</only_installed_packages>  
     <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>  
   </upgrade>  
   <!--


### PR DESCRIPTION
AutoYaST counterpart for https://github.com/yast/yast-update/pull/90

Yes, I know that .rnc profile changes are pending, I would like to update the file after doing some tests just in case it shows we need to revert.