### PR TITLE
[SLE-15-SP1] Fix the Makefile

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 14 11:43:20 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Update the Makefile to include restored icons (related to
+  bsc#1168123).
+- 4.1.14
+
+-------------------------------------------------------------------
 Tue Apr 14 08:18:51 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Fix partitioning desktop file to use the right icon and group

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.1.13
+Version:        4.1.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,10 +128,20 @@ fillup_DATA = \
 
 symbolicdir = @icondir@/hicolor/symbolic/apps
 symbolic_DATA = \
-  icons/hicolor/symbolic/apps/yast-autoyast-symbolic.svg
+  icons/hicolor/symbolic/apps/yast-autoyast-symbolic.svg \
+  icons/hicolor/symbolic/apps/yast-files-symbolic.svg \
+  icons/hicolor/symbolic/apps/yast-general-symbolic.svg \
+  icons/hicolor/symbolic/apps/yast-report-symbolic.svg \
+  icons/hicolor/symbolic/apps/yast-scripts-symbolic.svg
+
 scalabledir = @icondir@/hicolor/scalable/apps
 scalable_DATA = \
-  icons/hicolor/scalable/apps/yast-autoyast.svg
+  icons/hicolor/scalable/apps/yast-autoyast.svg \
+  icons/hicolor/scalable/apps/yast-files.svg \
+  icons/hicolor/scalable/apps/yast-general.svg \
+  icons/hicolor/scalable/apps/yast-report.svg \
+  icons/hicolor/scalable/apps/yast-scripts.svg
+
 
 EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(ybin_SCRIPTS) $(desktop_DATA) $(fillup_DATA) $(ylib_DATA) $(ydialogs_DATA) $(yclients_DATA) $(symbolic_DATA) $(scalable_DATA)
 


### PR DESCRIPTION
Recently, some missing icons were restored (see #585) but the _Makefile_ was not updated with those changes. So, the icons are not available in the final package.

This PR solves the problem.

Related to 

* https://bugzilla.suse.com/show_bug.cgi?id=1168123
* https://bugzilla.opensuse.org/show_bug.cgi?id=1168281

<details>
<summary>Click to show/hide the screenshot</summary>

---


| Icons properly shown in SLE-15-SP1 after apply those changes |
|-|
| ![Screenshot_sle15-sp1_2020-04-14_13:06:05](https://user-images.githubusercontent.com/1691872/79223635-9d9d3d80-7e51-11ea-8fc2-14e2b0d6fc22.png) |

</details>

