### PR TITLE
Init script: Checking working network with network-online.target

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 26 16:19:57 CET 2020 - schubi@suse.de
+
+- Init script: Checking working network with "network-online.target"
+  before starting the AY init script (bsc#1164105).
+- 3.2.43
+
+-------------------------------------------------------------------
 Tue Dec 17 16:19:57 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - UI: Report XML parsing errors instead of just crashing

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Wed Feb 26 16:19:57 CET 2020 - schubi@suse.de
 
-- Init script: Checking working network with "network-online.target"
-  before starting the AY init script (bsc#1164105).
+- Service for init scripts: Checking working network with
+  "network-online.target" before starting the AY init scripts
+  (bsc#1164105).
 - 3.2.43
 
 -------------------------------------------------------------------

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.42
+Version:        3.2.43
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/scripts/autoyast-initscripts.service
+++ b/scripts/autoyast-initscripts.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Autoyast2 Init Scripts
-After=remote-fs.target network.target time-sync.target mail-transfer-agent.target hwscan.service ypbind.service YaST2-Second-Stage.service
+After=remote-fs.target network-online.target time-sync.target mail-transfer-agent.target hwscan.service ypbind.service YaST2-Second-Stage.service
 Before=systemd-user-sessions.service
 
 [Service]


### PR DESCRIPTION
**Problem**
autoyast-initscripts.service is waiting for running network by the "old" target "network.target".
Newer version of systemd are supporting "network-online.target" which actively waits until the network is "up". See:
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

**Solution**
Replace the old target by the newer one.

**Test**
manually