### PR TITLE
Run all unit tests in "make check"

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -11,20 +11,26 @@ TESTS = \
     AutoinstGeneral_test.rb \
     AutoinstPartPlan_test.rb \
     AutoinstSoftware_test.rb \
-    ProfileLocation_test.rb  \
-    autoinst_storage_test.rb \
-    profile_test.rb \
+    ProfileLocation_test.rb \
     Y2ModuleConfig_test.rb \
+    autoinst_storage_test.rb \
     include/ask_test.rb \
     lib/activate_callbacks_test.rb \
-    lib/module_config_builder_test.rb \
-    lib/pkg_gpg_check_handler_test.rb \
-    lib/partitioning_preprocessor_test.rb \
-    lib/storage_proposal_issues_presenter_test.rb \
-    lib/storage_proposal_test.rb \
+    lib/autoinst_issues/invalid_value_test.rb \
+    lib/autoinst_issues/issue_test.rb \
+    lib/autoinst_issues/list_test.rb \
+    lib/autoinst_issues/missing_value_test.rb \
+    lib/autoinst_issues_presenter_test.rb \
+    lib/autosetup_helpers_test.rb \
     lib/clients/ayast_probe_test.rb \
     lib/dialogs/disk_selector_test.rb \
-    lib/dialogs/question_test.rb
+    lib/dialogs/question_test.rb \
+    lib/module_config_builder_test.rb \
+    lib/partitioning_preprocessor_test.rb \
+    lib/pkg_gpg_check_handler_test.rb \
+    lib/storage_proposal_issues_presenter_test.rb \
+    lib/storage_proposal_test.rb \
+    profile_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec


### PR DESCRIPTION
- Some tests were not specified in the `Makefile.am` and thus not run during `make check` which is run during RPM build.