### PR TITLE
Fix autoyast_mini in openQA (bsc#1140339)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 18 14:49:00 UTC 2019 - Martin Vidner <mvidner@suse.com>
+
+- Fixed an Internal Error when AutoYaST is importing users and
+  groups configuration (bsc#1140339).
+- 4.2.5
+
+-------------------------------------------------------------------
 Wed Jul  3 09:55:40 CEST 2019 - schubi@suse.de
 
 - Fixed new desktop file name (bsc#1138144).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -480,7 +480,7 @@ module Yast
     # Import Users configuration from profile
     def autosetup_users
       users_config = ModuleConfigBuilder.build(
-        Y2ModuleConfig.getModuleConfig("org.opensuse.yast.Users"), Profile.current)
+        Y2ModuleConfig.getModuleConfig("users"), Profile.current)
       if users_config
         Profile.remove_sections(users_config.keys)
         Call.Function("users_auto", ["Import", users_config])


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1140339
- https://trello.com/c/KKCZS798

I have tested the fix manually.

The bug was in not knowing what form a *name* should take. Whenever something has the `String` type, things can go wrong.