### PR TITLE
Allow to enable snappots when installing on Software RAID

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 16 10:28:46 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Added support for enabling snapper when installing over a
+  Software RAID (bsc#1135083).
+- 3.2.32.4
+
+-------------------------------------------------------------------
 Wed May 15 13:49:43 CEST 2019 - schubi@suse.de
 
 - Semi-automatic with partition: Do not use the common AY partition

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.32.3
+Version:        3.2.32.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstRAID.rb
+++ b/src/modules/AutoinstRAID.rb
@@ -220,10 +220,16 @@ module Yast
             []
           )
         )
+
+        if AutoinstStorage.root_btrfs?(md)
+          AutoinstStorage.configure_root_btrfs(md, device: "/dev/md", data: @raid["/dev/md"])
+        end
+
         Builtins.union(md, options)
       end
 
       allraid = []
+
       if Ops.greater_than(
           Builtins.size(
             Ops.get_list(@ExistingRAID, ["/dev/md", "partitions"], [])
@@ -237,6 +243,7 @@ module Yast
       else
         allraid = deep_copy(_RaidList)
       end
+
       Builtins.y2milestone("All RAID: %1", allraid)
 
 

--- a/test/AutoinstStorage_test.rb
+++ b/test/AutoinstStorage_test.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "AutoinstStorage"
+
+describe "Yast::AutoinstStorage" do
+  subject { Yast::AutoinstStorage }
+
+  let(:partition1) { { "mount" => "/", "used_fs" => root_fs } }
+
+  let(:partition2) { { "mount" => "/home", "used_fs" => :xfs } }
+
+  let(:partition3) { { "mount" => "swap", "used_fs" => :swap } }
+
+  let(:root_fs) { :btrfs }
+
+  describe "#find_root_btrfs" do
+    context "when there is no root partition" do
+      let(:partitions) { [partition2, partition3] }
+
+      it "returns nil" do
+        puts "aaa"
+        expect(subject.find_root_btrfs(partitions)).to be_nil
+      end
+    end
+  end
+
+  describe "#parsePartition" do
+    let(:filesystem) { :btrfs }
+    let(:subvolumes) do
+      [
+        { "path" => ".snapshots/1" },
+        { "path" => "var/lib/machines" }
+      ]
+    end
+
+    let(:partition) do
+      { "filesystem" => filesystem, "subvolumes" => subvolumes }
+    end
+
+    it "filters out snapper snapshots" do
+      parsed = subject.parsePartition(partition)
+      expect(parsed["subvolumes"]).to eq(
+        [{ "path" => "var/lib/machines" }]
+      )
+    end
+
+    context "when there are no Btrfs subvolumes" do
+      let(:subvolumes) { [] }
+
+      it "exports them as an empty array" do
+        parsed = subject.parsePartition(partition)
+        expect(parsed["subvolumes"]).to eq([])
+      end
+
+      context "and filesystem is not Btrfs" do
+        let(:filesystem) { :ext4 }
+
+        it "does not export the subvolumes list" do
+          parsed = subject.parsePartition(partition)
+          expect(parsed).to_not have_key("subvolumes")
+        end
+      end
+    end
+
+    context "when a partition_type is present" do
+      let(:partition) do
+        { "mount" => "/", "partition_type" => "primary" }
+      end
+
+      it "exports the partition type" do
+        parsed = subject.parsePartition(partition)
+        expect(parsed["partition_type"]).to eq("primary")
+      end
+    end
+
+    context "when a partition_type is not present" do
+      let(:partition) do
+        { "mount" => "/" }
+      end
+
+      it "ignores the partition_type" do
+        parsed = subject.parsePartition(partition)
+        expect(parsed).to_not have_key("partition_type")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When installing root over a Software RAID, snapper is not configured.

This is not a bug exactly, but a missing feature. The `AutoinstRAID` module has no support for enabling snapper.

* https://trello.com/c/JrY23Q8q/1090-3-sles12-sp34-1135083-snapper-does-not-get-setup-via-autoyast-for-btrfs-root-on-mdraid1
* https://bugzilla.suse.com/show_bug.cgi?id=1135083

## Solution

Added support for enabling snapper when installing over a Software RAID.

## Tests

* Manually tested
* Added unit tests

## Screenshots

<details>
<summary>Click to show/hide</summary>

![VirtualBox_SLE-12-SP3_15_07_2019_13_01_08](https://user-images.githubusercontent.com/1112304/61289135-8943eb80-a7c0-11e9-859e-1e885a8fe1cd.png)


![VirtualBox_SLE-12-SP3_15_07_2019_13_02_16](https://user-images.githubusercontent.com/1112304/61288801-ceb3e900-a7bf-11e9-8294-410d0a97b3f4.png)

</details>
