### PR TITLE
Re-probe storage devices

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 17 13:33:11 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Always perform a storage re-probe after executing pre-scripts.
+- Related to bsc#1133045
+- 4.2.3
+
+-------------------------------------------------------------------
 Mon Jun 10 14:11:02 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Add multi-device Btrfs related elements to the partitioning

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -1,5 +1,24 @@
 # encoding: utf-8
 
+# Copyright (c) [2013-2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 # File:    clients/inst_autosetup.ycp
 # Package: Auto-installation
 # Summary: Setup and prepare system for auto-installation
@@ -263,7 +282,6 @@ module Yast
       # moved here from autoinit for fate #301193
       # needs testing
       if Arch.s390
-        dasd_or_zfcp = Profile.current.key?("dasd") || Profile.current.key?("zfcp")
         if Builtins.haskey(Profile.current, "dasd")
           Builtins.y2milestone("dasd found")
           if Call.Function("dasd_auto", ["Import", Ops.get_map(Profile.current, "dasd", {})])
@@ -286,7 +304,11 @@ module Yast
 
       Progress.NextStage
 
-      probe_storage if modified_profile? || dasd_or_zfcp
+      # Pre-scripts can modify the AutoYaST profile. Even more, a pre-script could change the initial
+      # disks layout/configuration (e.g., by creating a new partition). It is difficult to evaluate
+      # whether a pre-script has modified something related to storage devices, so a re-probing is always
+      # performed here (related to bsc#1133045).
+      probe_storage
 
       if Profile.current["partitioning_advanced"] && !Profile.current["partitioning_advanced"].empty?
         write_storage = AutoinstStorage.ImportAdvanced(Profile.current["partitioning_advanced"])


### PR DESCRIPTION
## Problem

[AutoYaST pre-scripts](https://www.suse.com/documentation/sles-15/singlehtml/book_autoyast/book_autoyast.html#createprofile.scripts) can modify the storage configuration/layout. For example, a script might create new partitions.

A storage-reprobing is done after running the pre-scripts, but only if any pre-script modifies the control file, or there are Dasd or zfcp devices. As result, in some cases the storage changes performed by the pre-scripts are not reflected in the devicegraph tree.

* https://bugzilla.suse.com/show_bug.cgi?id=1133045
* https://trello.com/c/3re8LvvF/1049-autoyast-hw-probing-behavior-vs-scripts
* Related cards:
  * https://trello.com/c/fcaAfYJQ/944-3-l3-autoyast-installation-fails-with-error-during-the-create-partition-plans-phase
  * https://trello.com/c/eBhbiEbw/979-sle15-sp2-review-when-pre-scripts-are-executed
 
## Solution

There is not a clear reason to avoid a re-probing under certain circumstances (e.g., we have no reports about performance penalty). So now on, a storage re-probe is always performed after all pre-scripts are executed.

![Screenshot from 2019-06-18 15-10-21](https://user-images.githubusercontent.com/1112304/59692647-54527200-91dd-11e9-805d-eacec73d513a.png)

