### PR TITLE
Security fix: Removed all "--gpg-auto-import-keys" options from zyppe…

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 10 10:19:09 CET 2020 - schubi@suse.de
+
+- Security fix: Removed all "--gpg-auto-import-keys" options from
+  zypper commands (bsc#1140711)
+- 4.0.72
+
+-------------------------------------------------------------------
 Wed Feb 26 16:19:57 CET 2020 - schubi@suse.de
 
 - Service for init scripts: Checking working network with

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.71
+Version:        4.0.72
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -302,7 +302,8 @@ module Yast
       # Add Source:
       # zypper --root /space/tmp/tmproot/ ar ftp://10.10.0.100/install/SLP/openSUSE-11.2/i386/DVD1/ main
       zypperCall = Builtins.sformat(
-        "ZYPP_READONLY_HACK=1 zypper --root %1 --gpg-auto-import-keys --non-interactive ar %2 main-source %3",
+        "ZYPP_READONLY_HACK=1 zypper --root %1 " \
+          "--non-interactive ar %2 main-source %3",
         rootdir,
         @instsource,
         outputRedirect
@@ -321,7 +322,8 @@ module Yast
       addOns = Ops.get_list(addOnExport, "add_on_products", [])
       Builtins.foreach(addOns) do |addOn|
         zypperCall = Builtins.sformat(
-          "ZYPP_READONLY_HACK=1 zypper --root %1 --gpg-auto-import-keys --non-interactive ar %2 %3 %4",
+          "ZYPP_READONLY_HACK=1 zypper --root %1 " \
+            "--non-interactive ar %2 %3 %4",
           rootdir,
           Ops.get_string(addOn, "media_url", ""),
           Ops.get_string(addOn, "product", ""),
@@ -342,7 +344,8 @@ module Yast
 
       # Install
       zypperCall = Builtins.sformat(
-        "ZYPP_READONLY_HACK=1 zypper --root %1 --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses ",
+        "ZYPP_READONLY_HACK=1 zypper --root %1 " \
+          "--non-interactive install --auto-agree-with-licenses ",
         rootdir
       )
 


### PR DESCRIPTION
…r commands (bsc#1140711) (#570)
Backport of
https://github.com/yast/yast-autoinstallation/pull/570/files