### PR TITLE
Fixed cloning of the base product name (bsc#1084259)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  7 08:06:05 UTC 2018 - lslezak@suse.cz
+
+- Fixed cloning of the base product name (bsc#1084259)
+- 4.0.38
+
+-------------------------------------------------------------------
 Mon Mar  5 16:13:36 CET 2018 - schubi@suse.de
 
 - Fix in showing/accepting base licenses: Using

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.37
+Version:        4.0.38
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -165,7 +165,7 @@ module Yast
     # the criteria, nil otherwise
     def identify_product_by_selection(profile)
       identify_product do |product|
-        product.short_name == base_product_name(profile)
+        product.name == base_product_name(profile)
       end
     end
 

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -698,7 +698,7 @@ module Yast
 
       products = Product.FindBaseProducts
       raise "Found multiple base products" if products.size > 1
-      s["products"] = products.map{ |x| x["short_name"] }
+      s["products"] = products.map{ |x| x["name"] }
 
       s
     end

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -110,19 +110,19 @@ describe Yast::AutoinstFunctions do
   end
 
   describe "#selected_product" do
-    def base_product(name, short_name)
-      Y2Packager::Product.new(name: name, short_name: short_name)
+    def base_product(name)
+      Y2Packager::Product.new(name: name)
     end
 
-    let(:selected_name) { "SLES15" }
+    let(:selected_name) { "SLES" }
 
     before(:each) do
       allow(Y2Packager::Product)
         .to receive(:available_base_products)
         .and_return(
           [
-            base_product("SLES", selected_name),
-            base_product("SLED", "SLED15")
+            base_product("SLES"),
+            base_product("SLED")
           ]
         )
 
@@ -135,7 +135,7 @@ describe Yast::AutoinstFunctions do
         .to receive(:current)
         .and_return("software" => { "products" => [selected_name] })
 
-      expect(subject.selected_product.short_name).to eql selected_name
+      expect(subject.selected_product.name).to eql selected_name
     end
 
     it "returns nil when product is explicitly selected in the profile and such base product doesn't exist on media" do
@@ -151,7 +151,7 @@ describe Yast::AutoinstFunctions do
         .to receive(:current)
         .and_return("software" => { "patterns" => ["sles-base-32bit"] })
 
-      expect(subject.selected_product.short_name).to eql selected_name
+      expect(subject.selected_product.name).to eql selected_name
     end
 
     it "returns base product identified by packages in the profile if such base product exists on media" do
@@ -159,7 +159,7 @@ describe Yast::AutoinstFunctions do
         .to receive(:current)
         .and_return("software" => { "packages" => ["sles-release"] })
 
-      expect(subject.selected_product.short_name).to eql selected_name
+      expect(subject.selected_product.name).to eql selected_name
     end
 
     it "returns base product if there is just one on media and product cannot be identified from profile" do
@@ -167,14 +167,14 @@ describe Yast::AutoinstFunctions do
         .to receive(:available_base_products)
         .and_return(
           [
-            base_product("SLED", "SLED15")
+            base_product("SLED")
           ]
         )
       allow(Yast::Profile)
         .to receive(:current)
         .and_return("software" => {})
 
-      expect(subject.selected_product.short_name).to eql "SLED15"
+      expect(subject.selected_product.name).to eql "SLED"
     end
   end
 end

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -32,7 +32,7 @@ describe Yast::AutoinstSoftware do
     it "puts product definition into the exported profile" do
       expect(Yast::Product)
         .to receive(:FindBaseProducts)
-        .and_return([{ "short_name" => "LeanOS" }])
+        .and_return([{ "name" => "LeanOS" }])
 
       profile = subject.Export
 
@@ -45,8 +45,8 @@ describe Yast::AutoinstSoftware do
         .to receive(:FindBaseProducts)
         .and_return(
           [
-            { "short_name" => "LeanOS" },
-            { "short_name" => "AgileOS" }
+            { "name" => "LeanOS" },
+            { "name" => "AgileOS" }
           ]
         )
 


### PR DESCRIPTION
The cloned profile contains a wrong base product name:
```xml
<products config:type="list">
  <product>SLED15</product>
</products>
```
it should be a simple name without version:
```xml
  <product>SLED</product>
```

- Use the `"name"` attribute at cloning (it is expected at installation).
- https://bugzilla.suse.com/show_bug.cgi?id=1084259
- 4.0.38