### PR TITLE
Travis fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM yastdevel/ruby:sle12-sp5
 
 
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends --force-resolution \
   trang \
   libxml2-tools \
   libxslt-tools


### PR DESCRIPTION
- Fixes Travis build
- Use `--force-resolution` zypper option to allow package downgrades to resolve package dependencies.