### PR TITLE
Avoid to crash when profile has a not valid sofware section

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 22 16:40:30 UTC 2019 - dgonzalez@suse.com
+
+- Avoid to crash when the profile has a not valid sofware section
+  (bsc#1125959).
+- 4.1.2
+
+-------------------------------------------------------------------
 Tue Feb 12 13:50:19 CET 2019 - schubi@suse.de
 
 - Reading IPv6 setting in order to initialize it correctly.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -180,10 +180,15 @@ module Yast
     # @param profile [Hash] AutoYaST profile
     # @return [String] product name
     def base_product_name(profile)
-      software = profile["software"] || {}
-      products = software["products"] || []
+      software = profile["software"]
 
-      products.first
+      if software.nil?
+        log.info("Error: given profile has not a valid software section")
+
+        return nil
+      end
+
+      software.fetch("products", []).first
     end
   end
 

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -136,7 +136,7 @@ module Yast
     # @return [Y2Packager::Product] a product if exactly one product matches
     # the criteria, nil otherwise
     def identify_product_by_patterns(profile)
-      software = profile.fetch("software", {})
+      software = profile["software"] || {}
 
       identify_product do |product|
         software.fetch("patterns", []).any? { |p| p =~ /#{product.name.downcase}-.*/ }
@@ -151,7 +151,7 @@ module Yast
     # @return [Y2Packager::Product] a product if exactly one product matches
     # the criteria, nil otherwise
     def identify_product_by_packages(profile)
-      software = profile.fetch("software", {})
+      software = profile["software"] || {}
 
       identify_product do |product|
         software.fetch("packages", []).any? { |p| p =~ /#{product.name.downcase}-release/ }
@@ -180,8 +180,10 @@ module Yast
     # @param profile [Hash] AutoYaST profile
     # @return [String] product name
     def base_product_name(profile)
-      software = profile.fetch("software", {})
-      software.fetch("products", []).first
+      software = profile["software"] || {}
+      products = software["products"] || []
+
+      products.first
     end
   end
 

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -177,4 +177,12 @@ describe Yast::AutoinstFunctions do
       expect(subject.selected_product.name).to eql "SLED"
     end
   end
+
+  it "does not crash when there is not a software section" do
+      allow(Yast::Profile)
+        .to receive(:current)
+        .and_return("software" => nil)
+
+      expect(subject.selected_product).to be_nil
+  end
 end

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -176,13 +176,23 @@ describe Yast::AutoinstFunctions do
 
       expect(subject.selected_product.name).to eql "SLED"
     end
-  end
 
-  it "does not crash when there is not a software section" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return("software" => nil)
+    context "when there is not a valid software section" do
+      before do
+        allow(Yast::Profile)
+          .to receive(:current)
+          .and_return("software" => nil)
+      end
 
-      expect(subject.selected_product).to be_nil
+      it "returns nil" do
+        expect(subject.selected_product).to be_nil
+      end
+
+      it "logs a message" do
+        expect(subject.log).to receive(:info).at_least(1).with(/not a valid software section/)
+
+        subject.selected_product
+      end
+    end
   end
 end


### PR DESCRIPTION
### Problem

https://bugzilla.opensuse.org/show_bug.cgi?id=1125959

> AutoinstFunction#base_product_name was crashing when given profile had
not a valid `software` section, which could happen due to several
reasons. For example, a not valid XML syntax or simply a user oversight.
>
> It was failing with
>
>> undefined method 'fetch' for nil:NilClass"

### Why?

Because the `Profile.current` had a `nil` value for the `software` key.

### Solution

Use `hsh["key"] || default_value` instead `hsh.fetch("key", default_value)`.

Also added a `log.info` to easy the debugging process.

### Testing

Added an expectation to the current test.

