### PR TITLE
Package handler

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 11 15:27:34 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted to changes in yast2-storage-ng (related to bsc#1140040).
+- 4.2.31
+
+-------------------------------------------------------------------
 Tue Mar 10 10:19:09 CET 2020 - schubi@suse.de
 
 - Security fix: Removed all "--gpg-auto-import-keys" options from

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -54,8 +54,8 @@ BuildRequires:  yast2-slp
 BuildRequires:  yast2-country
 # Required for test suite testing one time sync
 BuildRequires:       yast2-ntp-client >= 4.0.1
-# Y2Storage::AutoinstProposal constructor receives a ProposalSettings object
-BuildRequires:  yast2-storage-ng >= 4.2.55
+# New API for Y2Storage::PackageHandler and storage features
+BuildRequires:  yast2-storage-ng >= 4.2.95
 # %%{_unitdir} macro definition is in a separate package since 13.1
 %if 0%{?suse_version} >= 1310
 BuildRequires:  systemd-rpm-macros
@@ -76,8 +76,8 @@ Requires:       yast2-network >= 3.1.145
 Requires:       yast2-schema >= 4.0.6
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml
-# Y2Storage::AutoinstProposal constructor receives a ProposalSettings object
-Requires:       yast2-storage-ng >= 4.2.55
+# New API for Y2Storage::PackageHandler and storage features
+Requires:       yast2-storage-ng >= 4.2.95
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Conflicts:      yast2-installation < 3.1.166
@@ -108,8 +108,8 @@ installation sources.
 Summary:        YaST2 - Auto Installation Modules
 Group:          System/YaST
 
-# Y2Storage::AutoinstIssues containing section information
-BuildRequires:  yast2-storage-ng >= 4.0.15
+# New API for Y2Storage::PackageHandler and storage features
+BuildRequires:  yast2-storage-ng >= 4.2.95
 
 # API for Disabled Modules (ProductControl)
 Requires:       yast2 >= 2.16.36

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -861,8 +861,8 @@ module Yast
 
       # Add storage-related software packages (filesystem tools etc.) to the
       # set of packages to be installed.
-      pkg_handler = Y2Storage::PackageHandler.new
-      pkg_handler.add_feature_packages(Y2Storage::StorageManager.instance.staging)
+      storage_features = Y2Storage::StorageManager.instance.staging.used_features
+      pkg_handler = Y2Storage::PackageHandler.new(storage_features.pkg_list)
       pkg_handler.set_proposal_packages
 
       # switch for recommended patterns installation (workaround for our very weird pattern design)


### PR DESCRIPTION
https://github.com/yast/yast-storage-ng/pull/1060 implements a long overdue refactoring of how yast2-storage-ng manages the so-called storage features and its related packages.


Now the API of `PackageHandler` and friends is properly object-oriented, SOLID and all that. But since it changed, this adaptation was needed in yast-autoinstallation (the only user of those classes outside yast2-storage-ng itself).