### PR TITLE
Fix product features read

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 13 13:47:51 UTC 2018 - igonzalezsosa@suse.com
+
+- Honor partitioning settings from product (bsc#1085755).
+- 4.0.46
+
+-------------------------------------------------------------------
 Tue Apr  3 10:43:16 UTC 2018 - jlopez@suse.com
 
 - Fix tests to use correct storage instance (part of fate#318196).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.45
+Version:        4.0.46
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -135,6 +135,9 @@ module Yast
       #
       Progress.NextStage
 
+      # Merging selected product
+      AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
+
       # configure general settings
       AutoinstGeneral.Import(Ops.get_map(Profile.current, "general", {}))
       Builtins.y2milestone(
@@ -356,9 +359,6 @@ module Yast
       return :abort if Popup.ConfirmAbort(:painless) if UI.PollInput == :abort
 
       Progress.NextStage
-
-      # Merging selected product
-      AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
 
       # Evaluating package and patterns selection.
       # Selection will stored in PackageAI.

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -85,7 +85,8 @@ module Yast
       general_settings.delete("btrfs_set_default_subvolume_name")
 
       # Override product settings from control file
-      Yast::ProductFeatures.SetSection("partitioning", general_settings)
+      control_settings = Yast::ProductFeatures.GetSection("partitioning") || {}
+      Yast::ProductFeatures.SetSection("partitioning", control_settings.merge(general_settings))
     end
 
     # Import Fstab data


### PR DESCRIPTION
* Read product features earlier.
* Merge (not replace) storage settings with `general/storage` values from the profile.

Fixes [bsc#1085755](https://bugzilla.suse.com/show_bug.cgi?id=1085755).