### PR TITLE
Fix (some) desktop files

### DIFF
--- a/modconfig/partitioning.desktop
+++ b/modconfig/partitioning.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Type=Application
-Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-Misc;
+Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-System;
 
 X-KDE-ModuleType=Library
 X-KDE-HasReadOnlyMode=true
 X-SuSE-YaST-Call=partitioning
 
-X-SuSE-YaST-Group=Hardware
+X-SuSE-YaST-Group=System
 X-SuSE-YaST-Argument=
 X-SuSE-YaST-RootOnly=true
 X-SuSE-YaST-AutoInst=configure
@@ -18,9 +18,9 @@ X-SuSE-YaST-AutoInstPath=install
 X-SuSE-YaST-AutoInstDataType=list
 X-SuSE-YaST-AutoInstSchema=partitioning.rnc
 
-Icon=yast-partitioning
+Icon=yast-disk
 Exec=
 
-Name=Partitioning
-GenericName=Configure Partitioning and Storage  Settings
+Name=YaST Partitioner
+GenericName=Configure Partitioning and Storage Settings
 StartupNotify=true

--- a/modconfig/software.desktop
+++ b/modconfig/software.desktop
@@ -16,7 +16,7 @@ X-SuSE-YaST-AutoInstResource=software
 X-SuSE-YaST-AutoInstPath=install
 X-SuSE-YaST-AutoInstSchema=software.rnc
 
-Icon=yast-software
+Icon=yast-sw_single
 Exec=
 
 Name=Package Selection

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 31 15:30:56 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Fix desktop files updating some icons and groups (related to
+  bsc#1168123).
+- 4.2.32
+
+-------------------------------------------------------------------
 Wed Mar 11 15:27:34 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adapted to changes in yast2-storage-ng (related to bsc#1140040).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.31
+Version:        4.2.32
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Some time ago, the icons used by YaST modules were updated and moved[1][2]. However, there are some missing icons in AutoYaST onfiguration, some of them completely deleted and others not properly updated in the _autoinstall_ desktop files.

* https://bugzilla.suse.com/show_bug.cgi?id=1168123

## Solution

Only two of those icons can be fixed from here, using the right name. Additionally, the Partitioner group and categories has been updated too, to sync it with [3].

---

[1] https://github.com/yast/yast-theme/pull/100
[2] https://github.com/yast/yast-theme/commit/afa341066b9851808fbaa25756470cd119d41bfd
[3] https://github.com/yast/yast-storage-ng/blob/adb3e9b28cf6496f4440f7f2c0c78ab945266189/src/desktop/org.opensuse.yast.Disk.desktop
