### PR TITLE
Display error when using the online medium without registration (bsc#1154988)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct 25 11:55:01 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not crash when using the online medium without the
+  registration section in the AY XML profile, display an error
+  message with some hints (bsc#1154988)
+- 4.2.13
+
+-------------------------------------------------------------------
 Fri Oct 18 14:03:27 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - AutoYaST support for the OnlineOnly installation medium

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoinit.rb
+++ b/src/clients/inst_autoinit.rb
@@ -96,8 +96,21 @@ module Yast
       # register the system earlier because the medium does not contain any
       # repositories, we need the repositories from the registration server
       # TODO: maybe we will need it also in the autoupgrade case...
-      if Y2Packager::MediumType.online? && !Mode.autoupgrade
-        suse_register
+      if Y2Packager::MediumType.online?
+        # check that the registration section is defined and registration is enabled
+        reg_section = Yast::Profile.current.fetch(REGISTER_SECTION, {})
+        reg_enabled = reg_section["do_registration"]
+
+        if !reg_enabled
+          msg = _("Registration is mandatory when using the online " \
+            "installation medium. Enable registration in " \
+            "the AutoYaST profile.")
+          Popup.LongError(msg)  # No timeout because we are stopping the installation/upgrade.
+
+          return :abort
+        end
+
+        suse_register if !Mode.autoupgrade
       end
 
       if !(Mode.autoupgrade && AutoinstConfig.ProfileInRootPart)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1154988
- Do not crash when using the online medium without the registration section in the AY XML profile
- Display an error message with some hints.
- 4.2.13

### Screenshots

The original crash:

![ay_no_registration](https://user-images.githubusercontent.com/907998/67570281-3f5c9100-f731-11e9-8528-ef574273549b.png)

With the fix applied:

![ay_no_registration_fixed](https://user-images.githubusercontent.com/907998/67570293-471c3580-f731-11e9-913a-3d9cd729fcf9.png)

After pressing *OK* the installation aborts.