### PR TITLE
Added more list entry names to be used instead of 'listentry'

### DIFF
--- a/doc/profile_changes_SLE15.md
+++ b/doc/profile_changes_SLE15.md
@@ -171,10 +171,10 @@ Unfortunately firewalld does not support **RPC** configuration.
 
 ```xml
 <firewall>
-  FW_SERVICES_DMZ_TCP="ftp ssh 80 5900:5999"
-  FW_SERVICES_EXT_UDP="1723 ipsec-nat-t"
-  FW_SERVICES_EXT_IP="esp icmp gre"
-  FW_MASQUERADE="yes"
+  <FW_SERVICES_DMZ_TCP>ftp ssh 80 5900:5999</FW_SERVICES_DMZ_TCP>
+  <FW_SERVICES_EXT_UDP>1723 ipsec-nat-t</FW_SERVICES_EXT_UDP>
+  <FW_SERVICES_EXT_IP>esp icmp gre</FW_SERVICES_EXT_IP>
+  <FW_MASQUERADE>yes</FW_MASQUERADE>
 </firewall>
 ```
 

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 21 15:55:03 UTC 2018 - knut.anderssen@suse.com
+
+- Added more entries to be used instead of the listentry tag when
+  cloning the system (bsc#1013047)
+- 4.0.41
+
+-------------------------------------------------------------------
 Tue Mar 20 15:24:43 CET 2018 - schubi@suse.de
 
 - Improved error message if the base product cannot be found.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.40
+Version:        4.0.41
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/xml.rb
+++ b/src/include/autoinstall/xml.rb
@@ -102,7 +102,12 @@ module Yast
           "ask-list"                 => "ask",
           "device_order"             => "device",
           "param-list"               => "param",
-          "semi-automatic"           => "module"
+          "semi-automatic"           => "module",
+          "ports"                    => "port",
+          "sources"                  => "source",
+          "zones"                    => "zone",
+          "authorized_keys"          => "authorized_key",
+          "products"                 => "product"
         }
       )
 


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/o6xMc6sL/1374-0-ostumbleweed-p1-1013047-generated-autoyast-profile-does-not-validate-firewall)
- https://bugzilla.suse.com/show_bug.cgi?id=1013047