### PR TITLE
Install the module products also in AutoYaST autoupgrade (related to bsc#1086818)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 16 07:53:36 UTC 2018 - lslezak@suse.cz
+
+- Install the module products also in AutoYaST autoupgrade
+  (related to bsc#1086818 and bsc#1087206)
+- 4.0.47
+
+-------------------------------------------------------------------
 Fri Apr 13 13:47:51 UTC 2018 - igonzalezsosa@suse.com
 
 - Honor partitioning settings from product (bsc#1085755).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.46
+Version:        4.0.47
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autosetup_upgrade.rb
+++ b/src/clients/inst_autosetup_upgrade.rb
@@ -300,11 +300,8 @@ module Yast
       if !Update.did_init1
         Update.did_init1 = true
 
-        Pkg.PkgApplReset
-
         # bnc #300540
         # bnc #391785
-        # Drops packages after PkgApplReset, not before (that would null that)
         Update.DropObsoletePackages
 
         # make sure the packages needed for accessing the installation repository


### PR DESCRIPTION
## Fix for installing the products also in the AutoYaST autoupgrade mode

- We had a bug report that interactive upgrade did not install the products for new SLE15 modules: https://bugzilla.suse.com/show_bug.cgi?id=1086818
- I have found the very same issue also in the AutoYaST autoupgrade mode, see the screenshots below
- It turned out that the products were correctly selected by the registration module, but they were reset later by the AutoYaST autoupgrade code and lost
- This one liner patch removes that reset

### History

- This part of the code was [added 7 years ago](https://github.com/yast/yast-autoinstallation/commit/0a57dda918b1d0e820d783d6dde60c6d74c9d170#diff-66d4410704185b63421d5ab3f1d517f1R311) (looks like a copy&paste from `update_proposal.ycp` client)
- Originally the code stored the selected products and restored them after the reset, this is [still done even in SLE12-SP1](https://github.com/yast/yast-autoinstallation/blob/SLE-12-SP1/src/clients/inst_autosetup_upgrade.rb#L307-L319)
- However, in SLE12-SP2 it [has been removed](https://github.com/yast/yast-autoinstallation/commit/203c015620bbc34d759bdab05671035b7c4ebaab), the product selection was delegated to `Packages.SelectProduct` but the reset was kept.
- In the interactive upgrade we [still restore the products](https://github.com/yast/yast-update/blob/master/src/clients/update_proposal.rb#L422-L441) (BTW this is the code which was originally copy&pasted 7 years ago)

*In the end I came to the conclusion that we can remove the reset. If there is any reason to keep it  we would need to reselect the products later and that would be a bigger change than this one liner, so that's why I decided to go this simpler way.*

### Screenshots

Without the patch the module products added by the `scc_auto` client before are reset and the new SLE15 modules are not selected to install.
![sles12_autoupgrade_proposal_broken_products](https://user-images.githubusercontent.com/907998/38798145-0b6d5ca8-4161-11e8-808e-68e7366b000d.png)

After removing the reset the products are correctly selected to install.
![sles12_autoupgrade_proposal](https://user-images.githubusercontent.com/907998/38798185-25d1662a-4161-11e8-9028-01c4b92afdb5.png)
