### PR TITLE
Do not run the registration step twice (bsc#1153293)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 16 11:36:17 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not run the registration step again in the installed system
+  (in the 2nd stage after reboot) (bsc#1153293)
+- 4.2.11
+
+-------------------------------------------------------------------
 Tue Oct 15 11:37:54 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix dependency for autoyast2-installation (bsc#1131235)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -58,6 +58,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
       allow_any_instance_of(Y2Autoinstallation::AutosetupHelpers).to receive(
         :registration_module_available?).and_return(reg_module_available)
       allow(Yast::Profile).to receive(:current).and_return(profile_content)
+      allow(Yast::Profile).to receive(:remove_sections).with("suse_register")
     end
 
     context "yast2-register is not available" do
@@ -98,6 +99,12 @@ describe Y2Autoinstallation::AutosetupHelpers do
 
         it "downloads release notes" do
           expect(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes")
+          client.suse_register
+        end
+
+        # bsc#1153293
+        it "removes the registration section to not run in again in the 2nd stage" do
+          expect(Yast::Profile).to receive(:remove_sections).with("suse_register")
           client.suse_register
         end
 

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -103,7 +103,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
         end
 
         # bsc#1153293
-        it "removes the registration section to not run in again in the 2nd stage" do
+        it "removes the registration section to not run it again in the 2nd stage" do
           expect(Yast::Profile).to receive(:remove_sections).with("suse_register")
           client.suse_register
         end


### PR DESCRIPTION
- Do not run registration again in the 2nd stage, running it in the 1st stage is enough :wink:
- https://bugzilla.suse.com/show_bug.cgi?id=1153293
- Tested manually with the AY profile attached in bugzilla
  - Before applying the fix the registration was called again in the 2nd stage
  - After applying the fix it was called only once in the 1st stage
- Added an unit test for this
- 4.2.11