### PR TITLE
Do not reduce thin LVs to disk size (bug#1148918)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  2 10:03:33 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Do not try to reduce the size of thin logical volumes to make
+  them fit in the physical disk (bsc#1148918).
+- 3.2.37
+
+-------------------------------------------------------------------
 Tue Jul 16 10:28:46 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Added support for enabling snapper when installing over a

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.36
+Version:        3.2.37
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1148918. AutoYaST is trying to reduce the size of the thin LVs to make them fit into the size of the physical disk where the LVM thin pool is located. That's exactly the opposed of the thin provisioning idea, in which LVs can be "over-committed"

Manually tested by @dgdavid 

Unit tests not added because the whole `AutoinstLVM` module is untested.

<details>
<summary>Click to show/hide screenshots</summary>

---

<p align="center">Before</p>

![Screenshot_sles12sp4-lvm10l3_without_selfupdates](https://user-images.githubusercontent.com/1691872/64112739-2f06e600-cd80-11e9-9919-1fb0f4a4ad2d.png)

---

<p align="center">After</p>

![Screenshot_sles12sp4-lvm10l3_2019-09-02_12:48:42](https://user-images.githubusercontent.com/1691872/64112759-404ff280-cd80-11e9-82c9-d4f38c2ee31a.png)

</details>
