### PR TITLE
New storage UI (first steps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ package/autoyast2-*.bz2
 /.yardoc
 /coverage
 /test-driver
+ 

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -281,6 +281,10 @@ done
 %dir %{yast_libdir}/autoinstall/dialogs
 %{yast_libdir}/autoinstall/dialogs/*.rb
 
+%dir %{yast_libdir}/autoinstall/widgets
+%dir %{yast_libdir}/autoinstall/widgets/storage
+%{yast_libdir}/autoinstall/widgets/storage/*.rb
+
 %dir %{yast_libdir}/autoinstall/clients
 %{yast_libdir}/autoinstall/clients/*.rb
 

--- a/src/clients/storage_auto.rb
+++ b/src/clients/storage_auto.rb
@@ -100,7 +100,7 @@ module Yast
           Y2Storage::AutoinstProfile::PartitioningSection
             .new_from_storage(manager.probed)
         else
-          Y2Storage::AutoinstProfile::PartitioningSection.new
+          Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([{ disk: :CT_DISK }])
         end
       Y2Autoinstallation::Dialogs::Storage.new(partitioning)
     end

--- a/src/clients/storage_auto.rb
+++ b/src/clients/storage_auto.rb
@@ -2,8 +2,11 @@
 # Package:  Autoinstallation Configuration System
 # Summary:  Storage
 # Authors:  Anas Nashif<nashif@suse.de>
-#
-# $Id$
+
+require "autoinstall/dialogs/storage"
+require "y2storage/storage_manager"
+require "y2storage/autoinst_profile/partitioning_section"
+
 module Yast
   class StorageAutoClient < Client
     include Yast::Logger
@@ -60,8 +63,7 @@ module Yast
         @ret = []
       # Change configuration (run AutoSequence)
       elsif @func == "Change"
-        @ret = StorageDialog()
-        UI.CloseDialog
+        @ret = storage_dialog.run
       # Return actual state
       elsif @func == "Export"
         @ret = AutoinstPartPlan.Export
@@ -82,6 +84,25 @@ module Yast
       deep_copy(@ret)
 
       # EOF
+    end
+
+  private
+
+    # Returns the storage dialog
+    #
+    # It uses the probed storage version is available
+    #
+    # @return [Y2Storage::Dialogs::Storage] Storage dialog
+    def storage_dialog
+      manager = Y2Storage::StorageManager.instance
+      partitioning =
+        if manager.probed?
+          Y2Storage::AutoinstProfile::PartitioningSection
+            .new_from_storage(manager.probed)
+        else
+          Y2Storage::AutoinstProfile::PartitioningSection.new
+        end
+      Y2Autoinstallation::Dialogs::Storage.new(partitioning)
     end
   end
 end

--- a/src/clients/storage_auto.rb
+++ b/src/clients/storage_auto.rb
@@ -63,7 +63,9 @@ module Yast
         @ret = []
       # Change configuration (run AutoSequence)
       elsif @func == "Change"
+        storage_dialog = build_storage_dialog
         @ret = storage_dialog.run
+        AutoinstPartPlan.Import(storage_dialog.partitioning.to_hashes) if @ret == :next
       # Return actual state
       elsif @func == "Export"
         @ret = AutoinstPartPlan.Export
@@ -88,20 +90,16 @@ module Yast
 
   private
 
-    # Returns the storage dialog
+    # Returns a dialog to edit the storage
     #
     # It uses the probed storage version is available
     #
     # @return [Y2Storage::Dialogs::Storage] Storage dialog
-    def storage_dialog
-      manager = Y2Storage::StorageManager.instance
-      partitioning =
-        if manager.probed?
-          Y2Storage::AutoinstProfile::PartitioningSection
-            .new_from_storage(manager.probed)
-        else
-          Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([{ disk: :CT_DISK }])
-        end
+    def build_storage_dialog
+      part_plan = AutoinstPartPlan.Export
+      # FIXME: workaround to avoid crashing the dialog
+      part_plan = [{ "type" => :CT_DISK }] if part_plan.empty?
+      partitioning = Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(part_plan)
       Y2Autoinstallation::Dialogs::Storage.new(partitioning)
     end
   end

--- a/src/lib/autoinstall/dialogs/storage.rb
+++ b/src/lib/autoinstall/dialogs/storage.rb
@@ -23,6 +23,7 @@ require "autoinstall/widgets/storage/overview_tree_pager"
 require "autoinstall/storage_controller"
 
 Yast.import "Label"
+Yast.import "Popup"
 
 module Y2Autoinstallation
   module Dialogs
@@ -66,13 +67,19 @@ module Y2Autoinstallation
       end
 
       # @macro seeDialog
-      def cancel_button
-        ""
+      def back_button
+        Yast::Label.CancelButton
       end
 
       # @macro seeDialog
       def next_handler
-        controller.partitioning
+        @partitioning = controller.partitioning
+        true
+      end
+
+      # @macro seeDialog
+      def back_handler
+        Yast::Popup.ReallyAbort(controller.modified?)
       end
 
       def should_open_dialog?

--- a/src/lib/autoinstall/dialogs/storage.rb
+++ b/src/lib/autoinstall/dialogs/storage.rb
@@ -20,6 +20,7 @@
 require "cwm"
 require "cwm/dialog"
 require "autoinstall/widgets/storage/overview_tree_pager"
+require "autoinstall/storage_controller"
 
 Yast.import "Label"
 
@@ -42,7 +43,7 @@ module Y2Autoinstallation
       #   Partitioning section of the profile
       def initialize(partitioning)
         textdomain "autoinst"
-        @partitioning = partitioning
+        @controller = Y2Autoinstallation::StorageController.new(partitioning)
       end
 
       # @macro seeDialog
@@ -50,9 +51,7 @@ module Y2Autoinstallation
         MarginBox(
           0.5,
           0.5,
-          Y2Autoinstallation::Widgets::Storage::OverviewTreePager.new(
-            partitioning
-          )
+          Y2Autoinstallation::Widgets::Storage::OverviewTreePager.new(controller)
         )
       end
 
@@ -73,7 +72,26 @@ module Y2Autoinstallation
 
       # @macro seeDialog
       def next_handler
-        partitioning
+        controller.partitioning
+      end
+
+      def should_open_dialog?
+        true
+      end
+
+    private
+
+      attr_reader :controller
+
+      # CWM show loop
+      #
+      # This method is redefined to keep the dialog in a loop if a
+      # `redraw` is needed.
+      def cwm_show
+        loop do
+          result = super
+          return result unless result == :redraw
+        end
       end
     end
   end

--- a/src/lib/autoinstall/dialogs/storage.rb
+++ b/src/lib/autoinstall/dialogs/storage.rb
@@ -1,0 +1,80 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+require "cwm/dialog"
+require "autoinstall/widgets/storage/overview_tree_pager"
+
+Yast.import "Label"
+
+module Y2Autoinstallation
+  module Dialogs
+    # Dialog to set up the partition plan
+    #
+    # @example Edit a partitioning section
+    #   devicegraph = devicegraph = Y2Storage::StorageManager.instance.probed
+    #   partitioning = Y2Storage::Autoinst::PartitioningSection.new_from_storage(devicegraph)
+    #   result = Y2Autoinstallation::Dialogs::Storage.new(partitioning).run
+    class Storage < CWM::Dialog
+      # @return [Y2Storage::AutoinstProfile::PartitioningSection]
+      #   Partitioning section of the profile
+      attr_reader :partitioning
+
+      # Constructor
+      #
+      # @param partitioning [Y2Storage::AutoinstProfile::PartitioningSection]
+      #   Partitioning section of the profile
+      def initialize(partitioning)
+        textdomain "autoinst"
+        @partitioning = partitioning
+      end
+
+      # @macro seeDialog
+      def contents
+        MarginBox(
+          0.5,
+          0.5,
+          Y2Autoinstallation::Widgets::Storage::OverviewTreePager.new(
+            partitioning
+          )
+        )
+      end
+
+      # @macro seeDialog
+      def next_button
+        Yast::Label.FinishButton
+      end
+
+      # @macro seeDialog
+      def abort_button
+        ""
+      end
+
+      # @macro seeDialog
+      def cancel_button
+        ""
+      end
+
+      # @macro seeDialog
+      def next_handler
+        partitioning
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -36,6 +36,7 @@ module Y2Autoinstallation
     #   Partitioning section of the profile
     def initialize(partitioning)
       @partitioning = partitioning
+      @modified = false
     end
 
     TYPES_MAP = {
@@ -56,6 +57,14 @@ module Y2Autoinstallation
     # @param parent [Y2Storage::AutoinstProfile::DriveSection] Parent section
     def add_partition(parent)
       parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new
+    end
+
+    # It determines whether the profile was modified
+    #
+    # @todo Implement logic to detect whether the partitioning
+    #   was modified or not.
+    def modified?
+      true
     end
   end
 end

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -1,0 +1,54 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+
+module Y2Autoinstallation
+  # Controller for the edition of the partitioning section of a profile
+  #
+  # It is supposed to be used internally by
+  # {Y2Autoinstallation::Dialogs::Storage}.
+  class StorageController
+    # @return [Y2Storage::AutoinstProfile::PartitioningSection]
+    #   Partition section
+    attr_reader :partitioning
+
+    # Constructor
+    #
+    # @param partitioning [Y2Storage::AutoinstProfile::PartitioningSection]
+    #   Partitioning section of the profile
+    def initialize(partitioning)
+      @partitioning = partitioning
+    end
+
+    TYPES_MAP = {
+      disk: :CT_DISK
+    }.freeze
+
+    # Adds a new drive section of the given type
+    #
+    # @param type [Symbol]
+    def add_drive(type)
+      section = Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(type: TYPES_MAP[type])
+      partitioning.drives << section
+      section
+    end
+  end
+end

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -50,5 +50,12 @@ module Y2Autoinstallation
       partitioning.drives << section
       section
     end
+
+    # Adds a new partition section under the given section
+    #
+    # @param parent [Y2Storage::AutoinstProfile::DriveSection] Parent section
+    def add_partition(parent)
+      parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new
+    end
   end
 end

--- a/src/lib/autoinstall/ui_state.rb
+++ b/src/lib/autoinstall/ui_state.rb
@@ -1,0 +1,33 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/ui_state"
+
+module Y2Autoinstallation
+  # Singleton class to keep the position of the user in the UI and other similar
+  # information that needs to be rememberd across UI redraws to give the user a
+  # sense of continuity.
+  class UIState < CWM::UIState
+    # @see CWM::UIState#textdomain_name
+    def textdomain_name
+      "autoinst"
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets.rb
+++ b/src/lib/autoinstall/widgets.rb
@@ -1,0 +1,26 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# Work around YARD inability to link across repos/gems:
+# @!macro [new] seeAbstractWidget
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FAbstractWidget:${0}
+# @!macro [new] seeCustomWidget
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FCustomWidget:${0}
+# @!macro [new] seeDialog
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FDialog:${0}

--- a/src/lib/autoinstall/widgets.rb
+++ b/src/lib/autoinstall/widgets.rb
@@ -24,3 +24,5 @@
 #   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FCustomWidget:${0}
 # @!macro [new] seeDialog
 #   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FDialog:${0}
+# @!macro [new] seeComboBox
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FComboBox:${0}

--- a/src/lib/autoinstall/widgets/editable_combo_box.rb
+++ b/src/lib/autoinstall/widgets/editable_combo_box.rb
@@ -1,0 +1,54 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Autoinstallation
+  module Widgets
+    # Mixin to extend the #value= method for editable ComboBox widgets
+    #
+    # Ideally, this behaviour might be implemented in the original
+    # {CWM::ComboBox}.
+    #
+    # @example Define an editable combo box
+    #  class MyComboBox < CWM::ComboBox
+    #    include EditableComboBox
+    #
+    #    def opt
+    #      [:editable]
+    #    end
+    #  end
+    #
+    # As you can see in the example, you need to define the
+    # {#opt} method to include the `:editable` option.
+    module EditableComboBox
+      # Changes the list of items
+      #
+      # @see seeComboBox
+      def change_items(new_items)
+        @items = new_items
+        super(new_items)
+      end
+
+      # @macro seeAbstractWidget
+      def value=(val)
+        change_items(items + [[val, val]]) if val && !items.map(&:first).include?(val)
+        super(val)
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/editable_combo_box.rb
+++ b/src/lib/autoinstall/widgets/editable_combo_box.rb
@@ -22,7 +22,7 @@ module Y2Autoinstallation
     # Mixin to extend the #value= method for editable ComboBox widgets
     #
     # Ideally, this behaviour might be implemented in the original
-    # {CWM::ComboBox}.
+    # CWM ComboBox class.
     #
     # @example Define an editable combo box
     #  class MyComboBox < CWM::ComboBox
@@ -34,11 +34,11 @@ module Y2Autoinstallation
     #  end
     #
     # As you can see in the example, you need to define the
-    # {#opt} method to include the `:editable` option.
+    # `#opt` method to include the `:editable` option.
     module EditableComboBox
       # Changes the list of items
       #
-      # @see seeComboBox
+      # @macro seeComboBox
       def change_items(new_items)
         @items = new_items
         super(new_items)

--- a/src/lib/autoinstall/widgets/storage/add_drive_button.rb
+++ b/src/lib/autoinstall/widgets/storage/add_drive_button.rb
@@ -1,0 +1,75 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Button to add new drive sections
+      #
+      # This button allows to add new drive sections of different types
+      # (`CT_DISK`, `CT_LVM`, `CT_RAID`, etc.).
+      class AddDriveButton < CWM::MenuButton
+        include Yast::Logger
+
+        # Constructor
+        #
+        # @param controller [Y2Autoinstallation::StorageController] UI controller
+        def initialize(controller)
+          textdomain "autoinst"
+          super()
+          @controller = controller
+          self.handle_all_events = true
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Add")
+        end
+
+        # Returns the list of possible actions
+        #
+        # @return [Array<Symbol,String>]
+        def items
+          [
+            [:add_disk, _("Disk")]
+          ]
+        end
+
+        # Handles the events
+        #
+        # @param event [Hash] Event to handle
+        def handle(event)
+          case event["ID"]
+          when :add_disk
+            controller.add_drive(:disk)
+            :redraw
+          end
+        end
+
+      private
+
+        # @return [Y2Autoinstallation::StorageController]
+        attr_reader :controller
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/disk_device.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_device.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/common_widgets"
+require "autoinstall/widgets/editable_combo_box"
 
 module Y2Autoinstallation
   module Widgets
@@ -27,6 +28,8 @@ module Y2Autoinstallation
       #
       # It corresponds to the `device` element in the profile.
       class DiskDevice < CWM::ComboBox
+        include EditableComboBox
+
         # Constructor
         #
         # @param initial [String,nil] Initial value
@@ -56,19 +59,6 @@ module Y2Autoinstallation
         # @return [Array<Array<String, String>>] List of possible values
         def items
           @items ||= [["", "auto"]] + DISKS.map { |i| [i, i] }
-        end
-
-        # Changes the list of items
-        #
-        # @see seeComboBox
-        def change_items(new_items)
-          @items = new_items
-          super(new_items)
-        end
-
-        def value=(val)
-          change_items(items + [[val, val]]) if val && !items.map(&:first).include?(val)
-          super(val)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/disk_device.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_device.rb
@@ -31,8 +31,6 @@ module Y2Autoinstallation
         include EditableComboBox
 
         # Constructor
-        #
-        # @param initial [String,nil] Initial value
         def initialize
           textdomain "autoinst"
           super

--- a/src/lib/autoinstall/widgets/storage/disk_device.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_device.rb
@@ -1,0 +1,74 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to select a block device for a partition section
+      class DiskDevice < CWM::ComboBox
+        # Constructor
+        #
+        # @param initial [String,nil] Initial value
+        def initialize(initial: nil)
+          textdomain "autoinst"
+          @initial = initial
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          self.value = initial if initial
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Device")
+        end
+
+        # @macro seeAbstractWidget
+        def opt
+          [:editable, :hstretch]
+        end
+
+        DISKS = [
+          "/dev/sda", "/dev/sdb", "/dev/vda", "/dev/vdb", "/dev/hda", "/dev/hdb"
+        ].freeze
+        private_constant :DISKS
+
+        # Returns the list of possible values
+        #
+        # @return [Array<Array<String, String>>] List of possible values
+        def items
+          return @items if @items
+
+          known_disks = DISKS.dup
+          known_disks.unshift(initial) if initial && !known_disks.include?(initial)
+          @items = [["", "auto"]] + known_disks.map { |i| [i, i] }
+        end
+
+      private
+
+        # @return [String,nil] Initial value
+        attr_reader :initial
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/disk_device.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_device.rb
@@ -24,18 +24,15 @@ module Y2Autoinstallation
   module Widgets
     module Storage
       # Widget to select a block device for a partition section
+      #
+      # It corresponds to the `device` element in the profile.
       class DiskDevice < CWM::ComboBox
         # Constructor
         #
         # @param initial [String,nil] Initial value
-        def initialize(initial: nil)
+        def initialize
           textdomain "autoinst"
-          @initial = initial
-        end
-
-        # @macro seeAbstractWidget
-        def init
-          self.value = initial if initial
+          super
         end
 
         # @macro seeAbstractWidget
@@ -45,7 +42,7 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def opt
-          [:editable, :hstretch]
+          [:editable]
         end
 
         DISKS = [
@@ -53,21 +50,26 @@ module Y2Autoinstallation
         ].freeze
         private_constant :DISKS
 
-        # Returns the list of possible values
+        # Returns the list of items
         #
+        # @macro seeComboBox
         # @return [Array<Array<String, String>>] List of possible values
         def items
-          return @items if @items
-
-          known_disks = DISKS.dup
-          known_disks.unshift(initial) if initial && !known_disks.include?(initial)
-          @items = [["", "auto"]] + known_disks.map { |i| [i, i] }
+          @items ||= [["", "auto"]] + DISKS.map { |i| [i, i] }
         end
 
-      private
+        # Changes the list of items
+        #
+        # @see seeComboBox
+        def change_items(new_items)
+          @items = new_items
+          super(new_items)
+        end
 
-        # @return [String,nil] Initial value
-        attr_reader :initial
+        def value=(val)
+          change_items(items + [[val, val]]) if val && !items.map(&:first).include?(val)
+          super(val)
+        end
       end
     end
   end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -125,7 +125,7 @@ module Y2Autoinstallation
 
         # Initialize drive widget
         #
-        # @param [InitDrive]
+        # @return [InitDrive]
         def init_drive_widget
           @init_drive_widget ||= InitDrive.new
         end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/page"
+require "autoinstall/widgets/storage/disk_device"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # This page allows to edit usage information for a disk
+      class DiskPage < ::CWM::Page
+        # @return [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
+        #   to a disk
+        attr_reader :section
+
+        # Constructor
+        #
+        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
+        #   to a disk
+        def initialize(section)
+          textdomain "autoinst"
+          @section = section
+          super()
+          self.widget_id = "disk_page:#{object_id}"
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          if section.device && !section.device.empty?
+            format(_("Disk %{device}"), device: section.device)
+          else
+            format(_("Disk"))
+          end
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          return @contents if @contents
+          @contents = VBox(
+            Left(Heading(label)),
+            disk_device_widget,
+          )
+        end
+
+      private
+
+        # Disk device selector
+        #
+        # @return [DiskDevice]
+        def disk_device_widget
+          @disk_device_widget ||= DiskDevice.new(initial: section.device)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -52,11 +52,15 @@ module Y2Autoinstallation
 
         # @macro seeCustomWidget
         def contents
-          return @contents if @contents
-          @contents = VBox(
+          VBox(
             Left(Heading(label)),
             disk_device_widget,
           )
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          section.device = disk_device_widget.value
         end
 
       private
@@ -65,7 +69,7 @@ module Y2Autoinstallation
         #
         # @return [DiskDevice]
         def disk_device_widget
-          @disk_device_widget ||= DiskDevice.new(initial: section.device)
+          DiskDevice.new(initial: section.device)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -37,7 +37,7 @@ module Y2Autoinstallation
           @controller = controller
           @section = section
           super()
-          self.widget_id = "disk_page:#{object_id}"
+          self.widget_id = "disk_page:#{section.object_id}"
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -63,6 +63,11 @@ module Y2Autoinstallation
         end
 
         # @macro seeAbstractWidget
+        def init
+          disk_device_widget.value = section.device
+        end
+
+        # @macro seeAbstractWidget
         def store
           section.device = disk_device_widget.value
         end
@@ -79,7 +84,8 @@ module Y2Autoinstallation
         #
         # @return [DiskDevice]
         def disk_device_widget
-          DiskDevice.new(initial: section.device)
+          @disk_device_widget ||= DiskDevice.new
+          end
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -90,9 +90,7 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def handle(event)
-          if event["ID"] == init_drive_widget.widget_id
-            set_disk_usage_status
-          end
+          set_disk_usage_status if event["ID"] == init_drive_widget.widget_id
           nil
         end
 

--- a/src/lib/autoinstall/widgets/storage/disk_usage.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_usage.rb
@@ -1,0 +1,66 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+require "autoinstall/widgets/editable_combo_box"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to determine how the disk will be used
+      #
+      # It corresponds to the `use` element in the profile.
+      class DiskUsage < CWM::ComboBox
+        extend Yast::I18n
+        include EditableComboBox
+
+        def initialize
+          textdomain "autoinst"
+          super
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Reuse")
+        end
+
+        # @macro seeAbstractWidget
+        def opt
+          [:editable]
+        end
+
+        ITEMS = [:all, :free, :linux].freeze
+        ITEMS_LABELS = {
+          all:   N_("All partitions"),
+          linux: N_("Linux partitions"),
+          free:  N_("Only free space")
+        }.freeze
+        private_constant :ITEMS, :ITEMS_LABELS
+
+        # @macro seeComboBox
+        def items
+          @items ||= ITEMS.map do |opt|
+            [opt.to_s, _(ITEMS_LABELS[opt])]
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/init_drive.rb
+++ b/src/lib/autoinstall/widgets/storage/init_drive.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to determine if the disk should be initialized
+      #
+      # It corresponds to the `initialize` element in the profile.
+      class InitDrive < CWM::CheckBox
+        def initialize
+          textdomain "autoinst"
+          super
+          self.widget_id = "init_drive"
+        end
+
+        # @macro seeAbstractWidget
+        def opt
+          [:notify]
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Initialize Drive")
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/mount_point.rb
+++ b/src/lib/autoinstall/widgets/storage/mount_point.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to select the mount point for a file system
+
+      # Constructor
+      #
+      # @param initial [String,nil] Initial value
+      class MountPoint < CWM::ComboBox
+        def initialize(initial: nil)
+          @initial = initial
+          super()
+        end
+
+        def opt
+          [:editable, :hstretch]
+        end
+
+        def init
+          self.value = @initial
+        end
+
+        ITEMS = [
+          "/",
+          "/boot",
+          "/srv",
+          "/tmp",
+          "/usr/local",
+          "swap"
+        ].freeze
+        private_constant :ITEMS
+
+        def items
+          return @items if @items
+          known_items = ITEMS.dup
+          known_items.unshift(@initial) if @initial && !ITEMS.include?(@initial)
+          @items = known_items.map { |i| [i, i] }
+        end
+
+        def label
+          _("Mount point")
+        end
+
+      private
+
+        # @return [String,nil] Initial value
+        attr_reader :initial
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/mount_point.rb
+++ b/src/lib/autoinstall/widgets/storage/mount_point.rb
@@ -29,18 +29,18 @@ module Y2Autoinstallation
       #
       # @param initial [String,nil] Initial value
       class MountPoint < CWM::ComboBox
-        def initialize(initial: nil)
+        def initialize
           textdomain "autoinst"
-          @initial = initial
-          super()
+          super
         end
 
+        def label
+          _("Mount point")
+        end
+
+        # @macro seeAbstractWidget
         def opt
-          [:editable, :hstretch]
-        end
-
-        def init
-          self.value = @initial
+          [:editable]
         end
 
         ITEMS = [
@@ -53,22 +53,22 @@ module Y2Autoinstallation
         ].freeze
         private_constant :ITEMS
 
+        # @macro seeComboBox
         def items
-          return @items if @items
-
-          known_items = ITEMS.dup
-          known_items.unshift(@initial) if @initial && !ITEMS.include?(@initial)
-          @items = known_items.map { |i| [i, i] }
+          @items ||= ITEMS.map { |i| [i, i] }
         end
 
-        def label
-          _("Mount point")
+        # @see seeComboBox
+        def change_items(new_items)
+          @items = new_items
+          super(new_items)
         end
 
-      private
-
-        # @return [String,nil] Initial value
-        attr_reader :initial
+        # @see seeAbstractWidget
+        def value=(val)
+          change_items(items + [[val, val]]) if val && !items.map(&:first).include?(val)
+          super(val)
+        end
       end
     end
   end

--- a/src/lib/autoinstall/widgets/storage/mount_point.rb
+++ b/src/lib/autoinstall/widgets/storage/mount_point.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/common_widgets"
+require "autoinstall/widgets/editable_combo_box"
 
 module Y2Autoinstallation
   module Widgets
@@ -29,6 +30,8 @@ module Y2Autoinstallation
       #
       # @param initial [String,nil] Initial value
       class MountPoint < CWM::ComboBox
+        include EditableComboBox
+
         def initialize
           textdomain "autoinst"
           super
@@ -56,18 +59,6 @@ module Y2Autoinstallation
         # @macro seeComboBox
         def items
           @items ||= ITEMS.map { |i| [i, i] }
-        end
-
-        # @see seeComboBox
-        def change_items(new_items)
-          @items = new_items
-          super(new_items)
-        end
-
-        # @see seeAbstractWidget
-        def value=(val)
-          change_items(items + [[val, val]]) if val && !items.map(&:first).include?(val)
-          super(val)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/mount_point.rb
+++ b/src/lib/autoinstall/widgets/storage/mount_point.rb
@@ -30,6 +30,7 @@ module Y2Autoinstallation
       # @param initial [String,nil] Initial value
       class MountPoint < CWM::ComboBox
         def initialize(initial: nil)
+          textdomain "autoinst"
           @initial = initial
           super()
         end
@@ -54,6 +55,7 @@ module Y2Autoinstallation
 
         def items
           return @items if @items
+
           known_items = ITEMS.dup
           known_items.unshift(@initial) if @initial && !ITEMS.include?(@initial)
           @items = known_items.map { |i| [i, i] }

--- a/src/lib/autoinstall/widgets/storage/overview_tree.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree.rb
@@ -1,0 +1,47 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/tree"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # A tree that is told what its items are.
+      # We need a tree whose items include Pages that point to the OverviewTreePager.
+      class OverviewTree < CWM::Tree
+        # @return [Array<CWM::PagerTreeItem>] List of tree items
+        attr_reader :items
+
+        # Constructor
+        #
+        # @param items [Array<CWM::PagerTreeItem>] List of tree items to be included
+        def initialize(items)
+          textdomain "autoinst"
+          @items = items
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          ""
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -23,6 +23,7 @@ require "autoinstall/widgets/storage/overview_tree"
 require "autoinstall/widgets/storage/disk_page"
 require "autoinstall/widgets/storage/partition_page"
 require "autoinstall/widgets/storage/add_drive_button"
+require "autoinstall/ui_state"
 
 module Y2Autoinstallation
   module Widgets
@@ -50,6 +51,24 @@ module Y2Autoinstallation
           controller.partitioning.drives.each_with_object([]) do |drive, all|
             all << drive_item(drive)
           end
+        end
+
+        # Switch to the given page
+        #
+        # It redefines the original implementation to save the current
+        # page and refresh the tree.
+        #
+        # @param page [CWM::Page] Page to change to
+        def switch_page(page)
+          UIState.instance.go_to_tree_node(page)
+          tree.change_items(items)
+          super
+        end
+
+        # Ensures the tree is properly initialized according to the UI state after
+        # a redraw
+        def initial_page
+          UIState.instance.find_tree_node(@pages) || super
         end
 
       private

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -76,10 +76,12 @@ module Y2Autoinstallation
         #   to a disk
         def disk_item(section)
           children = section.partitions.map do |part|
-            part_page = Y2Autoinstallation::Widgets::Storage::PartitionPage.new(part)
+            part_page = Y2Autoinstallation::Widgets::Storage::PartitionPage.new(
+              controller, section, part
+            )
             CWM::PagerTreeItem.new(part_page)
           end
-          page = Y2Autoinstallation::Widgets::Storage::DiskPage.new(section)
+          page = Y2Autoinstallation::Widgets::Storage::DiskPage.new(controller, section)
           CWM::PagerTreeItem.new(page, children: children)
         end
       end

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -1,0 +1,78 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+require "cwm/tree_pager"
+require "autoinstall/widgets/storage/overview_tree"
+require "autoinstall/widgets/storage/disk_page"
+require "autoinstall/widgets/storage/partition_page"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      class OverviewTreePager < CWM::TreePager
+        # @return [Y2Storage::AutoinstProfile::PartitioningSection]
+        #   Partitioning section of the profile
+        attr_reader :partitioning
+
+        # @constructor
+        #
+        # @param partitioning [Y2Storage::AutoinstProfile::PartitioningSection]
+        #   Partitioning section to edit
+        def initialize(partitioning)
+          textdomain("autoinst")
+          @partitioning = partitioning
+
+          super(OverviewTree.new(items))
+        end
+
+        # @return [Array<CWM::PagerTreeItem>] List of tree items
+        def items
+          @items ||= partitioning.drives.each_with_object([]) do |drive, all|
+            all << drive_item(drive)
+          end
+        end
+
+      private
+
+        # Returns the drive item for the given section
+        #
+        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section
+        # @return [CWM::PagerTreeItem] Tree item
+        def drive_item(section)
+          case section.type
+          when :CT_DISK
+            disk_item(section)
+          end
+        end
+
+        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
+        #   to a disk
+        def disk_item(section)
+          children = section.partitions.map do |part|
+            part_page = Y2Autoinstallation::Widgets::Storage::PartitionPage.new(part)
+            CWM::PagerTreeItem.new(part_page)
+          end
+          page = Y2Autoinstallation::Widgets::Storage::DiskPage.new(section)
+          CWM::PagerTreeItem.new(page, children: children)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -22,34 +22,44 @@ require "cwm/tree_pager"
 require "autoinstall/widgets/storage/overview_tree"
 require "autoinstall/widgets/storage/disk_page"
 require "autoinstall/widgets/storage/partition_page"
+require "autoinstall/widgets/storage/add_drive_button"
 
 module Y2Autoinstallation
   module Widgets
     module Storage
       class OverviewTreePager < CWM::TreePager
-        # @return [Y2Storage::AutoinstProfile::PartitioningSection]
-        #   Partitioning section of the profile
-        attr_reader :partitioning
-
-        # @constructor
+        # Constructor
         #
-        # @param partitioning [Y2Storage::AutoinstProfile::PartitioningSection]
-        #   Partitioning section to edit
-        def initialize(partitioning)
+        # @param controller [Y2Autoinstallation::StorgeController] UI controller
+        def initialize(controller)
           textdomain("autoinst")
-          @partitioning = partitioning
+          @controller = controller
 
-          super(OverviewTree.new(items))
+          super(tree)
+        end
+
+        def contents
+          VBox(
+            super,
+            Left(AddDriveButton.new(controller))
+          )
         end
 
         # @return [Array<CWM::PagerTreeItem>] List of tree items
         def items
-          @items ||= partitioning.drives.each_with_object([]) do |drive, all|
+          controller.partitioning.drives.each_with_object([]) do |drive, all|
             all << drive_item(drive)
           end
         end
 
       private
+
+        # @return [Y2Autoinstallation::StorageController]
+        attr_reader :controller
+
+        def tree
+          @tree ||= OverviewTree.new(items)
+        end
 
         # Returns the drive item for the given section
         #

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -58,9 +58,13 @@ module Y2Autoinstallation
         # @macro seeCustomWidget
         def contents
           VBox(
-            Left(Heading(label)),
-            mount_point_widget,
-            VStretch(),
+            Left(Heading(_("Partition"))),
+            Left(
+              VBox(
+                mount_point_widget,
+                VStretch()
+              )
+            ),
             HBox(
               HStretch(),
               AddChildrenButton.new(controller, drive)

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -1,0 +1,75 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/page"
+require "autoinstall/widgets/storage/mount_point"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # This page allows to edit the information of a partition
+      #
+      # Depending on its usage (file system, LVM PV, RAID member, etc.) it may
+      # display a different set of widgets.
+      class PartitionPage < ::CWM::Page
+        # @return [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+        attr_reader :section
+
+        # Constructor
+        #
+        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+        #   of the profile
+        def initialize(section)
+          textdomain "autoinst"
+          @section = section
+          super()
+          self.widget_id = "partition_page:#{object_id}"
+        end
+
+        # @macro abstractWidget
+        def label
+          if section.mount && !section.mount.empty?
+            format(_("Partition at %{mount_point}"), mount_point: section.mount)
+          else
+            _("Partition")
+          end
+        end
+
+        # @macro customWidget
+        def contents
+          VBox(
+            Left(Heading(label)),
+            mount_point_widget
+          )
+        end
+
+      private
+
+        # Mount point widget
+        #
+        # @return [MountPoint]
+        def mount_point_widget
+          return @mount_point_widget if @mount_point_widget
+          @mount_point_widget = MountPoint.new(initial: section.mount)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -43,7 +43,7 @@ module Y2Autoinstallation
           self.widget_id = "partition_page:#{object_id}"
         end
 
-        # @macro abstractWidget
+        # @macro seeAbstractWidget
         def label
           if section.mount && !section.mount.empty?
             format(_("Partition at %{mount_point}"), mount_point: section.mount)
@@ -52,12 +52,17 @@ module Y2Autoinstallation
           end
         end
 
-        # @macro customWidget
+        # @macro seeCustomWidget
         def contents
           VBox(
             Left(Heading(label)),
             mount_point_widget
           )
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          section.mount = mount_point_widget.value
         end
 
       private
@@ -66,8 +71,7 @@ module Y2Autoinstallation
         #
         # @return [MountPoint]
         def mount_point_widget
-          return @mount_point_widget if @mount_point_widget
-          @mount_point_widget = MountPoint.new(initial: section.mount)
+          MountPoint.new(initial: section.mount)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/page"
+require "autoinstall/widgets/storage/add_children_button"
 require "autoinstall/widgets/storage/mount_point"
 
 module Y2Autoinstallation
@@ -29,16 +30,18 @@ module Y2Autoinstallation
       # Depending on its usage (file system, LVM PV, RAID member, etc.) it may
       # display a different set of widgets.
       class PartitionPage < ::CWM::Page
-        # @return [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-        attr_reader :section
-
         # Constructor
         #
+        # @param controller [Y2Autoinstallation::StorageController] UI controller
+        # @param drive [Y2Storage::AutoinstProfile::DriveSection] Drive section
+        #   of the profile
         # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
         #   of the profile
-        def initialize(section)
+        def initialize(controller, drive, section)
           textdomain "autoinst"
+          @controller = controller
           @section = section
+          @drive = drive
           super()
           self.widget_id = "partition_page:#{object_id}"
         end
@@ -56,7 +59,12 @@ module Y2Autoinstallation
         def contents
           VBox(
             Left(Heading(label)),
-            mount_point_widget
+            mount_point_widget,
+            VStretch(),
+            HBox(
+              HStretch(),
+              AddChildrenButton.new(controller, drive)
+            )
           )
         end
 
@@ -66,6 +74,15 @@ module Y2Autoinstallation
         end
 
       private
+
+        # @return [Y2Autoinstallation::StorageController]
+        attr_reader :controller
+
+        # @return [Y2Storage::AutoinstProfile::DriveSection]
+        attr_reader :drive
+
+        # @return [Y2Storage::AutoinstProfile::PartitionSection]
+        attr_reader :section
 
         # Mount point widget
         #

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -43,7 +43,7 @@ module Y2Autoinstallation
           @section = section
           @drive = drive
           super()
-          self.widget_id = "partition_page:#{object_id}"
+          self.widget_id = "partition_page:#{section.object_id}"
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -69,6 +69,11 @@ module Y2Autoinstallation
         end
 
         # @macro seeAbstractWidget
+        def init
+          mount_point_widget.value = section.mount
+        end
+
+        # @macro seeAbstractWidget
         def store
           section.mount = mount_point_widget.value
         end
@@ -88,7 +93,7 @@ module Y2Autoinstallation
         #
         # @return [MountPoint]
         def mount_point_widget
-          MountPoint.new(initial: section.mount)
+          @mount_point_widget ||= MountPoint.new
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/partition_table.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_table.rb
@@ -1,0 +1,60 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to set the type of partition table to use
+      #
+      # It corresponds to the `disklabel` element in the profile.
+      class PartitionTable < CWM::ComboBox
+        extend Yast::I18n
+
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Partition table")
+        end
+
+        ITEMS = [:msdos, :gpt, :none].freeze
+        ITEMS_LABELS = {
+          msdos: N_("MSDOS"),
+          gpt:   N_("GPT"),
+          none:  N_("None")
+        }.freeze
+        private_constant :ITEMS, :ITEMS_LABELS
+
+        # @return [Array<Array<String,String>>] List of possible values
+        def items
+          ITEMS.map do |opt|
+            [opt.to_s, _(ITEMS_LABELS[opt])]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/dialogs/storage_test.rb
+++ b/test/lib/dialogs/storage_test.rb
@@ -1,0 +1,30 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "autoinstall/dialogs/storage"
+require "y2storage"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Dialogs::Storage do
+  subject { described_class.new(partitioning) }
+  let(:partitioning) { Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([]) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/lib/storage_controller_test.rb
+++ b/test/lib/storage_controller_test.rb
@@ -17,26 +17,22 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/overview_tree_pager"
+require_relative "../test_helper"
 require "autoinstall/storage_controller"
-require "cwm/rspec"
+require "y2storage/autoinst_profile/partitioning_section"
 
-describe Y2Autoinstallation::Widgets::Storage::OverviewTreePager do
-  subject { described_class.new(controller) }
+describe Y2Autoinstallation::StorageController do
+  subject { described_class.new(partitioning) }
 
   let(:partitioning) do
-    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
-      [{ "mount" => "/dev/sda" }]
-    )
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([])
   end
 
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
-
-  describe "#items" do
-    it "returns one item for each drive" do
-      items = subject.items
-      expect(items.size).to eq(1)
+  describe "#add" do
+    it "adds a new section with the given type" do
+      subject.add_drive(:disk)
+      new_drive = partitioning.drives.first
+      expect(new_drive.type).to eq(:CT_DISK)
     end
   end
 end

--- a/test/lib/widgets/storage/add_drive_button_test.rb
+++ b/test/lib/widgets/storage/add_drive_button_test.rb
@@ -18,25 +18,26 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/overview_tree_pager"
-require "autoinstall/storage_controller"
-require "cwm/rspec"
+require "autoinstall/widgets/storage/add_drive_button"
 
-describe Y2Autoinstallation::Widgets::Storage::OverviewTreePager do
+describe Y2Autoinstallation::Widgets::Storage::AddDriveButton do
   subject { described_class.new(controller) }
 
+  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
   let(:partitioning) do
-    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
-      [{ "mount" => "/dev/sda" }]
-    )
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([])
   end
 
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+  describe "#handle" do
+    let(:event) do
+      { "ID" => :add_disk }
+    end
 
-  describe "#items" do
-    it "returns one item for each drive" do
-      items = subject.items
-      expect(items.size).to eq(1)
+    context "adding a disk" do
+      it "adds a disk" do
+        expect(controller).to receive(:add_drive).with(:disk)
+        subject.handle(event)
+      end
     end
   end
 end

--- a/test/lib/widgets/storage/disk_device_test.rb
+++ b/test/lib/widgets/storage/disk_device_test.rb
@@ -20,28 +20,11 @@
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/disk_device"
 require "cwm/rspec"
+require_relative TESTS_PATH.join("support", "editable_combo_box_examples").to_s
 
 describe Y2Autoinstallation::Widgets::Storage::DiskDevice do
   subject { described_class.new }
 
   include_examples "CWM::ComboBox"
-
-  describe "#value=" do
-    let(:unknown) { "/dev/test" }
-
-    context "when an unknown value is given" do
-      it "adds the value to the list of items" do
-        subject.value = unknown
-        expect(subject.items.map(&:first)).to include(unknown)
-      end
-
-      it "sets the current value" do
-        allow(Yast::UI).to receive(:ChangeWidget)
-          .with(anything, :Items, anything)
-        expect(Yast::UI).to receive(:ChangeWidget)
-          .with(anything, :Value, unknown)
-        subject.value = unknown
-      end
-    end
-  end
+  include_examples "EditableComboBox"
 end

--- a/test/lib/widgets/storage/disk_device_test.rb
+++ b/test/lib/widgets/storage/disk_device_test.rb
@@ -1,0 +1,55 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/disk_device"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::DiskDevice do
+  subject { described_class.new(initial: initial) }
+  let(:initial) { "/dev/sdb" }
+
+  include_examples "CWM::ComboBox"
+
+  describe "#init" do
+    context "when an initial value is given" do
+      it "initializes the value" do
+        expect(subject).to receive(:value=).with(initial)
+        subject.init
+      end
+    end
+
+    context "when no initial value was given" do
+      subject { described_class.new }
+
+      it "does not initialize the value" do
+        expect(subject).to_not receive(:value=)
+        subject.init
+      end
+    end
+  end
+
+  describe "#items" do
+    let(:initial) { "/dev/test" }
+
+    it "includes the initial value" do
+      expect(subject.items).to include([initial, initial])
+    end
+  end
+end

--- a/test/lib/widgets/storage/disk_device_test.rb
+++ b/test/lib/widgets/storage/disk_device_test.rb
@@ -22,34 +22,26 @@ require "autoinstall/widgets/storage/disk_device"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::DiskDevice do
-  subject { described_class.new(initial: initial) }
-  let(:initial) { "/dev/sdb" }
+  subject { described_class.new }
 
   include_examples "CWM::ComboBox"
 
-  describe "#init" do
-    context "when an initial value is given" do
-      it "initializes the value" do
-        expect(subject).to receive(:value=).with(initial)
-        subject.init
+  describe "#value=" do
+    let(:unknown) { "/dev/test" }
+
+    context "when an unknown value is given" do
+      it "adds the value to the list of items" do
+        subject.value = unknown
+        expect(subject.items.map(&:first)).to include(unknown)
       end
-    end
 
-    context "when no initial value was given" do
-      subject { described_class.new }
-
-      it "does not initialize the value" do
-        expect(subject).to_not receive(:value=)
-        subject.init
+      it "sets the current value" do
+        allow(Yast::UI).to receive(:ChangeWidget)
+          .with(anything, :Items, anything)
+        expect(Yast::UI).to receive(:ChangeWidget)
+          .with(anything, :Value, unknown)
+        subject.value = unknown
       end
-    end
-  end
-
-  describe "#items" do
-    let(:initial) { "/dev/test" }
-
-    it "includes the initial value" do
-      expect(subject.items).to include([initial, initial])
     end
   end
 end

--- a/test/lib/widgets/storage/disk_page_test.rb
+++ b/test/lib/widgets/storage/disk_page_test.rb
@@ -1,0 +1,50 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/disk_page"
+require "y2storage"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::DiskPage do
+  subject { described_class.new(drive) }
+  let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes({}) }
+
+  include_examples "CWM::Page"
+
+  describe "#label" do
+    before { drive.device = device }
+
+    context "when the partition device is defined" do
+      let(:device) { "/dev/sda" }
+
+      it "includes the device" do
+        expect(subject.label).to include("/dev/sda")
+      end
+    end
+
+    context "when the partition device is not defined" do
+      let(:device) { "" }
+
+      it "does not include the device" do
+        expect(subject.label).to eq("Disk")
+      end
+    end
+  end
+end

--- a/test/lib/widgets/storage/disk_page_test.rb
+++ b/test/lib/widgets/storage/disk_page_test.rb
@@ -24,6 +24,7 @@ require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::DiskPage do
   subject { described_class.new(drive) }
+
   let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes({}) }
 
   include_examples "CWM::Page"
@@ -45,6 +46,25 @@ describe Y2Autoinstallation::Widgets::Storage::DiskPage do
       it "does not include the device" do
         expect(subject.label).to eq("Disk")
       end
+    end
+  end
+
+  describe "#store" do
+    let(:disk_device_widget) do
+      instance_double(
+        Y2Autoinstallation::Widgets::Storage::DiskDevice,
+        value: "/dev/sdb"
+      )
+    end
+
+    before do
+      allow(Y2Autoinstallation::Widgets::Storage::DiskDevice)
+        .to receive(:new).and_return(disk_device_widget)
+    end
+
+    it "sets the section values" do
+      subject.store
+      expect(drive.device).to eq("/dev/sdb")
     end
   end
 end

--- a/test/lib/widgets/storage/disk_page_test.rb
+++ b/test/lib/widgets/storage/disk_page_test.rb
@@ -19,13 +19,20 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/disk_page"
-require "y2storage"
+require "autoinstall/storage_controller"
+require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::DiskPage do
-  subject { described_class.new(drive) }
+  subject { described_class.new(controller, drive) }
 
-  let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes({}) }
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+      [{ "type" => :CT_DISK }]
+    )
+  end
+  let(:drive) { partitioning.drives.first }
+  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
 
   include_examples "CWM::Page"
 

--- a/test/lib/widgets/storage/disk_usage_test.rb
+++ b/test/lib/widgets/storage/disk_usage_test.rb
@@ -1,0 +1,30 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/disk_usage"
+require "cwm/rspec"
+require_relative TESTS_PATH.join("support", "editable_combo_box_examples").to_s
+
+describe Y2Autoinstallation::Widgets::Storage::DiskUsage do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+  include_examples "EditableComboBox"
+end

--- a/test/lib/widgets/storage/mount_point.rb
+++ b/test/lib/widgets/storage/mount_point.rb
@@ -1,0 +1,55 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/mount_point"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::MountPoint do
+  subject { described_class.new(initial: initial) }
+  let(:initial) { "/" }
+
+  include_examples "CWM::ComboBox"
+
+  describe "#init" do
+    context "when an initial value is given" do
+      it "initializes the value" do
+        expect(subject).to receive(:value=).with(initial)
+        subject.init
+      end
+    end
+
+    context "when no initial value was given" do
+      subject { described_class.new }
+
+      it "does not initialize the value" do
+        expect(subject).to_not receive(:value=)
+        subject.init
+      end
+    end
+  end
+
+  describe "#items" do
+    let(:initial) { "/opt" }
+
+    it "includes the initial value" do
+      expect(subject.items).to include([initial, initial])
+    end
+  end
+end

--- a/test/lib/widgets/storage/mount_point_test.rb
+++ b/test/lib/widgets/storage/mount_point_test.rb
@@ -22,34 +22,26 @@ require "autoinstall/widgets/storage/mount_point"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::MountPoint do
-  subject { described_class.new(initial: initial) }
-  let(:initial) { "/" }
+  subject { described_class.new }
 
   include_examples "CWM::ComboBox"
 
-  describe "#init" do
-    context "when an initial value is given" do
-      it "initializes the value" do
-        expect(subject).to receive(:value=).with(initial)
-        subject.init
+  describe "#value=" do
+    let(:unknown) { "/opt" }
+
+    context "when an unknown value is given" do
+      it "adds the value to the list of items" do
+        subject.value = unknown
+        expect(subject.items.map(&:first)).to include(unknown)
       end
-    end
 
-    context "when no initial value was given" do
-      subject { described_class.new }
-
-      it "does not initialize the value" do
-        expect(subject).to_not receive(:value=)
-        subject.init
+      it "sets the current value" do
+        allow(Yast::UI).to receive(:ChangeWidget)
+          .with(anything, :Items, anything)
+        expect(Yast::UI).to receive(:ChangeWidget)
+          .with(anything, :Value, unknown)
+        subject.value = unknown
       end
-    end
-  end
-
-  describe "#items" do
-    let(:initial) { "/opt" }
-
-    it "includes the initial value" do
-      expect(subject.items).to include([initial, initial])
     end
   end
 end

--- a/test/lib/widgets/storage/overview_tree_pager_test.rb
+++ b/test/lib/widgets/storage/overview_tree_pager_test.rb
@@ -1,0 +1,39 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/overview_tree_pager"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::OverviewTreePager do
+  subject { described_class.new(partitioning) }
+
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+      [{ "mount" => "/dev/sda" }]
+    )
+  end
+
+  describe "#items" do
+    it "returns one item for each drive" do
+      items = subject.items
+      expect(items.size).to eq(1)
+    end
+  end
+end

--- a/test/lib/widgets/storage/partition_page_test.rb
+++ b/test/lib/widgets/storage/partition_page_test.rb
@@ -1,0 +1,50 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/partition_page"
+require "y2storage"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
+  subject { described_class.new(partition) }
+  let(:partition) { Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes({}) }
+
+  include_examples "CWM::Page"
+
+  describe "#label" do
+    before { partition.mount = mount }
+
+    context "when the partition mount point is defined" do
+      let(:mount) { "/opt" }
+
+      it "includes the mount point" do
+        expect(subject.label).to include("/opt")
+      end
+    end
+
+    context "when the partition mount point is not defined" do
+      let(:mount) { "" }
+
+      it "does not include the mount point" do
+        expect(subject.label).to eq("Partition")
+      end
+    end
+  end
+end

--- a/test/lib/widgets/storage/partition_page_test.rb
+++ b/test/lib/widgets/storage/partition_page_test.rb
@@ -47,4 +47,23 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
       end
     end
   end
+
+  describe "#store" do
+    let(:mount_point_widget) do
+      instance_double(
+        Y2Autoinstallation::Widgets::Storage::MountPoint,
+        value: "/boot"
+      )
+    end
+
+    before do
+      allow(Y2Autoinstallation::Widgets::Storage::MountPoint)
+        .to receive(:new).and_return(mount_point_widget)
+    end
+
+    it "sets the section values" do
+      subject.store
+      expect(partition.mount).to eq("/boot")
+    end
+  end
 end

--- a/test/lib/widgets/storage/partition_page_test.rb
+++ b/test/lib/widgets/storage/partition_page_test.rb
@@ -19,12 +19,20 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/partition_page"
-require "y2storage"
+require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
-  subject { described_class.new(partition) }
-  let(:partition) { Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes({}) }
+  subject { described_class.new(controller, drive, partition) }
+
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+      [{ "type" => :CT_DISK, "partitions" => [{ "mount" => "/" }] }]
+    )
+  end
+  let(:drive) { partitioning.drives.first }
+  let(:partition) { drive.partitions.first }
+  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
 
   include_examples "CWM::Page"
 

--- a/test/lib/widgets/storage/partition_table_test.rb
+++ b/test/lib/widgets/storage/partition_table_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/partition_table"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::PartitionTable do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+end

--- a/test/support/editable_combo_box_examples.rb
+++ b/test/support/editable_combo_box_examples.rb
@@ -17,14 +17,23 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/mount_point"
-require "cwm/rspec"
-require_relative TESTS_PATH.join("support", "editable_combo_box_examples").to_s
+RSpec.shared_examples "EditableComboBox" do
+  describe "#value=" do
+    let(:unknown) { "unknown" }
 
-describe Y2Autoinstallation::Widgets::Storage::MountPoint do
-  subject { described_class.new }
+    context "when an unknown value is given" do
+      it "adds the value to the list of items" do
+        subject.value = unknown
+        expect(subject.items.map(&:first)).to include(unknown)
+      end
 
-  include_examples "CWM::ComboBox"
-  include_examples "EditableComboBox"
+      it "sets the current value" do
+        allow(Yast::UI).to receive(:ChangeWidget)
+          .with(anything, :Items, anything)
+        expect(Yast::UI).to receive(:ChangeWidget)
+          .with(anything, :Value, unknown)
+        subject.value = unknown
+      end
+    end
+  end
 end


### PR DESCRIPTION
The UI to edit the AutoYaST profile's partition section is broken and it lacks a lot of functionality (Bcache, RAIDs, Btrfs multi-device file systems, etc.). Instead of monkey patching the old version, we have decided to rewrite it from scratch.

Obviously, a single PR would be a nightmare for the reviewer. Thus I have decided to open a [a new branch](https://github.com/yast/yast-autoinstallation/tree/storage-ui) and create several PRs against that branch.

This is the first one of a series of pull request which should bring this part of the UI to a new state. It includes:

* A new dialog that, using a tree pager, displays the disks and partitions information.
* Support to add and edit `drive` sections for disks (`type == :CT_DISK`). The partitions page is not finished yet.
* The code relies on the [Y2Storage::AutoinstProfile](https://www.rubydoc.info/github/yast/yast-storage-ng/Y2Storage/AutoinstProfile) classes.

A picture is worth a thousand words.

![ay-new-storage-ui](https://user-images.githubusercontent.com/15836/78803223-a35cd400-79b6-11ea-805b-7850608a0c36.png)

I have been thinking about moving the list of partitions to a table, but for the time being, I decided to follow the same approach as the old one. About the support for Bcache, LVM, etc., the idea is to add options to add that kind of `drives` in the `Add` menu button which is below the tree.

Trello: https://trello.com/c/6GuKcKUs/1729-5-autoyast-ui-improve-editing-drives