### PR TITLE
Remove available devices check

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr  2 10:32:53 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Removed check for available devices. When there are no devices,
+  the proposal issues will be shown (needed for bsc#1130256).
+- 4.0.68
+
+-------------------------------------------------------------------
 Wed Jan 30 15:14:25 CET 2019 - schubi@suse.de
 
 - Fixed conflicting items in rule dialogs (bsc#1123091).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.67
+Version:        4.0.68
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/autoinstall/storage_proposal.rb
+++ b/src/lib/autoinstall/storage_proposal.rb
@@ -119,6 +119,7 @@ module Y2Autoinstallation
     # @return [Y2Storage::GuidedProposal]
     def guided_proposal
       log.info "Creating a guided proposal"
+      # TODO: add specific issue when proposal fails because there are no devices
       Y2Storage::GuidedProposal.initial
     end
 

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -57,7 +57,7 @@ module Yast
     # @return [Boolean] success
     def Import(settings)
       log.info "entering Import with #{settings.inspect}"
-      return false unless available_storage?
+
       partitioning = preprocessed_settings(settings)
       return false unless partitioning
 
@@ -322,20 +322,6 @@ module Yast
       preprocessor = Y2Autoinstallation::PartitioningPreprocessor.new
       preprocessor.run(settings)
     end
-
-    # Determine (and warn the user) no storage is available for installation
-    #
-    # @return [Boolean] true if there are devices for installation; false otherwise.
-    def available_storage?
-      probed = Y2Storage::StorageManager.instance.probed
-      return true if probed && !probed.empty?
-      Yast::Popup.Error(
-        _("No storage devices were found for the installation.\n" \
-          "Please, check your hardware or your AutoYaST profile.")
-      )
-      false
-    end
-
   end
 
   AutoinstStorage = AutoinstStorageClass.new

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -191,37 +191,6 @@ describe Yast::AutoinstStorage do
           subject.Import({})
         end
       end
-
-    end
-
-    context "when there are no available storage for installation" do
-      before do
-        allow(probed_devicegraph).to receive(:empty?).and_return(true)
-      end
-
-      it "displays an error" do
-        expect(Yast::Popup).to receive(:Error).with(/No storage devices/)
-        subject.Import({})
-      end
-
-      it "returns false" do
-        expect(subject.Import({})).to eq(false)
-      end
-    end
-
-    context "when the probed devicegraph is nil" do
-      before do
-        allow(storage_manager).to receive(:probed).and_return(nil)
-      end
-
-      it "displays an error" do
-        expect(Yast::Popup).to receive(:Error).with(/No storage devices/)
-        subject.Import({})
-      end
-
-      it "returns false" do
-        expect(subject.Import({})).to eq(false)
-      end
     end
   end
 


### PR DESCRIPTION
## Problem

An error is reported when trying to install over a diskless system. But in case of root over NFS, the installation could still be performed (even when the system has no physical disks at all).

Current error should not appear when the profile indicates root over NFS.

* Needed for: https://bugzilla.suse.com/show_bug.cgi?id=1130256
* PBI: https://trello.com/c/x4LYDnwe/865-3-l3-important-bug-1130256-autoyast-for-a-nfs-root-fails-at-partitioning
* Related PR: https://github.com/yast/yast-storage-ng/pull/884

## Solution

Remove current check completely, so only proposal issues will be shown when a proposal is not possible.

## Testing

* Added unit tests
* Tested manually