### PR TITLE
Fix version number. 3.2.37 already exists in SLE-12-SP5

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -3,7 +3,7 @@ Mon Sep  2 10:03:33 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Do not try to reduce the size of thin logical volumes to make
   them fit in the physical disk (bsc#1148918).
-- 3.2.37
+- 3.2.36.1
 
 -------------------------------------------------------------------
 Tue Jul 16 10:28:46 UTC 2019 - José Iván López González <jlopez@suse.com>

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.37
+Version:        3.2.36.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
When creating #522 I didn't realize SP4 and SP5 had diverged already and there was already a different 3.2.37 in SLE-15-SP5.