### PR TITLE
Fix bsc#1154855 - During firstboot ayast_setup will not be executed.

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 25 15:48:50 UTC 2019 - Peter Varkoly <varkoly@suse.com>
+
+- During firstboot ayast_setup will not be executed.
+  (bnc#1154855) 
+- 4.1.7
+
+-------------------------------------------------------------------
 Mon Apr 29 11:34:37 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Uninstall the "SUSE-Manager-Proxy" product when upgrading from

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/ayast_setup.rb
+++ b/src/clients/ayast_setup.rb
@@ -20,32 +20,23 @@
 #    configure your system like in the profile.
 #    Only stage2 configuration can be done.
 #    yast2 ./ayast_setup.rb setup filename=/tmp/my.xml
+
+require "autoinstall/clients/ayast_setup"
 module Yast
   class AyastSetupClient < Client
     include Yast::Logger
+    include Y2Autoinstall::Clients::AyastSetup
 
     def main
-      Yast.import "Pkg"
       textdomain "autoinst"
 
-      Builtins.y2milestone("----------------------------------------")
-      Builtins.y2milestone("ayast_setup started")
+      log.info("----------------------------------------")
+      log.info("ayast_setup started")
 
-      Yast.import "Profile"
-      Yast.import "Popup"
-      Yast.import "Wizard"
-      Yast.import "Mode"
       Yast.import "CommandLine"
-      Yast.import "Stage"
-      Yast.import "AutoInstall"
-      Yast.import "AutoinstSoftware"
-      Yast.import "PackageSystem"
-      Yast.import "AutoinstData"
-      Yast.import "Lan"
+      Yast.import "Mode"
 
       @dopackages = true
-
-
       @cmdline = {
         "id"         => "ayast_setup",
         "help"       => _(
@@ -78,9 +69,9 @@ module Yast
 
       @ret = CommandLine.Run(@cmdline)
 
-      Builtins.y2debug("ret = %1", @ret)
-      Builtins.y2milestone("----------------------------------------")
-      Builtins.y2milestone("ayast_setup finished")
+      log.debug("ret = #{@ret}")
+      log.info("----------------------------------------")
+      log.info("ayast_setup finished")
 
       nil
     end
@@ -91,86 +82,6 @@ module Yast
       :dummy
     end
 
-    def Setup
-      AutoInstall.Save
-      Wizard.CreateDialog
-      Mode.SetMode("autoinstallation")
-      Stage.Set("continue")
-
-      # IPv6 settings will be written despite the have been
-      # changed or not. So we have to read them at first.
-      # FIXME: Move it to Lan.rb and remove the Lan import dependency.
-      Lan.ipv6 = Lan.readIPv6
-
-      WFM.CallFunction("inst_autopost", [])
-      postPackages = Ops.get_list(
-        Profile.current,
-        ["software", "post-packages"],
-        []
-      )
-      postPackages = Builtins.filter(postPackages) do |p|
-        !PackageSystem.Installed(p)
-      end
-      AutoinstSoftware.addPostPackages(postPackages)
-
-      AutoinstData.post_patterns = Ops.get_list(
-        Profile.current,
-        ["software", "post-patterns"],
-        []
-      )
-
-      # the following is needed since 10.3
-      # otherwise the already configured network gets removed
-      if !Builtins.haskey(Profile.current, "networking")
-        Profile.current = Builtins.add(
-          Profile.current,
-          "networking",
-          { "keep_install_network" => true }
-        )
-      end
-
-      if @dopackages
-        Pkg.TargetInit("/", false)
-        WFM.CallFunction("inst_rpmcopy", [])
-      end
-      WFM.CallFunction("inst_autoconfigure", [])
-
-      # Restarting autoyast-initscripts.service in order to run
-      # init-scripts in the installed system.
-      cmd = "systemctl restart autoyast-initscripts.service"
-      ret = SCR.Execute(path(".target.bash_output"), cmd)
-      log.info "command \"#{cmd}\" returned #{ret}"
-      nil
-    end
-
-    def openFile(options)
-      options = deep_copy(options)
-      if Ops.get(options, "filename") == nil
-        CommandLine.Error(_("Path to AutoYaST profile must be set."))
-        return false
-      end
-      if Ops.get_string(options, "dopackages", "yes") == "no"
-        @dopackages = false
-      end
-      if SCR.Read(
-          path(".target.lstat"),
-          Ops.get_string(options, "filename", "")
-        ) == {} ||
-          !Profile.ReadXML(Ops.get_string(options, "filename", ""))
-        Mode.SetUI("commandline")
-        CommandLine.Print(
-          _(
-            "Error while parsing the control file.\n" +
-              "Check the log files for more details or fix the\n" +
-              "control file and try again.\n"
-          )
-        )
-        return false
-      end
-
-      Setup()
-      true
-    end
   end
 end
 

--- a/src/lib/autoinstall/clients/ayast_setup.rb
+++ b/src/lib/autoinstall/clients/ayast_setup.rb
@@ -1,0 +1,127 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+Yast.import "Profile"
+Yast.import "Wizard"
+Yast.import "Mode"
+Yast.import "CommandLine"
+Yast.import "Stage"
+Yast.import "AutoInstall"
+Yast.import "AutoinstSoftware"
+Yast.import "PackageSystem"
+Yast.import "AutoinstData"
+Yast.import "Lan"
+Yast.import "Pkg"
+
+
+module Y2Autoinstall
+  module Clients
+    module AyastSetup
+      include Yast::Logger    
+      Ops = Yast::Ops
+      SCR = Yast::SCR
+      WFM = Yast::WFM
+      Profile  = Yast::Profile
+      Builtins = Yast::Builtins
+      def Setup
+         Yast::AutoInstall.Save
+         Yast::Wizard.CreateDialog
+         Yast::Mode.SetMode("autoinstallation")
+         Yast::Stage.Set("continue")
+      
+         # IPv6 settings will be written despite the have been
+         # changed or not. So we have to read them at first.
+         # FIXME: Move it to Lan.rb and remove the Lan import dependency.
+         Yast::Lan.ipv6 = Yast::Lan.readIPv6
+      
+         WFM.CallFunction("inst_autopost", [])
+         postPackages = Ops.get_list(
+           Profile.current,
+           ["software", "post-packages"],
+           []
+         )
+         postPackages = Builtins.filter(postPackages) do |p|
+           !Yast::PackageSystem.Installed(p)
+         end
+         Yast::AutoinstSoftware.addPostPackages(postPackages)
+      
+         Yast::AutoinstData.post_patterns = Ops.get_list(
+           Profile.current,
+           ["software", "post-patterns"],
+           []
+         )
+      
+         # the following is needed since 10.3
+         # otherwise the already configured network gets removed
+         if !Builtins.haskey(Profile.current, "networking")
+           Profile.current = Builtins.add(
+             Profile.current,
+             "networking",
+             { "keep_install_network" => true }
+           )
+         end
+      
+         if @dopackages
+           Yast::Pkg.TargetInit("/", false)
+           WFM.CallFunction("inst_rpmcopy", [])
+         end
+         WFM.CallFunction("inst_autoconfigure", [])
+      
+         # Restarting autoyast-initscripts.service in order to run
+         # init-scripts in the installed system.
+         cmd = "systemctl restart autoyast-initscripts.service"
+         ret = SCR.Execute(path(".target.bash_output"), cmd)
+         log.info "command \"#{cmd}\" returned #{ret}"
+         nil
+      end
+      
+      def openFile(options)
+         options = deep_copy(options)
+         if Ops.get(options, "filename") == nil
+           Yast::CommandLine.Error(_("Path to AutoYaST profile must be set."))
+           return false
+         end
+         if Ops.get_string(options, "dopackages", "yes") == "no"
+           @dopackages = false
+         end
+         if SCR.Read(
+             path(".target.lstat"),
+             Ops.get_string(options, "filename", "")
+           ) == {} ||
+             !Profile.ReadXML(Ops.get_string(options, "filename", ""))
+           Yast::Mode.SetUI("commandline")
+           Yast::CommandLine.Print(
+             _(
+               "Error while parsing the control file.\n" +
+                 "Check the log files for more details or fix the\n" +
+                 "control file and try again.\n"
+             )
+           )
+           return false
+         end
+      
+         Setup()
+         true
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/clients/ayast_setup.rb
+++ b/src/lib/autoinstall/clients/ayast_setup.rb
@@ -36,6 +36,7 @@ Yast.import "Pkg"
 module Y2Autoinstall
   module Clients
     module AyastSetup
+      textdomain "autoinst"
       include Yast::Logger    
       Ops = Yast::Ops
       SCR = Yast::SCR

--- a/src/lib/autoinstall/clients/ayast_setup.rb
+++ b/src/lib/autoinstall/clients/ayast_setup.rb
@@ -36,7 +36,6 @@ Yast.import "Pkg"
 module Y2Autoinstall
   module Clients
     module AyastSetup
-      textdomain "autoinst"
       include Yast::Logger    
       Ops = Yast::Ops
       SCR = Yast::SCR
@@ -44,6 +43,7 @@ module Y2Autoinstall
       Profile  = Yast::Profile
       Builtins = Yast::Builtins
       def Setup
+         textdomain "autoinst"
          Yast::AutoInstall.Save
          Yast::Wizard.CreateDialog
          Yast::Mode.SetMode("autoinstallation")
@@ -96,6 +96,7 @@ module Y2Autoinstall
       end
       
       def openFile(options)
+         textdomain "autoinst"
          options = deep_copy(options)
          if Ops.get(options, "filename") == nil
            Yast::CommandLine.Error(_("Path to AutoYaST profile must be set."))

--- a/test/lib/clients/ayast_setup_test.rb
+++ b/test/lib/clients/ayast_setup_test.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "autoinstall/clients/ayast_setup"
+
+describe Y2Autoinstall::Clients::AyastSetup do
+  let(:client) do
+    instance_double(Y2Autoinstall::Clients::AyastSetup, Setup: :true)
+  end
+
+  describe "#main" do
+    it "Start the ayast_setup client" do
+	    expect(client.Setup).to eq(:true)
+    end
+  end
+end


### PR DESCRIPTION
I've moved the active part of ayast_setup into an library which can be imported from other yast modules too.