### PR TITLE
fix auto-adding required packages for autoyast sections (bsc#1153746)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 30 14:45:29 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- fix auto-adding required packages for autoyast sections (bsc#1153746)
+- don't run kdump autoyast config in 2nd stage
+- 4.2.15
+
+-------------------------------------------------------------------
 Fri Oct 25 15:30:06 UTC 2019 - Peter Varkoly <varkoly@suse.com>
 
 - bnc#1154855 - During firstboot ayast_setup will not be executed.

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.14
+Version:        4.2.15
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -500,10 +500,7 @@ module Yast
 
     # Add YaST2 packages dependencies
     def add_yast2_dependencies
-      keys = Profile.current.keys.select do |k|
-        Profile.current[k].is_a?(Array)||Profile.current[k].is_a?(Hash)
-      end
-      AutoinstSoftware.AddYdepsFromProfile(keys)
+      AutoinstSoftware.AddYdepsFromProfile(Profile.current.keys)
     end
   end
 end

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -377,6 +377,8 @@ module Yast
           "kdump_auto",
           ["Import", Ops.get_map(Profile.current, "kdump", {})]
         )
+        # Don't run it again in 2nd installation stage
+        Profile.remove_sections("kdump")
       end
 
       # Software

--- a/src/modules/Y2ModuleConfig.rb
+++ b/src/modules/Y2ModuleConfig.rb
@@ -422,8 +422,7 @@ module Yast
     def required_packages(sections)
       package_names = {}
       log.info "Evaluating needed packages for handling AY-sections #{sections}"
-      if PackageSystem.Installed("yast2-schema") &&
-         PackageSystem.Installed("grep")
+      if File.exist?(SCHEMA_PACKAGE_FILE)
         sections.each do |section|
           # Evaluate which *rng file belongs to the given section
           package_names[section] = []

--- a/test/Y2ModuleConfig_test.rb
+++ b/test/Y2ModuleConfig_test.rb
@@ -137,17 +137,16 @@ describe Yast::Y2ModuleConfig do
   end
 
   describe "#required_packages" do
-    context "packages needed for the check are not installed" do
+    context "files needed for the check are not installed" do
       it "returns an empty hash" do
-        allow(Yast::PackageSystem).to receive(:Installed).with("yast2-schema").and_return false
+        allow(File).to receive(:exist?).with("/usr/share/YaST2/schema/autoyast/rnc/includes.rnc").and_return false
         expect(subject.required_packages([])).to eq({})
       end
     end
 
-    context "all packages needed for the check are installed" do
+    context "all files needed for the check are installed" do
       before do
-        allow(Yast::PackageSystem).to receive(:Installed).with("yast2-schema").and_return true
-        allow(Yast::PackageSystem).to receive(:Installed).with("grep").and_return true
+        allow(File).to receive(:exist?).with("/usr/share/YaST2/schema/autoyast/rnc/includes.rnc").and_return true
       end
 
       context "no rng file found for the given AY section" do


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1153746
- https://trello.com/c/g5Ss3rRS

AutoYaST in second stage shows a warning dialog saying it can't work on some sections of the AutoYaST profile because some packages should have been installed for this. (The screenshot in the Trello board shows sections `mail` and `kdump`.)

## Analysis

The package calculation got broken along with the 'org.opensuse' namespace move in our desktop files. As the files are named in camel-case, this is terminally broken and should be re-thought. But not as part of this pr.

Also, it seems `kdump` is not needed in 2nd stage at all.

## Solution

3 parts:

- fix the function that determines the needed packages
- remove `kdump` from 2nd stage profile as the config is done in 1st stage

- `yast2-schema` package is needed in inst-sys; this is done in https://github.com/openSUSE/installation-images/pull/341