### PR TITLE
Add missing 'uuid' element

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug  2 15:58:25 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add missing 'uuid' element to the partition sections
+  (boo#1144007).
+- 4.2.6
+
+-------------------------------------------------------------------
 Thu Jul 18 15:05:10 UTC 2019 - Jan Engelhardt <jengelh@inai.de>
 
 - Use modern tar syntax

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -57,6 +57,7 @@ y2_partition =
   | part_fs_options
   | part_fstopt
   | part_label
+  | part_uuid
   | part_loop_fs
   | part_lv_name
   | part_lvm_group
@@ -164,6 +165,7 @@ create_subvolumes =
 
 part_fstopt = element fstopt { text }
 part_label = element label { text }
+part_uuid = element uuid { text }
 part_loop_fs =
   element loop_fs { BOOLEAN }
 part_mount = element mount { text }


### PR DESCRIPTION
Partially fixes [boo#1144007](https://bugzilla.suse.com/show_bug.cgi?id=1144007).

This change could be backported to SLE-15-GA and SLE-15-SP1.