### PR TITLE
Display more details when the package solver fails

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jan 19 14:02:32 UTC 2018 - lslezak@suse.cz
+
+- Display more details when the package solver fails
+
+-------------------------------------------------------------------
 Thu Jan 18 14:37:15 CET 2018 - schubi@suse.de
 
 - Using ProductFeatures.SetSection instead of

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -934,8 +934,10 @@ module Yast
       # Solve dependencies
       #
       if !Pkg.PkgSolve(false)
+        # TRANSLATORS: Error message
         msg = _("The package resolver run failed. Please check your software " \
           "section in the autoyast profile.")
+        # TRANSLATORS: Error message, %s is replaced by "/var/log/YaST2/y2log"
         msg += "\n" + _("Additional details can be found in the %s file.") %
           "/var/log/YaST2/y2log"
 


### PR DESCRIPTION
- Unfortunately it's not easy to get the details of solver failure
- This is related to [this openQA issue](https://openqa.suse.de/tests/1396302#step/installation/43)
- The `pkg-bindings` [save some details into a file](https://github.com/yast/yast-pkg-bindings/blob/2f303c70e552a11d96a7fd7c92399cf030cbfcfa/src/Package.cc#L1979) so just display it
- No version bump as this is just a minor enhancement