### PR TITLE
Speed optimization for the previous fix (bsc#1077882)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 31 13:04:57 UTC 2018 - lslezak@suse.cz
+
+- Speed optimization for the previous fix, the "clone_system"
+  client spent several minutes processing the packages
+  (related to bsc#1077882)
+- 4.0.27
+
+-------------------------------------------------------------------
 Mon Jan 29 14:58:35 UTC 2018 - lslezak@suse.cz
 
 - Avoid using Pkg.ResolvableProperties("", :package, "") calls

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.26
+Version:        4.0.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -119,8 +119,8 @@ Requires:       yast2-transfer >= 2.21.0
 # storage-ng based version
 Requires:       yast2-update >= 3.3.0
 Requires:       yast2-xml
-# pkgGpgCheck callback
-Requires:       yast2-pkg-bindings >= 3.1.31
+# "transact_by" key in PkgPropertiesAll()
+Requires:       yast2-pkg-bindings >= 4.0.7
 # Y2Storage::AutoinstIssues containing section information
 BuildRequires:  yast2-storage-ng >= 4.0.15
 Provides:       yast2-trans-autoinst

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -969,7 +969,7 @@ module Yast
 
       # user selected packages which have already been installed
       installed_by_user = Pkg.GetPackages(:installed, true).select{ |pkg_name|
-        Pkg.PkgPropertiesAll(pkg_name).any? { |package| package["on_system_by_user"] }
+        Pkg.PkgPropertiesAll(pkg_name).any? { |p| p["on_system_by_user"] && p["status"] == :installed }
       }
 
       # Filter out kernel and pattern packages
@@ -1177,9 +1177,9 @@ module Yast
       names_only = true
       packages = Pkg.GetPackages(status, names_only)
 
-      # Pkg.ResolvableProperties for each package separately to avoid huge memory consumption
+      # iterate over each package, Pkg.ResolvableProperties("", :package, "") requires a lot of memory
       packages.select do |package|
-        Pkg.ResolvableProperties(package, :package, "").any? {|p| p["transact_by"] == :user}
+        Pkg.PkgPropertiesAll(package).any? { |p| p["transact_by"] == :user && p["status"] == status }
       end
     end
   end

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -71,14 +71,16 @@ describe Yast::AutoinstSoftware do
     end
 
     it "returns packages locked by user" do
-      # just mock the only attribute needed
-      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(["transact_by" => :user])
+      # just mock only the needed attributes
+      expect(Yast::Pkg).to receive(:PkgPropertiesAll).with("foo").and_return(["transact_by" => :user, "status" => :taboo])
+      expect(Yast::Pkg).to receive(:PkgPropertiesAll).with("bar").and_return(["transact_by" => :user, "status" => :available])
       expect(subject.locked_packages).to include("foo").and include("bar")
     end
 
     it "ignores packages changed by the solver" do
-      # just mock the only attribute needed
-      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(["transact_by" => :solver])
+      # just mock only the needed attributes
+      expect(Yast::Pkg).to receive(:PkgPropertiesAll).with("foo").and_return(["transact_by" => :solver, "status" => :taboo])
+      expect(Yast::Pkg).to receive(:PkgPropertiesAll).with("bar").and_return(["transact_by" => :solver, "status" => :available])
       expect(subject.locked_packages).to be_empty
     end
   end


### PR DESCRIPTION
- Fix up for #393 - the `clone_system` client spent several minutes processing the packages, with this fix it takes just few seconds as before
- The `ResolvableProperties` call is quite expensive, it returns a lot of details for each package which we do not need here
- Replaced by `PkgPropertiesAll` which returns much less data so it's faster to create a process
- Depends on https://github.com/yast/yast-pkg-bindings/pull/95 which adds the required data
- 4.0.27