### PR TITLE
Export partition_type when cloning

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 28 15:01:36 UTC 2018 - igonzalezsosa@suse.com
+
+- Always export the partition_type for MS-DOS partition tables
+  (bsc#1091415).
+- 3.2.30
+
+-------------------------------------------------------------------
 Thu Feb  1 12:59:08 CET 2018 - schubi@suse.de
 
 - Report packages which cannot be select for installation

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.29
+Version:        3.2.30
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstPartPlan.rb
+++ b/src/modules/AutoinstPartPlan.rb
@@ -426,9 +426,9 @@ module Yast
               Ops.set(new_pe, "create", false)
             end
           end
-          if Builtins.haskey(pe, "type") &&
-              Ops.get_symbol(pe, "type", :x) == :primary
-            Ops.set(new_pe, "partition_type", "primary") # can we always copy that element?
+          # Consider the partition type when dealing with 'msdos' partition tables (bsc#1091415)
+          if Builtins.haskey(pe, "type") && v["label"] == "msdos"
+            Ops.set(new_pe, "partition_type", pe["type"].to_s)
           end
           if Builtins.haskey(pe, "region") &&
               Ops.get_boolean(new_pe, "create", true) == true

--- a/src/modules/AutoinstPartition.rb
+++ b/src/modules/AutoinstPartition.rb
@@ -27,33 +27,34 @@ module Yast
       # defines data structur of a partition
       # provides types for type checking
       @fields = {
-        "crypt"        => "",
-        "crypt_fs"     => false,
-        "crypt_key"    => "",
-        "create"       => true,
-        "mount"        => "/",
-        "fstopt"       => "",
-        "label"        => "",
-        "loop_fs"      => false,
-        "uuid"         => "",
-        "size"         => "10G",
-        "format"       => true,
-        "filesystem"   => Partitions.DefaultFs,
-        "mkfs_options" => "",
-        "partition_nr" => 1,
-        "partition_id" => 131,
-        "mountby"      => :device,
-        "resize"       => false,
-        "lv_name"      => "",
-        "stripes"      => 1,
-        "stripesize"   => 4,
-        "lvm_group"    => "",
-        "raid_name"    => "",
-        "raid_type"    => "",
-        "raid_options" => {},
-        "subvolumes"   => [],
-        "pool"         => false,
-        "used_pool"    => ""
+        "crypt"          => "",
+        "crypt_fs"       => false,
+        "crypt_key"      => "",
+        "create"         => true,
+        "mount"          => "/",
+        "fstopt"         => "",
+        "label"          => "",
+        "loop_fs"        => false,
+        "uuid"           => "",
+        "size"           => "10G",
+        "format"         => true,
+        "filesystem"     => Partitions.DefaultFs,
+        "mkfs_options"   => "",
+        "partition_nr"   => 1,
+        "partition_id"   => 131,
+        "mountby"        => :device,
+        "resize"         => false,
+        "lv_name"        => "",
+        "stripes"        => 1,
+        "stripesize"     => 4,
+        "lvm_group"      => "",
+        "partition_type" => "",
+        "pool"           => false,
+        "raid_name"      => "",
+        "raid_type"      => "",
+        "raid_options"   => {},
+        "subvolumes"     => [],
+        "used_pool"      => ""
       }
 
       @allfs = {}
@@ -293,11 +294,16 @@ module Yast
         newPart = Builtins.remove(newPart, "pool")
       end
       newPart = set(newPart, "loop_fs", Ops.get_boolean(part, "loop_fs", false))
-      if part.has_key?("partition_id")
+      if part.key?("partition_id")
         newPart["partition_id"] = part["partition_id"]
       else
         #removing default entry
         newPart.delete("partition_id")
+      end
+      if part.key?("partition_type")
+        newPart = set(newPart, "partition_type", part["partition_type"].to_s)
+      else
+        newPart.delete("partition_type")
       end
       newPart = set(newPart, "size", Ops.get_string(part, "size", ""))
       newPart = set(newPart, "lv_name", Ops.get_string(part, "lv_name", ""))

--- a/test/AutoinstPartPlan_test.rb
+++ b/test/AutoinstPartPlan_test.rb
@@ -87,5 +87,23 @@ describe "Yast::AutoinstPartPlan" do
       snapshots = subvolumes.select { |s| s.include?("snapshot") }
       expect(snapshots).to be_empty
     end
+
+    context "when the drive has a msdos partition" do
+      it "includes the partition_type" do
+        exported = subject.Export
+        partition = exported.first["partitions"].first
+        expect(partition).to include("partition_type" => "primary")
+      end
+    end
+
+    context "when the drive has a non-msdos partition" do
+      let(:target_map) { YAML.load_file(File.join(FIXTURES_PATH, "storage", "target_clone.yml")) }
+
+      it "does not include the partition_type" do
+        exported = subject.Export
+        partition = exported.first["partitions"].first
+        expect(partition).to_not have_key("partition_type")
+      end
+    end
   end
 end

--- a/test/AutoinstPartition_test.rb
+++ b/test/AutoinstPartition_test.rb
@@ -44,5 +44,27 @@ describe "Yast::AutoinstPartition" do
         end
       end
     end
+
+    context "when a partition_type is present" do
+      let(:partition) do
+        { "mount" => "/", "partition_type" => "primary" }
+      end
+
+      it "exports the partition type" do
+        parsed = subject.parsePartition(partition)
+        expect(parsed["partition_type"]).to eq("primary")
+      end
+    end
+
+    context "when a partition_type is not present" do
+      let(:partition) do
+        { "mount" => "/" }
+      end
+
+      it "ignores the partition_type" do
+        parsed = subject.parsePartition(partition)
+        expect(parsed).to_not have_key("partition_type")
+      end
+    end
   end
 end


### PR DESCRIPTION
In SLE 12, the `partition_type` element is ignored when exporting unless it is `primary` (?). It causes problems like [bsc#1091415](https://bugzilla.suse.com/show_bug.cgi?id=1091415). With this change, AutoYaST will always export the `partition_type` when using a MS-DOS partition table.