### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 16:31:46 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.27
+
+-------------------------------------------------------------------
 Tue Dec 31 11:43:56 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix cloning patterns (regression from 4.2.22)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.26
+Version:        4.2.27
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/include/autoinstall/general_dialogs.rb
+++ b/src/include/autoinstall/general_dialogs.rb
@@ -117,7 +117,7 @@ module Yast
           Left(
             CheckBox(
               Id(:accept_non_trusted_gpg_key),
-              _("Accept Non Trusted GPG Keys"),
+              _("Accept Untrusted GPG Keys"),
               accept_non_trusted_gpg_key
             )
           ),
@@ -271,7 +271,7 @@ module Yast
         VBox(
           TextEntry(
             Id(:frametitle),
-            _("Frametitle"),
+            _("Frame Title"),
             Ops.get_string(defaultValues, "frametitle", "")
           ),
           TextEntry(


### PR DESCRIPTION
## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.


### en_US.po file

```po
# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR SuSE Linux Products GmbH, Nuernberg
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
msgid ""
msgstr ""
"Project-Id-Version: xPACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2019-12-20 02:28+0000\n"
"PO-Revision-Date: 2007-08-14 15:56+0200\n"
"Last-Translator: xFULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: xLANGUAGE <LL@li.org>\n"
"Language: en_US\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit"

#: src/include/autoinstall/general_dialogs.rb:120
msgid "Accept Non Trusted GPG Keys"
msgstr "Accept Untrusted GPG Keys"

#: src/include/autoinstall/general_dialogs.rb:274
msgid "Frametitle"
msgstr "Frame Title"
```