### PR TITLE
Sle 12 sp4 bsc 1167596

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM yastdevel/ruby:sle12-sp4
 
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends --force-resolution --oldpackage \
   trang \
   libxml2-tools \
   libxslt-tools

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr  3 09:27:04 CEST 2020 - schubi@suse.de
+
+- Clone system: Reverting wrong fix for adding not used devices to
+  the skip list (bsc#1167596).
+- 3.2.36.6
+
+-------------------------------------------------------------------
 Tue Dec 17 16:19:57 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - UI: Report XML parsing errors instead of just crashing

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.36.5
+Version:        3.2.36.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AutoinstPartPlan.rb
+++ b/src/modules/AutoinstPartPlan.rb
@@ -48,12 +48,6 @@ module Yast
       # default value of settings modified
       @modified = false
 
-      # Devices which do not have any mount point, lvm_group or raid_name
-      # These devices will not be taken in the AutoYaSt configuration file
-      # but will be added to the skip_list in order not regarding it while
-      # next installation. (bnc#989392)
-      @skipped_devices = []
-
     end
 
     # Function sets internal variable, which indicates, that any
@@ -653,8 +647,6 @@ module Yast
         deep_copy(drive)
       end
 
-      @skipped_devices = []
-
       drives = Builtins.filter(
         Convert.convert(drives, :from => "list", :to => "list <map>")
       ) do |v|
@@ -667,10 +659,8 @@ module Yast
             raise Break
           end
         end
-        @skipped_devices << v["device"] unless keep
         keep
       end
-      Builtins.y2milestone("Skipped devices: #{@skipped_devices}")
 
       Mode.SetMode("autoinst_config")
       deep_copy(drives)
@@ -795,19 +785,6 @@ module Yast
           Builtins.y2milestone("device 'auto' dropped")
         end
         deep_copy(d)
-      end
-
-      # Adding skipped devices to partitioning section.
-      # These devices will not be taken in the AutoYaSt configuration file
-      # but will be added to the skip_list in order not regarding it while
-      # next installation. (bnc#989392)
-      unless @skipped_devices.empty?
-        skip_device = {}
-        skip_device["initialize"] = true
-        skip_device["skip_list"] = @skipped_devices.collect do |dev|
-          {"skip_key" => "device", "skip_value" => dev}
-        end
-        clean_drives << skip_device
       end
 
       deep_copy(clean_drives)

--- a/test/AutoinstPartPlan_test.rb
+++ b/test/AutoinstPartPlan_test.rb
@@ -15,7 +15,6 @@ describe "Yast::AutoinstPartPlan" do
   end
 
   let(:target_map_path) { File.join(FIXTURES_PATH, "storage", "nfs_root.yml") }
-  let(:target_map_clone) { File.join(FIXTURES_PATH, "storage", "target_clone.yml") }
   let(:default_subvol) { "@" }
   let(:filesystems) do
     double("filesystems",
@@ -45,19 +44,6 @@ describe "Yast::AutoinstPartPlan" do
             "device"=>"/dev/nfs", "use"=>"all"}
          ]
         )
-    end
-
-    it "ignoring not needed devices" do
-      target_map = YAML.load_file(target_map_clone)
-
-      expect(Yast::Storage).to receive(:GetTargetMap).and_return(target_map)
-      expect(subject.Read).to eq(true)
-      export = subject.Export.select { |d| d.key?("skip_list") }
-
-      expect(export[0]).to include("initialize" => true)
-      skip_list = export[0]["skip_list"]
-      expect(skip_list).to all(include("skip_key" => "device"))
-      expect(skip_list).to all(include("skip_value" => /\/dev\//))
     end
   end
 


### PR DESCRIPTION
**Revert fix:**
---------------------------------------------------------------------------------------------------------
Mon Aug 12 10:48:18 CEST 2016 - schubi@suse.de

Cloning devices: Devices which are not needed for the
installation will be ignored explicitly in the "skip_list".
(bnc#989392)
3.1.146
The fix
https://github.com/yast/yast-autoinstallation/pull/240/files
is generating a wrong skip list.
The regarding bug
https://bugzilla.suse.com/show_bug.cgi?id=989392
Has two fixes. The first (248) one has not fixed the issue but has looked
good in general for potential other issues. But it does not behave as expected.
--> removing this fix is worth for it because it is used while calling
"yast clone_system"