### PR TITLE
Decrease memory consumption (bsc#1077882)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 29 14:58:35 UTC 2018 - lslezak@suse.cz
+
+- Avoid using Pkg.ResolvableProperties("", :package, "") calls
+  which require too much memory (bsc#1077882)
+- 4.0.26
+
+-------------------------------------------------------------------
 Fri Jan 26 12:58:17 CET 2018 - schubi@suse.de
 
 - Reporting packages which cannot be selected for installation.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.25
+Version:        4.0.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -64,4 +64,23 @@ describe Yast::AutoinstSoftware do
     end
   end
 
+  describe "#locked_packages" do
+    before do
+      expect(Yast::Pkg).to receive(:GetPackages).with(:taboo, true).and_return(["foo"])
+      expect(Yast::Pkg).to receive(:GetPackages).with(:available, true).and_return(["bar"])
+    end
+
+    it "returns packages locked by user" do
+      # just mock the only attribute needed
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(["transact_by" => :user])
+      expect(subject.locked_packages).to include("foo").and include("bar")
+    end
+
+    it "ignores packages changed by the solver" do
+      # just mock the only attribute needed
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(["transact_by" => :solver])
+      expect(subject.locked_packages).to be_empty
+    end
+  end
+
 end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1077882
- Avoid using `Pkg.ResolvableProperties("", :package, "")` calls which require too much memory (returns *all* packages at once)
- Rather get the package list via `Pkg.GetPackages` and call `Pkg.ResolvableProperties` for each package separately
- So instead working with one huge list we process many smaller ones, the advantage is that the memory for the smaller parts can be reused in the loop decreasing the overall memory requirement
- Not tested, let's see if that helps in OpenQA...
- 4.0.26