### PR TITLE
Merge profiles: increase the default --maxdepth option

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 17 18:11:33 UTC 2018 - knut.anderssen@suse.com
+
+- AutoInstallRules: increased default maxdepth for not crashing
+  with a big software package list (bsc#1104655)
+- 4.0.60
+
+-------------------------------------------------------------------
 Fri Aug 17 09:46:05 CEST 2018 - schubi@suse.de
 
 - Installation/Update: Do not call registration if module

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.59
+Version:        4.0.60
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -896,12 +896,12 @@ module Yast
       merge_command =
         "#{MERGE_CMD} #{MERGE_DEFAULTS}" \
         "#{dontmerge_str} --param with \"'#{with}'\" " \
-        "--output #{to} " \
+        "--output \"#{to}\" " \
         "#{MERGE_XSLT_PATH} #{base_profile}"
 
       out = SCR.Execute(path(".target.bash_output"), merge_command, {})
-      Builtins.y2milestone("Merge command: #{merge_command}")
-      Builtins.y2milestone("Merge stdout: #{out["stdout"]}, stderr: #{out["stderr"]}")
+      log.info("Merge command: #{merge_command}")
+      log.info("Merge stdout: #{out["stdout"]}, stderr: #{out["stderr"]}")
       out
     end
 
@@ -915,11 +915,11 @@ module Yast
       skip = false
       error = false
       @tomerge.each do |file|
-        Builtins.y2milestone("Working on file: %1", file)
+        log.info("Working on file: %1", file)
         current_profile = File.join(AutoinstConfig.local_rules_location, file)
         if !skip
           if !XML_cleanup(current_profile, base_profile)
-            Builtins.y2error("Error reading XML file")
+            log.error("Error reading XML file")
             message = _(
               "The XML parser reported an error while parsing the autoyast profile. The error message is:\n"
             )
@@ -930,16 +930,16 @@ module Yast
         elsif !error
           xsltret = merge_profiles(base_profile, current_profile, merge_profile)
 
-          Builtins.y2milestone("Merge result: %1", xsltret)
+          log.info("Merge result: %1", xsltret)
           if xsltret["exit"] != 0 || xsltret.fetch("stderr", "") != ""
-            Builtins.y2error("Merge Failed")
-            StdErrLog(xsltret["stderr"])
+            log.error("Merge Failed")
+            StdErrLog(xsltret.fetch("stderr", ""))
             ok = false
           end
 
           XML_cleanup(merge_profile, base_profile)
         else
-          Builtins.y2error("Error while merging control files")
+          log.error("Error while merging control files")
         end
       end
 

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -7,6 +7,7 @@
 #
 # $Id$
 require "yast"
+require "yast2/popup"
 require "y2storage"
 
 module Yast
@@ -923,7 +924,8 @@ module Yast
             message = _(
               "The XML parser reported an error while parsing the autoyast profile. The error message is:\n"
             )
-            Popup.Error(message + XML.XMLError)
+            message += XML.XMLError
+            Yast2::Popup.show(message, headline: :error)
             error = true
           end
           skip = true

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -874,79 +874,70 @@ module Yast
       end
     end
 
+    #TODO: Move the responsibility of merging profiles to a specific class
+    # removing also the duplication of code between this module and the
+    # AutoinstClass one.
+
+    MERGE_CMD = "/usr/bin/xsltproc".freeze
+    MERGE_DEFAULTS = "--novalid --maxdepth 10000 --param replace \"'false'\"".freeze
+    MERGE_XSLT_PATH = "/usr/share/autoinstall/xslt/merge.xslt".freeze
+
+    # Merges the given profiles
+    #
+    # @param base_profile [String] the base profile file path
+    # @param with [String] the profile to be merged file path
+    # @param to [String] the resulting control file path
+    # @return [Hash] stdout and stderr output
+    def merge_profiles(base_profile, with, to)
+      dontmerge_str = ""
+      AutoinstConfig.dontmerge.each_with_index do |dm, i|
+        dontmerge_str << " --param dontmerge#{i+1} \"'#{dm}'\""
+      end
+      merge_command =
+        "#{MERGE_CMD} #{MERGE_DEFAULTS}" \
+        "#{dontmerge_str} --param with \"'#{with}'\" " \
+        "--output #{to} " \
+        "#{MERGE_XSLT_PATH} #{base_profile}"
+
+      out = SCR.Execute(path(".target.bash_output"), merge_command, {})
+      Builtins.y2milestone("Merge command: #{merge_command}")
+      Builtins.y2milestone("Merge stdout: #{out["stdout"]}, stderr: #{out["stderr"]}")
+      out
+    end
 
     # Merge Rule results
     # @param [String] result_profile the resulting control file path
     # @return [Boolean] true on success
     def Merge(result_profile)
-      tmpdir = AutoinstConfig.tmpDir
+      base_profile = File.join(AutoinstConfig.tmpdir, "base_profile.xml")
+      merge_profile = File.join(AutoinstConfig.tmpdir, "result.xml")
       ok = true
       skip = false
       error = false
-
-      base_profile = Ops.add(tmpdir, "/base_profile.xml")
-
-      Builtins.foreach(@tomerge) do |file|
+      @tomerge.each do |file|
         Builtins.y2milestone("Working on file: %1", file)
-        current_profile = Ops.add(
-          Ops.add(AutoinstConfig.local_rules_location, "/"),
-          file
-        )
+        current_profile = File.join(AutoinstConfig.local_rules_location, file)
         if !skip
-          if !XML_cleanup(current_profile, Ops.add(tmpdir, "/base_profile.xml"))
+          if !XML_cleanup(current_profile, base_profile)
             Builtins.y2error("Error reading XML file")
             message = _(
               "The XML parser reported an error while parsing the autoyast profile. The error message is:\n"
             )
-            message = Ops.add(message, XML.XMLError)
-            Popup.Error(message)
+            Popup.Error(message + XML.XMLError)
             error = true
           end
           skip = true
         elsif !error
-          _MergeCommand = "/usr/bin/xsltproc --novalid --param replace \"'false'\" "
-          dontmerge_str = ""
-          i = 1
-          Builtins.foreach(AutoinstConfig.dontmerge) do |dm|
-            dontmerge_str = Ops.add(
-              dontmerge_str,
-              Builtins.sformat(" --param dontmerge%1 \"'%2'\" ", i, dm)
-            )
-            i = Ops.add(i, 1)
-          end
-          _MergeCommand = Ops.add(_MergeCommand, dontmerge_str)
+          xsltret = merge_profiles(base_profile, current_profile, merge_profile)
 
-          _MergeCommand = Ops.add(_MergeCommand, "--param with ")
-          _MergeCommand = Ops.add(
-            Ops.add(Ops.add(_MergeCommand, "\"'"), current_profile),
-            "'\"  "
-          )
-          _MergeCommand = Ops.add(
-            Ops.add(Ops.add(_MergeCommand, "--output "), tmpdir),
-            "/result.xml"
-          )
-          _MergeCommand = Ops.add(
-            _MergeCommand,
-            " /usr/share/autoinstall/xslt/merge.xslt "
-          )
-          _MergeCommand = Ops.add(Ops.add(_MergeCommand, base_profile), " ")
-
-          Builtins.y2milestone("Merge command: %1", _MergeCommand)
-          xsltret = Convert.to_map(
-            SCR.Execute(path(".target.bash_output"), _MergeCommand)
-          )
           Builtins.y2milestone("Merge result: %1", xsltret)
-          if Ops.get_integer(xsltret, "exit", -1) != 0 ||
-              Ops.get_string(xsltret, "stderr", "") != ""
+          if xsltret["exit"] != 0 || xsltret.fetch("stderr", "") != ""
             Builtins.y2error("Merge Failed")
-            StdErrLog(Ops.get_string(xsltret, "stderr", ""))
+            StdErrLog(xsltret["stderr"])
             ok = false
           end
 
-          XML_cleanup(
-            Ops.add(tmpdir, "/result.xml"),
-            Ops.add(tmpdir, "/base_profile.xml")
-          )
+          XML_cleanup(merge_profile, base_profile)
         else
           Builtins.y2error("Error while merging control files")
         end
@@ -954,14 +945,7 @@ module Yast
 
       return !error if error
 
-      SCR.Execute(
-        path(".target.bash"),
-        Ops.add(
-          Ops.add(Ops.add("cp ", tmpdir), "/base_profile.xml "),
-          result_profile
-        )
-      )
-
+      SCR.Execute(path(".target.bash"), "cp #{base_profile} #{result_profile}")
       Builtins.y2milestone("Ok=%1", ok)
       @dontmergeIsDefault = true
       AutoinstConfig.dontmerge = deep_copy(@dontmergeBackup)

--- a/src/modules/AutoinstClass.rb
+++ b/src/modules/AutoinstClass.rb
@@ -112,6 +112,9 @@ module Yast
       nil
     end
 
+    MERGE_CMD = "/usr/bin/xsltproc".freeze
+    MERGE_DEFAULTS = "--novalid --maxdepth 10000 --param replace \"'false'\"".freeze
+
     # Merge classes
     #
     def MergeClasses(configuration, base_profile, resultFileName)
@@ -120,7 +123,7 @@ module Yast
         dontmerge_str << " --param dontmerge#{i+1} \"'#{dm}'\" "
       end
       merge_command =
-        "/usr/bin/xsltproc --novalid --param replace \"'false'\" #{dontmerge_str} --param with " \
+        "#{MERGE_CMD} #{MERGE_DEFAULTS} #{dontmerge_str} --param with " \
         "\"'#{findPath(configuration["name"], configuration["class"])}'\"  " \
         "--output #{File.join(AutoinstConfig.tmpDir, resultFileName)}  " \
         "#{MERGE_XSLT_PATH} #{base_profile} "

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -221,7 +221,7 @@ describe "Yast::AutoInstallRules" do
     let(:xsltproc_command) {
       "/usr/bin/xsltproc --novalid --maxdepth 10000 --param replace \"'false'\" " \
       "--param with \"'#{to_merge_path}'\" "\
-      "--output #{output_path} " \
+      "--output \"#{output_path}\" " \
       "#{merge_xslt_path} #{base_profile_path}"
     }
 
@@ -267,7 +267,7 @@ describe "Yast::AutoInstallRules" do
         "/usr/bin/xsltproc --novalid --maxdepth 10000 --param replace \"'false'\" " \
         "--param dontmerge1 \"'partition'\" " \
         "--param with \"'#{to_merge_path}'\" "\
-        "--output #{output_path} " \
+        "--output \"#{output_path}\" " \
         "#{merge_xslt_path} #{base_profile_path}"
       }
 

--- a/test/AutoinstClass_test.rb
+++ b/test/AutoinstClass_test.rb
@@ -222,7 +222,7 @@ describe "Yast::AutoinstClass" do
     let(:merge_xslt_path) { File.join(ROOT_PATH, 'xslt', 'merge.xslt') }
     let(:conf_to_merge) { { "class" => "swap", "name" => "largeswap.xml" } }
     let(:xsltproc_command) {
-      "/usr/bin/xsltproc --novalid --param replace \"'false'\"  " \
+      "/usr/bin/xsltproc --novalid --maxdepth 10000 --param replace \"'false'\"  " \
       "--param with \"'#{subject.findPath("largeswap.xml", "swap")}'\"  "\
       "--output #{File.join(tmp_dir, "output.xml")}  " \
       "#{merge_xslt_path} #{base_profile_path} "
@@ -267,7 +267,7 @@ describe "Yast::AutoinstClass" do
       let(:expected_xml_path) { File.join(ROOT_PATH, 'test', 'fixtures', 'output', 'partitions-dontmerge.xml')  }
       let(:dontmerge) { ['partition'] }
       let(:xsltproc_command) {
-        "/usr/bin/xsltproc --novalid --param replace \"'false'\"  " \
+        "/usr/bin/xsltproc --novalid --maxdepth 10000 --param replace \"'false'\"  " \
         "--param dontmerge1 \"'partition'\"  " \
         "--param with \"'#{subject.findPath("largeswap.xml", "swap")}'\"  "\
         "--output #{File.join(tmp_dir, "output.xml")}  " \


### PR DESCRIPTION
- Trello Card: https://trello.com/c/6mrdmQ1R/194-l3-bug-1104655-autoyast-error-on-merging-profiles-rules
- https://bugzilla.suse.com/show_bug.cgi?id=1104655

There have been some changes in the xslt libraries regarding to the recursion detection which probably are also the source of this bug as we can see in link below:

https://build.opensuse.org/package/rdiff/devel:libraries:c_c++/libxslt?linkrev=base&rev=65

I have just cleaned up a little bit the method with the merge responsibility mostly as it was cleaned for Classes handling.