### PR TITLE
Fix /tmp/profile

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 10 14:23:07 UTC 2018 - igonzalezsosa@suse.com
+
+- Fix initialization to copy the profile to /tmp/profile again
+  (bsc#1075334)
+- 4.0.18
+
+-------------------------------------------------------------------
 Fri Jan  5 07:36:01 UTC 2018 - jsrain@suse.cz
 
 - always upgrade system via equivalent of 'zypper dup', removing

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.17
+Version:        4.0.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autoinit.rb
+++ b/src/clients/inst_autoinit.rb
@@ -18,6 +18,7 @@ module Yast
       Yast.import "Installation"
       Yast.import "AutoInstall"
       Yast.import "AutoinstConfig"
+      Yast.import "AutoinstFunctions"
       Yast.import "AutoinstGeneral"
       Yast.import "ProfileLocation"
       Yast.import "AutoInstallRules"
@@ -107,7 +108,7 @@ module Yast
         WFM.CallFunction("fcoe-client_auto", ["Write"])
       end
 
-      if !AutoinstConfig.selected_product
+      if !AutoinstFunctions.selected_product
         Report.Error(_("No base product selected"))
 
         return :abort

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -34,7 +34,6 @@ module Yast
       Yast.import "Stage"
       Yast.import "Label"
       Yast.import "Report"
-      Yast.import "Profile"
 
       Yast.include self, "autoinstall/xml.rb"
 
@@ -529,41 +528,6 @@ module Yast
       main_help
     end
 
-    # Tries to find a base product if could be identified from the AY profile
-    #
-    # There are several ways how can base product be defined in the profile
-    # 1) explicitly
-    # 2) impllicitly according to software selection
-    # 3) if not set explicitly and just one product is available on media - use it
-    #
-    # @return [Y2Packager::Product] a base product or nil
-    def selected_product
-      return @selected_product if @selected_product
-
-      profile = Profile.current
-      product = identify_product_by_selection(profile)
-
-      # user asked for a product which is not available -> exit, not found
-      return nil if product.nil? && base_product_name(profile)
-
-      @selected_product = if product
-        log.info("selected_product - found explicitly defined base product: #{product.inspect}")
-        product
-      elsif (product = identify_product_by_patterns(profile))
-        log.info("selected_product - base product identified by patterns: #{product.inspect}")
-        product
-      elsif (product = identify_product_by_packages(profile))
-        log.info("selected_product - base product identified by packages: #{product.inspect}")
-        product
-      else
-        # last instance
-        base_products = Y2Packager::Product.available_base_products
-        base_products.first if base_products.size == 1
-      end
-
-      @selected_product
-    end
-
     # Profile path during installation
     #
     # @return [String] Path
@@ -635,79 +599,6 @@ module Yast
     publish :function => :AutoinstConfig, :type => "void ()"
     publish :function => :MainHelp, :type => "string ()"
     publish :function => :check_second_stage_environment, :type => "string ()"
-
-    private
-
-    # Reads base product name from the profile
-    #
-    # FIXME: Currently it returns first found product name. It should be no
-    # problem since this section was unused in AY installation so far.
-    # However, it might be needed to add a special handling for multiple
-    # poducts in the future. At least we can filter out products which are
-    # not base products.
-    #
-    # @param profile [Hash] AutoYaST profile
-    # @return [String] product name
-    def base_product_name(profile)
-      software = profile.fetch("software", {})
-      software.fetch("products", []).first
-    end
-
-    # Tries to identify a base product according to the condition in block
-    #
-    # @return [Y2Packager::Product] a product if exactly one product matches
-    # the criteria, nil otherwise
-    def identify_product
-      base_products = Y2Packager::Product.available_base_products
-
-      products = base_products.select do |product|
-        yield(product)
-      end
-
-      return products.first if products.size == 1
-      nil
-    end
-
-    # Try to find base product according to patterns in profile
-    #
-    # searching for patterns like "sles-base-32bit"
-    #
-    # @param [Hash] profile - a hash representation of AY profile
-    # @return [Y2Packager::Product] a product if exactly one product matches
-    # the criteria, nil otherwise
-    def identify_product_by_patterns(profile)
-      software = profile.fetch("software", {})
-
-      identify_product do |product|
-        software.fetch("patterns", []).any? { |p| p =~ /#{product.name.downcase}-.*/ }
-      end
-    end
-
-    # Try to find base product according to packages selection in profile
-    #
-    # searching for packages like "sles-release"
-    #
-    # @param [Hash] profile - a hash representation of AY profile
-    # @return [Y2Packager::Product] a product if exactly one product matches
-    # the criteria, nil otherwise
-    def identify_product_by_packages(profile)
-      software = profile.fetch("software", {})
-
-      identify_product do |product|
-        software.fetch("packages", []).any? { |p| p =~ /#{product.name.downcase}-release/ }
-      end
-    end
-
-    # Try to identify base product using user's selection in profile
-    #
-    # @param [Hash] profile - a hash representation of AY profile
-    # @return [Y2Packager::Product] a product if exactly one product matches
-    # the criteria, nil otherwise
-    def identify_product_by_selection(profile)
-      identify_product do |product|
-        product.short_name == base_product_name(profile)
-      end
-    end
   end
 
   AutoinstConfig = AutoinstConfigClass.new

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -35,8 +35,6 @@ module Yast
       Yast.import "Label"
       Yast.import "Report"
       Yast.import "Profile"
-      Yast.import "AutoinstFunctions"
-      Yast.import "Pkg"
 
       Yast.include self, "autoinstall/xml.rb"
 
@@ -229,38 +227,6 @@ module Yast
       @Proposals = deep_copy(l)
 
       nil
-    end
-
-    # Checking the environment the installed system
-    # to run a second stage if it is needed.
-    #
-    # @return [String] empty String or error messsage about missing packages.
-    def check_second_stage_environment
-      error = ""
-      return error unless AutoinstFunctions.second_stage_required?
-
-      missing_packages = Profile.needed_second_stage_packages.select do |p|
-        !Pkg.IsSelected(p)
-      end
-      unless missing_packages.empty?
-        log.warn "Second stage cannot be run due missing packages: #{missing_packages}"
-        # TRANSLATORS: %s will be replaced by a package list
-        error = format(_("AutoYaST cannot run second stage due to missing packages \n%s.\n"),
-          missing_packages.join(", "))
-        unless registered?
-          if Profile.current["suse_register"] &&
-            Profile.current["suse_register"]["do_registration"] == true
-            error << _("The registration has failed. " \
-              "Please check your registration settings in the AutoYaST configuration file.")
-            log.warn "Registration has been called but has failed."
-          else
-            error << _("You have not registered your system. " \
-              "Missing packages can be added by configuring the registration in the AutoYaST configuration file.")
-            log.warn "Registration is not configured at all."
-          end
-        end
-      end
-      error
     end
 
     # Searches for 'autoyast' via SLP and returns the full URL of
@@ -671,16 +637,6 @@ module Yast
     publish :function => :check_second_stage_environment, :type => "string ()"
 
     private
-
-    # Determine whether the system is registered
-    #
-    # @return [Boolean]
-    def registered?
-      require "registration/registration"
-      Registration::Registration.is_registered?
-    rescue LoadError
-      false
-    end
 
     # Reads base product name from the profile
     #

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -65,6 +65,41 @@ module Yast
       error
     end
 
+    # Tries to find a base product if could be identified from the AY profile
+    #
+    # There are several ways how can base product be defined in the profile
+    # 1) explicitly
+    # 2) impllicitly according to software selection
+    # 3) if not set explicitly and just one product is available on media - use it
+    #
+    # @return [Y2Packager::Product] a base product or nil
+    def selected_product
+      return @selected_product if @selected_product
+
+      profile = Profile.current
+      product = identify_product_by_selection(profile)
+
+      # user asked for a product which is not available -> exit, not found
+      return nil if product.nil? && base_product_name(profile)
+
+      @selected_product = if product
+        log.info("selected_product - found explicitly defined base product: #{product.inspect}")
+        product
+      elsif (product = identify_product_by_patterns(profile))
+        log.info("selected_product - base product identified by patterns: #{product.inspect}")
+        product
+      elsif (product = identify_product_by_packages(profile))
+        log.info("selected_product - base product identified by packages: #{product.inspect}")
+        product
+      else
+        # last instance
+        base_products = Y2Packager::Product.available_base_products
+        base_products.first if base_products.size == 1
+      end
+
+      @selected_product
+    end
+
   private
 
     # Determine whether the system is registered
@@ -77,6 +112,76 @@ module Yast
       false
     end
 
+    # Tries to identify a base product according to the condition in block
+    #
+    # @return [Y2Packager::Product] a product if exactly one product matches
+    # the criteria, nil otherwise
+    def identify_product
+      base_products = Y2Packager::Product.available_base_products
+
+      products = base_products.select do |product|
+        yield(product)
+      end
+
+      return products.first if products.size == 1
+      nil
+    end
+
+    # Try to find base product according to patterns in profile
+    #
+    # searching for patterns like "sles-base-32bit"
+    #
+    # @param [Hash] profile - a hash representation of AY profile
+    # @return [Y2Packager::Product] a product if exactly one product matches
+    # the criteria, nil otherwise
+    def identify_product_by_patterns(profile)
+      software = profile.fetch("software", {})
+
+      identify_product do |product|
+        software.fetch("patterns", []).any? { |p| p =~ /#{product.name.downcase}-.*/ }
+      end
+    end
+
+    # Try to find base product according to packages selection in profile
+    #
+    # searching for packages like "sles-release"
+    #
+    # @param [Hash] profile - a hash representation of AY profile
+    # @return [Y2Packager::Product] a product if exactly one product matches
+    # the criteria, nil otherwise
+    def identify_product_by_packages(profile)
+      software = profile.fetch("software", {})
+
+      identify_product do |product|
+        software.fetch("packages", []).any? { |p| p =~ /#{product.name.downcase}-release/ }
+      end
+    end
+
+    # Try to identify base product using user's selection in profile
+    #
+    # @param [Hash] profile - a hash representation of AY profile
+    # @return [Y2Packager::Product] a product if exactly one product matches
+    # the criteria, nil otherwise
+    def identify_product_by_selection(profile)
+      identify_product do |product|
+        product.short_name == base_product_name(profile)
+      end
+    end
+
+    # Reads base product name from the profile
+    #
+    # FIXME: Currently it returns first found product name. It should be no
+    # problem since this section was unused in AY installation so far.
+    # However, it might be needed to add a special handling for multiple
+    # poducts in the future. At least we can filter out products which are
+    # not base products.
+    #
+    # @param profile [Hash] AutoYaST profile
+    # @return [String] product name
+    def base_product_name(profile)
+      software = profile.fetch("software", {})
+      software.fetch("products", []).first
+    end
   end
 
   AutoinstFunctions = AutoinstFunctionsClass.new

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -10,6 +10,7 @@ module Yast
       Yast.import "Mode"
       Yast.import "AutoinstConfig"
       Yast.import "ProductControl"
+      Yast.import "Profile"
       Yast.import "Pkg"
     end
 

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -28,6 +28,7 @@ module Yast
       Yast.import "Report"
       Yast.import "Kernel"
       Yast.import "AutoinstConfig"
+      Yast.import "AutoinstFunctions"
       Yast.import "ProductControl"
       Yast.import "Mode"
       Yast.import "Misc"
@@ -849,7 +850,7 @@ module Yast
       Pkg.SetSolverFlags({ "ignoreAlreadyRecommended" => Mode.normal, 
                            "onlyRequires" => !sw_settings.fetch("install_recommended",true) })
 
-      merge_product(AutoinstConfig.selected_product)
+      merge_product(AutoinstFunctions.selected_product)
 
       failed = []
 

--- a/test/AutoinstConfig_tests.rb
+++ b/test/AutoinstConfig_tests.rb
@@ -59,49 +59,6 @@ describe "Yast::AutoinstConfig" do
     end
   end
 
-  describe "#check_second_stage_environment" do
-    context "second stage is not needed" do
-      it "returns an empty error string" do
-        allow(Yast::AutoinstFunctions).to receive(:second_stage_required?).and_return(false)
-        expect(subject.check_second_stage_environment).to be_empty
-      end
-    end
-
-    context "second stage is needed" do
-      before do
-        allow(Yast::AutoinstFunctions).to receive(:second_stage_required?).and_return(true)
-      end
-
-      context "required package are installed" do
-        it "returns an empty error string" do
-          allow(Yast::Pkg).to receive(:IsSelected).and_return(true)
-          expect(subject.check_second_stage_environment).to be_empty
-        end
-      end
-
-      context "required package are not installed" do
-        before do
-          allow(Yast::Pkg).to receive(:IsSelected).and_return(false)
-        end
-
-        context "registration has not been defined in AY configuration file" do
-          it "reports error to set registration" do
-            allow(Yast::Profile).to receive(:current).and_return({})
-            expect(subject.check_second_stage_environment).to include("configuring the registration")
-          end
-        end
-
-        context "registration has failed" do
-          it "reports error to check registration settings" do
-            allow(Yast::Profile).to receive(:current).and_return(
-              {"suse_register" => {"do_registration" => true}})
-            expect(subject.check_second_stage_environment).to include("registration has failed")
-          end
-        end
-      end
-    end
-  end
-
   describe "#update_profile_location" do
     context "when profile location is not defined" do
       it "returns 'floppy' with path to a profile as the new location" do

--- a/test/AutoinstConfig_tests.rb
+++ b/test/AutoinstConfig_tests.rb
@@ -3,7 +3,6 @@
 require_relative "test_helper"
 
 Yast.import "AutoinstConfig"
-Yast.import "Profile"
 
 describe "Yast::AutoinstConfig" do
 
@@ -110,75 +109,6 @@ describe "Yast::AutoinstConfig" do
         expect(subject.user).to eq("moo")
         expect(subject.pass).to eq("woo")
       end
-    end
-  end
-
-  describe "#selected_product" do
-    def base_product(name, short_name)
-      Y2Packager::Product.new(name: name, short_name: short_name)
-    end
-
-    let(:selected_name) { "SLES15" }
-
-    before(:each) do
-      allow(Y2Packager::Product)
-        .to receive(:available_base_products)
-        .and_return(
-          [
-            base_product("SLES", selected_name),
-            base_product("SLED", "SLED15")
-          ]
-        )
-
-        # reset cache between tests
-        subject.instance_variable_set(:@selected_product, nil)
-    end
-
-    it "returns proper base product when explicitly selected in the profile and such base product exists on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return("software" => { "products" => [selected_name] })
-
-      expect(subject.selected_product.short_name).to eql selected_name
-    end
-
-    it "returns nil when product is explicitly selected in the profile and such base product doesn't exist on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return("software" => { "products" => { "product" => "Fedora" } })
-
-      expect(subject.selected_product).to be nil
-    end
-
-    it "returns base product identified by patterns in the profile if such base product exists on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return("software" => { "patterns" => ["sles-base-32bit"] })
-
-      expect(subject.selected_product.short_name).to eql selected_name
-    end
-
-    it "returns base product identified by packages in the profile if such base product exists on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return("software" => { "packages" => ["sles-release"] })
-
-      expect(subject.selected_product.short_name).to eql selected_name
-    end
-
-    it "returns base product if there is just one on media and product cannot be identified from profile" do
-      allow(Y2Packager::Product)
-        .to receive(:available_base_products)
-        .and_return(
-          [
-            base_product("SLED", "SLED15")
-          ]
-        )
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return("software" => {})
-
-      expect(subject.selected_product.short_name).to eql "SLED15"
     end
   end
 

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -64,4 +64,48 @@ describe Yast::AutoinstFunctions do
       end
     end
   end
+
+  describe "#check_second_stage_environment" do
+    context "second stage is not needed" do
+      it "returns an empty error string" do
+        allow(subject).to receive(:second_stage_required?).and_return(false)
+        expect(subject.check_second_stage_environment).to be_empty
+      end
+    end
+
+    context "second stage is needed" do
+      before do
+        allow(subject).to receive(:second_stage_required?).and_return(true)
+      end
+
+      context "required package are installed" do
+        it "returns an empty error string" do
+          allow(Yast::Pkg).to receive(:IsSelected).and_return(true)
+          expect(subject.check_second_stage_environment).to be_empty
+        end
+      end
+
+      context "required package are not installed" do
+        before do
+          allow(Yast::Pkg).to receive(:IsSelected).and_return(false)
+        end
+
+        context "registration has not been defined in AY configuration file" do
+          it "reports error to set registration" do
+            allow(Yast::Profile).to receive(:current).and_return({})
+            expect(subject.check_second_stage_environment).to include("configuring the registration")
+          end
+        end
+
+        context "registration has failed" do
+          it "reports error to check registration settings" do
+            allow(Yast::Profile).to receive(:current).and_return(
+              {"suse_register" => {"do_registration" => true}})
+            expect(subject.check_second_stage_environment).to include("registration has failed")
+          end
+        end
+      end
+    end
+  end
+
 end

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -19,6 +19,7 @@ describe Yast::AutoinstFunctions do
     Yast::Mode.SetMode(mode)
     Yast::Stage.Set(stage)
     allow(Yast::AutoinstConfig).to receive(:second_stage).and_return(second_stage)
+    Yast::Profile.Import({})
   end
 
   describe "#second_stage_required?" do
@@ -108,4 +109,72 @@ describe Yast::AutoinstFunctions do
     end
   end
 
+  describe "#selected_product" do
+    def base_product(name, short_name)
+      Y2Packager::Product.new(name: name, short_name: short_name)
+    end
+
+    let(:selected_name) { "SLES15" }
+
+    before(:each) do
+      allow(Y2Packager::Product)
+        .to receive(:available_base_products)
+        .and_return(
+          [
+            base_product("SLES", selected_name),
+            base_product("SLED", "SLED15")
+          ]
+        )
+
+        # reset cache between tests
+        subject.instance_variable_set(:@selected_product, nil)
+    end
+
+    it "returns proper base product when explicitly selected in the profile and such base product exists on media" do
+      allow(Yast::Profile)
+        .to receive(:current)
+        .and_return("software" => { "products" => [selected_name] })
+
+      expect(subject.selected_product.short_name).to eql selected_name
+    end
+
+    it "returns nil when product is explicitly selected in the profile and such base product doesn't exist on media" do
+      allow(Yast::Profile)
+        .to receive(:current)
+        .and_return("software" => { "products" => { "product" => "Fedora" } })
+
+      expect(subject.selected_product).to be nil
+    end
+
+    it "returns base product identified by patterns in the profile if such base product exists on media" do
+      allow(Yast::Profile)
+        .to receive(:current)
+        .and_return("software" => { "patterns" => ["sles-base-32bit"] })
+
+      expect(subject.selected_product.short_name).to eql selected_name
+    end
+
+    it "returns base product identified by packages in the profile if such base product exists on media" do
+      allow(Yast::Profile)
+        .to receive(:current)
+        .and_return("software" => { "packages" => ["sles-release"] })
+
+      expect(subject.selected_product.short_name).to eql selected_name
+    end
+
+    it "returns base product if there is just one on media and product cannot be identified from profile" do
+      allow(Y2Packager::Product)
+        .to receive(:available_base_products)
+        .and_return(
+          [
+            base_product("SLED", "SLED15")
+          ]
+        )
+      allow(Yast::Profile)
+        .to receive(:current)
+        .and_return("software" => {})
+
+      expect(subject.selected_product.short_name).to eql "SLED15"
+    end
+  end
 end


### PR DESCRIPTION
It fixes [bsc#1075334](https://bugzilla.suse.com/show_bug.cgi?id=1075334).

The problem was caused by a circular dependency between `Profile` and `AutoinstConfig`. I've moved `check_second_stage_environment` and `selected_product` (and related private functions) from `AutoinstConfig` to `AutoinstFunctions` (which already contained a method to check whether the second stage was needed). Now, `AutoinstConfig` does not depend on `Profile` anymore.

Please, see also https://github.com/yast/yast-installation/pull/641 and https://github.com/yast/yast-registration/pull/349.