### PR TITLE
reducing memory usage

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 18 16:42:31 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650, bsc#1140037).
+- 4.2.22
+
+-------------------------------------------------------------------
 Thu Nov 14 07:43:39 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not override all storage proposal settings when importing

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_store_upgrade_software.rb
+++ b/src/clients/inst_store_upgrade_software.rb
@@ -15,7 +15,7 @@ module Yast
       @patterns = Y2Packager::Resolvable.find(kind: :pattern) || []
       @patterns.select! do |p|
         p.transact_by == :user ||
-        p.transact_by == :app_high
+          p.transact_by == :app_high
       end
 
       # note: does not matter if it is installed or to be installed, the resulting
@@ -24,10 +24,10 @@ module Yast
       @patterns_to_remove = []
       @patterns_to_install = @patterns.map do |p|
         if p.status == :selected ||
-           p.status == :installed
+            p.status == :installed
           next p.name
         elsif p.status == :removed ||
-          p.status == :available
+            p.status == :available
           @patterns_to_remove << p.name
         end
 
@@ -51,16 +51,16 @@ module Yast
       @products = Y2Packager::Resolvable.find(kind: :product) || []
       @products.select! do |p|
         p.transact_by == :user ||
-        p.transact_by == :app_high
+          p.transact_by == :app_high
       end
 
       @products_to_remove = []
       @products_to_install = @products.map do |p|
         if p.status == :selected ||
-           p.status == :installed
+            p.status == :installed
           next p.name
         elsif p.status == :removed ||
-              p.status == :available
+            p.status == :available
           @products_to_remove << p.name
         end
 

--- a/src/clients/inst_store_upgrade_software.rb
+++ b/src/clients/inst_store_upgrade_software.rb
@@ -61,7 +61,7 @@ module Yast
           next p.name
         elsif p.status == :removed ||
               p.status == :available
-          @products_to_remove = << p.name
+          @products_to_remove << p.name
         end
 
         nil

--- a/src/clients/software_auto.rb
+++ b/src/clients/software_auto.rb
@@ -234,7 +234,7 @@ module Yast
         all_patterns = Y2Packager::Resolvable.find(
           kind:   :pattern, status: :selected).map(&:name)
         Builtins.y2milestone(
-          "available patterns %1", all_patterns)
+          "available patterns %1", all_patterns
         )
         patadd = all_patterns
       else

--- a/src/clients/software_auto.rb
+++ b/src/clients/software_auto.rb
@@ -231,12 +231,12 @@ module Yast
 
       patadd = []
       if @ret != :back
-        all_patterns = Y2Packager::Resolvable.find(kind:   :pattern,
-                                                   status: :selected)
+        all_patterns = Y2Packager::Resolvable.find(
+          kind:   :pattern, status: :selected).map(&:name)
         Builtins.y2milestone(
-          "available patterns %1", all_patterns
+          "available patterns %1", all_patterns)
         )
-        patadd = all_patterns.map(&:name)
+        patadd = all_patterns
       else
         patadd = deep_copy(AutoinstSoftware.patterns)
       end

--- a/src/clients/software_auto.rb
+++ b/src/clients/software_auto.rb
@@ -4,6 +4,9 @@
 # Summary:  Handle Package selections and packages
 #
 # $Id$
+
+require "y2packager/resolvable"
+
 module Yast
   class SoftwareAutoClient < Client
     def main
@@ -183,7 +186,7 @@ module Yast
         false,
         true
       )
-      patterns = Pkg.ResolvableProperties("", :pattern, "")
+      patterns = Y2Packager::Resolvable.find(kind: :pattern)
       Builtins.y2milestone("available patterns %1", patterns)
       # sort available_base_selections by order
       # $[ "order" : [ "name", "summary" ], .... ]
@@ -228,15 +231,12 @@ module Yast
 
       patadd = []
       if @ret != :back
+        all_patterns = Y2Packager::Resolvable.find(kind: :pattern,
+          status: :selected)
         Builtins.y2milestone(
-          "available patterns %1",
-          Pkg.ResolvableProperties("", :pattern, "")
+          "available patterns %1", all_patterns
         )
-        Builtins.foreach(Pkg.ResolvableProperties("", :pattern, "")) do |p|
-          if Ops.get_symbol(p, "status", :nothing) == :selected
-            patadd = Builtins.add(patadd, Ops.get_string(p, "name", ""))
-          end
-        end
+        patadd = all_patterns.map { |p| p.name }
       else
         patadd = deep_copy(AutoinstSoftware.patterns)
       end

--- a/src/clients/software_auto.rb
+++ b/src/clients/software_auto.rb
@@ -232,7 +232,8 @@ module Yast
       patadd = []
       if @ret != :back
         all_patterns = Y2Packager::Resolvable.find(
-          kind:   :pattern, status: :selected).map(&:name)
+          kind: :pattern, status: :selected
+        ).map(&:name)
         Builtins.y2milestone(
           "available patterns %1", all_patterns
         )

--- a/src/clients/software_auto.rb
+++ b/src/clients/software_auto.rb
@@ -231,12 +231,12 @@ module Yast
 
       patadd = []
       if @ret != :back
-        all_patterns = Y2Packager::Resolvable.find(kind: :pattern,
-          status: :selected)
+        all_patterns = Y2Packager::Resolvable.find(kind:   :pattern,
+                                                   status: :selected)
         Builtins.y2milestone(
           "available patterns %1", all_patterns
         )
-        patadd = all_patterns.map { |p| p.name }
+        patadd = all_patterns.map(&:name)
       else
         patadd = deep_copy(AutoinstSoftware.patterns)
       end

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -1017,23 +1017,15 @@ module Yast
       Pkg.SourceStartManager(true)
       Pkg.PkgSolve(false)
 
-      all_patterns = Y2Packager::Resolvable.find(kind: :pattern)
       @all_xpatterns = Y2Packager::Resolvable.find(kind: :pattern)
       to_install_packages = install_packages
       patterns = []
 
-      # FIXME: filter method but it use only side effect of filling patterns
-      Builtins.filter(all_patterns) do |p|
-        ret2 = false
+      @all_xpatterns.each do |p|
         if p.status == :installed &&
-            !Builtins.contains(patterns, (p.name || "no name"))
-          patterns = Builtins.add(
-            patterns,
-            p.name.empty? ? "no name" : p.name
-          )
-          ret2 = true
+           !patterns.include?(p.name)
+            patterns << p.name.empty? ? "no name" : p.name
         end
-        ret2
       end
       Pkg.TargetFinish
 
@@ -1089,12 +1081,11 @@ module Yast
     #    "packages" -> list<string> user selected packages
     #           "remove-packages" -> list<string> packages to remove
     def read_initial_stage
-      install_patterns = Y2Packager::Resolvable.find(kind: :pattern).collect do |pattern|
+      install_patterns = Y2Packager::Resolvable.find(kind: :pattern, user_visible: true).collect do |pattern|
         # Do not take care about if the pattern has been selected by the user or the product
         # definition, cause we need a base selection here for the future
         # autoyast installation. (bnc#882886)
-        if pattern.user_visible &&
-            (pattern.status == :selected || pattern.status == :installed)
+        if pattern.status == :selected || pattern.status == :installed
           pattern.name
         end
       end

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -109,9 +109,8 @@ module Yast
       @instsource = settings.fetch("instsource", "")
 
       @packagesAvailable = Pkg.GetPackages(:available, true)
-      @patternsAvailable = []
-      allPatterns = Y2Packager::Resolvable.find(kind:         :pattern,
-                                                user_visible: false).map(&:name)
+      @patternsAvailable = Y2Packager::Resolvable.find(kind:         :pattern,
+                                                       user_visible: false).map(&:name)
 
       regexFound = []
       Ops.set(

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -110,8 +110,8 @@ module Yast
 
       @packagesAvailable = Pkg.GetPackages(:available, true)
       @patternsAvailable = []
-      allPatterns = Y2Packager::Resolvable.find(kind: :pattern,
-        user_visible: false).map { |p| p.name }
+      allPatterns = Y2Packager::Resolvable.find(kind:         :pattern,
+                                                user_visible: false).map(&:name)
 
       regexFound = []
       Ops.set(

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -109,8 +109,8 @@ module Yast
       @instsource = settings.fetch("instsource", "")
 
       @packagesAvailable = Pkg.GetPackages(:available, true)
-      @patternsAvailable = Y2Packager::Resolvable.find(kind: :pattern,
-        user_visible: true).map(&:name)
+      @patternsAvailable = Y2Packager::Resolvable.find(kind:         :pattern,
+                                                       user_visible: true).map(&:name)
 
       regexFound = []
       Ops.set(
@@ -1029,7 +1029,7 @@ module Yast
             !Builtins.contains(patterns, (p.name || "no name"))
           patterns = Builtins.add(
             patterns,
-            p.name.empty? ?  "no name" : p.name
+            p.name.empty? ? "no name" : p.name
           )
           ret2 = true
         end

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -109,8 +109,10 @@ module Yast
       @instsource = settings.fetch("instsource", "")
 
       @packagesAvailable = Pkg.GetPackages(:available, true)
-      @patternsAvailable = Y2Packager::Resolvable.find(kind:         :pattern,
-                                                       user_visible: true).map(&:name)
+      @patternsAvailable = Y2Packager::Resolvable.find(
+        kind:         :pattern,
+        user_visible: true
+      ).map(&:name)
 
       regexFound = []
       Ops.set(
@@ -1082,7 +1084,7 @@ module Yast
     #           "remove-packages" -> list<string> packages to remove
     def read_initial_stage
       install_patterns =
-        Y2Packager::Resolvable.find(kind: :pattern, user_visible: true).collect do |pattern|
+        Y2Packager::Resolvable.find(kind: :pattern, user_visible: true).map do |pattern|
           # Do not take care about if the pattern has been selected by the user or the product
           # definition, cause we need a base selection here for the future
           # autoyast installation. (bnc#882886)

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -8,6 +8,7 @@
 require "yast"
 require "y2storage"
 require "y2packager/product"
+require "y2packager/resolvable"
 
 module Yast
   class AutoinstSoftwareClass < Module
@@ -109,11 +110,8 @@ module Yast
 
       @packagesAvailable = Pkg.GetPackages(:available, true)
       @patternsAvailable = []
-      allPatterns = Pkg.ResolvableDependencies("", :pattern, "")
-      Builtins.filter(allPatterns) do |m|
-        @patternsAvailable.push(m.fetch("name", "")) if m.fetch("user_visible", false)
-        m.fetch("user_visible", false)
-      end
+      allPatterns = Y2Packager::Resolvable.find(kind: :pattern,
+        user_visible: false).map { |p| p.name }
 
       regexFound = []
       Ops.set(
@@ -863,8 +861,8 @@ module Yast
       # switch for recommended patterns installation (workaround for our very weird pattern design)
       if sw_settings.fetch("install_recommended", false) == false
         # set SoftLock to avoid the installation of recommended patterns (#159466)
-        Builtins.foreach(Pkg.ResolvableProperties("", :pattern, "")) do |p|
-          Pkg.ResolvableSetSoftLock(Ops.get_string(p, "name", ""), :pattern)
+        Y2Packager::Resolvable.find(kind: :pattern) do |p|
+          Pkg.ResolvableSetSoftLock(p.name, :pattern)
         end
       end
 
@@ -1020,19 +1018,19 @@ module Yast
       Pkg.SourceStartManager(true)
       Pkg.PkgSolve(false)
 
-      all_patterns = Pkg.ResolvableProperties("", :pattern, "")
-      @all_xpatterns = Pkg.ResolvableDependencies("", :pattern, "")
+      all_patterns = Y2Packager::Resolvable.find(kind: :pattern)
+      @all_xpatterns = Y2Packager::Resolvable.find(kind: :pattern)
       to_install_packages = install_packages
       patterns = []
 
       # FIXME: filter method but it use only side effect of filling patterns
       Builtins.filter(all_patterns) do |p|
         ret2 = false
-        if Ops.get_symbol(p, "status", :none) == :installed &&
-            !Builtins.contains(patterns, Ops.get_string(p, "name", "no name"))
+        if (p.status || :none) == :installed &&
+            !Builtins.contains(patterns, (p.name || "no name"))
           patterns = Builtins.add(
             patterns,
-            Ops.get_string(p, "name", "no name")
+            (p.name || "no name")
           )
           ret2 = true
         end
@@ -1051,7 +1049,7 @@ module Yast
       new_p = []
       Builtins.foreach(patterns) do |tmp_pattern|
         xpattern = Builtins.filter(@all_xpatterns) do |p|
-          Ops.get_string(p, "name", "") == tmp_pattern
+          (p.name || "") == tmp_pattern
         end
         found = Ops.get(xpattern, 0, {})
         req = false
@@ -1092,13 +1090,13 @@ module Yast
     #    "packages" -> list<string> user selected packages
     #           "remove-packages" -> list<string> packages to remove
     def read_initial_stage
-      install_patterns = Pkg.ResolvableProperties("", :pattern, "").collect do |pattern|
+      install_patterns = Y2Packager::Resolvable.find(kind: :pattern).collect do |pattern|
         # Do not take care about if the pattern has been selected by the user or the product
         # definition, cause we need a base selection here for the future
         # autoyast installation. (bnc#882886)
-        if pattern["user_visible"] &&
-            (pattern["status"] == :selected || pattern["status"] == :installed)
-          pattern["name"]
+        if pattern.user_visible &&
+            (pattern.status == :selected || pattern.status == :installed)
+          pattern.name
         end
       end
 

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -1023,8 +1023,8 @@ module Yast
 
       @all_xpatterns.each do |p|
         if p.status == :installed &&
-           !patterns.include?(p.name)
-            patterns << p.name.empty? ? "no name" : p.name
+            !patterns.include?(p.name)
+          (patterns << p.name.empty?) ? "no name" : p.name
         end
       end
       Pkg.TargetFinish
@@ -1081,14 +1081,13 @@ module Yast
     #    "packages" -> list<string> user selected packages
     #           "remove-packages" -> list<string> packages to remove
     def read_initial_stage
-      install_patterns = Y2Packager::Resolvable.find(kind: :pattern, user_visible: true).collect do |pattern|
-        # Do not take care about if the pattern has been selected by the user or the product
-        # definition, cause we need a base selection here for the future
-        # autoyast installation. (bnc#882886)
-        if pattern.status == :selected || pattern.status == :installed
-          pattern.name
+      install_patterns =
+        Y2Packager::Resolvable.find(kind: :pattern, user_visible: true).collect do |pattern|
+          # Do not take care about if the pattern has been selected by the user or the product
+          # definition, cause we need a base selection here for the future
+          # autoyast installation. (bnc#882886)
+          pattern.name if pattern.status == :selected || pattern.status == :installed
         end
-      end
 
       software = {}
       software["packages"] = install_packages


### PR DESCRIPTION
Replacing old Pkg.ResolvableProperties()and Pkg.ResolvabeDependencies() calls by Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find in order to save memory.