### PR TITLE
Count extended partition when determining if partitions fit

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov 27 15:28:20 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider extended partitions when trying to figure out whether
+  the partitioning layout described in the profile fits
+  (bsc#1156567).
+- 3.1.171
+
+-------------------------------------------------------------------
 Thu Feb  1 12:59:08 CET 2018 - schubi@suse.de
 
 - Report packages which cannot be select for installation

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.1.170
+Version:        3.1.171
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/autopart.rb
+++ b/src/include/autoinstall/autopart.rb
@@ -1527,16 +1527,14 @@ module Yast
 
       new_ps = ps.count { |p| p.fetch("create", true) }
       reuse_ps = ps.count { |p| p.fetch("partition_nr",0)==p.fetch("usepart",-1) }
-      free_pnr = g.fetch("free_pnr",[]).size
-      if g.fetch("extended_possible",false)
-        free_pnr -= 1
-        free_pnr += g.fetch("ext_pnr",[]).size
-      end
+      sum_free_parts = g.fetch("free_pnr",[]).size + g.fetch("ext_pnr", []).size
+      sum_free_parts -= 1 if g.fetch("extended_possible",false)
+
       Builtins.y2milestone(
         "get_perfect_list: size(ps):%1 new_ps:%2 reuse_ps:%3 sum_free:%4",
-        ps.size, new_ps, reuse_ps, free_pnr
+        ps.size, new_ps, reuse_ps, sum_free_parts
       )
-      if (new_ps>0||reuse_ps>0) && g.fetch("gap", []).size>0 && new_ps<=free_pnr 
+      if (new_ps>0||reuse_ps>0) && g.fetch("gap", []).size>0 && new_ps<=sum_free_parts
         lg = Builtins.eval(g)
 
         # prepare local gap var


### PR DESCRIPTION
If the extended partition already exists, the `extended_possible` key is set to `false`, thus the free partitions within the extended one were not taken into account.

It partially fixes https://bugzilla.suse.com/show_bug.cgi?id=1156567.