### PR TITLE
Uninstall the "SUSE-Manager-Proxy" product (bsc#1133215)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 29 11:34:37 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Uninstall the "SUSE-Manager-Proxy" product when upgrading from
+  SLES12 + SUMA Proxy + SUMA Branch Server (bsc#1133215)
+- 4.1.6
+
+-------------------------------------------------------------------
 Tue Apr  2 10:32:53 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Removed check for available devices. When there are no devices,

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.1.5
+Version:        4.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -60,8 +60,8 @@ BuildRequires:  systemd
 
 Requires:       autoyast2-installation = %{version}
 Requires:       libxslt
-# Yast::Popup.ErrorAnyQuestion fixed
-Requires:       yast2 >= 4.0.60
+# Y2Packager::ProductUpgrade.remove_obsolete_upgrades
+Requires:       yast2 >= 4.1.69
 Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
 Requires:       yast2-ntp-client >= 4.0.1

--- a/src/clients/inst_autosetup_upgrade.rb
+++ b/src/clients/inst_autosetup_upgrade.rb
@@ -9,6 +9,8 @@
 # $Id: inst_autosetup.ycp 61521 2010-03-29 09:10:07Z ug $
 require "autoinstall/autosetup_helpers"
 
+require "y2packager/product_upgrade"
+
 module Yast
   class InstAutosetupUpgradeClient < Client
     include Yast::Logger
@@ -359,6 +361,10 @@ module Yast
         Builtins.foreach(@remove_products) do |p|
           Pkg.ResolvableRemove(p, :product)
         end
+
+        # deselect the upgraded obsolete products (bsc#1133215)
+        Y2Packager::ProductUpgrade.remove_obsolete_upgrades
+
         Builtins.foreach(@patterns) { |p| Pkg.ResolvableInstall(p, :pattern) }
         Builtins.foreach(@packages) { |p| Pkg.ResolvableInstall(p, :package) }
         Builtins.foreach(@products) { |p| Pkg.ResolvableInstall(p, :product) }


### PR DESCRIPTION
...when upgrading from SLES12 + SUMA Proxy + SUMA Branch Server

- Similar to https://github.com/yast/yast-update/pull/124, just for the AutoYaST autoupgrade
- Tested manually
- 4.1.6