### PR TITLE
Add support for RAID definitions

### DIFF
--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -106,7 +106,7 @@ module Y2Autoinstallation
     # Cleans a profile section
     #
     # Resets all known attributes
-    # @param [Y2Storage::AutoinstProfile::SectionWithAttributes]
+    # @param section [Y2Storage::AutoinstProfile::SectionWithAttributes]
     def clean_section(section)
       section.class.attributes.each do |attr|
         section.public_send("#{attr[:name]}=", nil)

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -77,6 +77,22 @@ module Y2Autoinstallation
       end
     end
 
+    # Determines the partition usage
+    #
+    # NOTE: perhaps this logic should live in the PartitionSection class.
+    #
+    # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+    # @return [Symbol]
+    def partition_usage(section)
+      use =
+        if section.mount
+          :filesystem
+        elsif section.raid_name
+          :raid
+        end
+      use || :filesystem
+    end
+
     # It determines whether the profile was modified
     #
     # @todo Implement logic to detect whether the partitioning

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -58,6 +58,25 @@ module Y2Autoinstallation
       parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new
     end
 
+    EXCLUSIVE_PARTITION_ATTRS = [:filesystem, :mount, :raid_name].freeze
+    private_constant :EXCLUSIVE_PARTITION_ATTRS
+
+    # Updates a partition section
+    #
+    # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+    # @param values [Hash] Values to update
+    def update_partition(section, values)
+      EXCLUSIVE_PARTITION_ATTRS.each { |a| section.public_send("#{a}=", nil) }
+
+      if values[:filesystem] || values[:mount]
+        section.filesystem = values[:filesystem]
+        section.mount = values[:mount]
+        section.format = values[:format]
+      elsif values[:raid_name]
+        section.raid_name = values[:raid_name]
+      end
+    end
+
     # It determines whether the profile was modified
     #
     # @todo Implement logic to detect whether the partitioning

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -59,6 +59,15 @@ module Y2Autoinstallation
       parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new(parent)
     end
 
+    # Updates a drive section
+    # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+    # @param values [Hash] Values to update
+    def update_drive(section, values)
+      partitions = section.partitions
+      section.init_from_hashes(values.merge("type" => section.type))
+      section.partitions = partitions
+    end
+
     # Updates a partition section
     #
     # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -56,26 +56,16 @@ module Y2Autoinstallation
     #
     # @param parent [Y2Storage::AutoinstProfile::DriveSection] Parent section
     def add_partition(parent)
-      parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new
+      parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new(parent)
     end
-
-    EXCLUSIVE_PARTITION_ATTRS = [:filesystem, :mount, :raid_name].freeze
-    private_constant :EXCLUSIVE_PARTITION_ATTRS
 
     # Updates a partition section
     #
     # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
     # @param values [Hash] Values to update
     def update_partition(section, values)
-      EXCLUSIVE_PARTITION_ATTRS.each { |a| section.public_send("#{a}=", nil) }
-
-      if values[:filesystem] || values[:mount]
-        section.filesystem = values[:filesystem]
-        section.mount = values[:mount]
-        section.format = values[:format]
-      elsif values[:raid_name]
-        section.raid_name = values[:raid_name]
-      end
+      clean_section(section)
+      section.init_from_hashes(values)
     end
 
     # Determines the partition usage
@@ -100,6 +90,18 @@ module Y2Autoinstallation
     #   was modified or not.
     def modified?
       true
+    end
+
+  private
+
+    # Cleans a profile section
+    #
+    # Resets all known attributes
+    # @param [Y2Storage::AutoinstProfile::SectionWithAttributes]
+    def clean_section(section)
+      section.class.attributes.each do |attr|
+        section.public_send("#{attr[:name]}=", nil)
+      end
     end
   end
 end

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -40,7 +40,8 @@ module Y2Autoinstallation
     end
 
     TYPES_MAP = {
-      disk: :CT_DISK
+      disk: :CT_DISK,
+      raid: :CT_RAID
     }.freeze
 
     # Adds a new drive section of the given type

--- a/src/lib/autoinstall/widgets/storage/add_children_button.rb
+++ b/src/lib/autoinstall/widgets/storage/add_children_button.rb
@@ -41,7 +41,8 @@ module Y2Autoinstallation
         end
 
         TYPE_LABELS = {
-          CT_DISK: N_("Partition")
+          CT_DISK: N_("Partition"),
+          CT_RAID: N_("Partition")
         }.freeze
 
         def label

--- a/src/lib/autoinstall/widgets/storage/add_drive_button.rb
+++ b/src/lib/autoinstall/widgets/storage/add_drive_button.rb
@@ -50,7 +50,8 @@ module Y2Autoinstallation
         # @return [Array<Symbol,String>]
         def items
           [
-            [:add_disk, _("Disk")]
+            [:add_disk, _("Disk")],
+            [:add_raid, _("RAID")]
           ]
         end
 
@@ -58,11 +59,12 @@ module Y2Autoinstallation
         #
         # @param event [Hash] Event to handle
         def handle(event)
-          case event["ID"]
-          when :add_disk
-            controller.add_drive(:disk)
-            :redraw
-          end
+          event_id = event["ID"].to_s
+          return unless event_id.start_with?("add_")
+
+          type = event_id.split("_", 2).last
+          controller.add_drive(type.to_sym)
+          :redraw
         end
 
       private

--- a/src/lib/autoinstall/widgets/storage/add_drive_button.rb
+++ b/src/lib/autoinstall/widgets/storage/add_drive_button.rb
@@ -37,6 +37,7 @@ module Y2Autoinstallation
           textdomain "autoinst"
           super()
           @controller = controller
+          self.handle_all_events = true
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/autoinstall/widgets/storage/chunk_size.rb
+++ b/src/lib/autoinstall/widgets/storage/chunk_size.rb
@@ -48,6 +48,7 @@ module Y2Autoinstallation
         # @macro seeComboBox
         def items
           return @items if @items
+
           sizes = []
           size = MIN_SIZE
           while size <= MAX_SIZE

--- a/src/lib/autoinstall/widgets/storage/chunk_size.rb
+++ b/src/lib/autoinstall/widgets/storage/chunk_size.rb
@@ -1,0 +1,62 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+require "y2storage"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to select the chunk size for a RAID
+      #
+      # It corresponds to the `chunk_size` element within a `raid_options` section
+      # of an AutoYaST profile.
+      class ChunkSize < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super()
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Chunk Size")
+        end
+
+        # TODO: the minimal size depends on the RAID level
+        MIN_SIZE = Y2Storage::DiskSize.KiB(4)
+        MAX_SIZE = Y2Storage::DiskSize.MiB(64)
+        MULTIPLIER = 2
+
+        # @macro seeComboBox
+        def items
+          return @items if @items
+          sizes = []
+          size = MIN_SIZE
+          while size <= MAX_SIZE
+            sizes << size
+            size *= 2
+          end
+          @items = [["", _("Default")]] + sizes.map { |s| ["#{s.to_i}B", s.to_s] }
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -83,10 +83,19 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def store
-          section.device = disk_device_widget.value
-          section.initialize_attr = init_drive_widget.value
-          section.use = disk_usage_widget.value
-          section.disklabel = partition_table_widget.value
+          controller.update_drive(section, values)
+        end
+
+        # Returns widget values
+        #
+        # @return [Hash<String,Object>]
+        def values
+          {
+            "device"     => disk_device_widget.value,
+            "initialize" => init_drive_widget.value,
+            "use"        => disk_usage_widget.value,
+            "disklabel"  => partition_table_widget.value
+          }
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/autoinstall/widgets/storage/filesystem.rb
+++ b/src/lib/autoinstall/widgets/storage/filesystem.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/filesystems"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # File system type for a given drive/partition
+      #
+      # It corresponds to the `filesystem` element in the profile.
+      class Filesystem < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Filesystem")
+        end
+
+        # @macro seeComboBox
+        def items
+          Y2Partitioner::Filesystems.all.map { |f| [f.to_s, f.to_human_string] }
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
@@ -66,15 +66,15 @@ module Y2Autoinstallation
 
         # Returns the widgets values
         #
-        # @return [Hash<Symbol,Object>]
+        # @return [Hash<String,Object>]
         def values
           widget_values = {
-            format: format_filesystem_widget.value,
-            mount:  mount_point_widget.value
+            "format" => format_filesystem_widget.value,
+            "mount"  => mount_point_widget.value
           }
 
-          if widget_values[:format] && filesystem_widget.value
-            widget_values[:filesystem] = filesystem_widget.value.to_sym
+          if widget_values["format"] && filesystem_widget.value
+            widget_values["filesystem"] = filesystem_widget.value.to_sym
           end
 
           widget_values

--- a/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
@@ -1,0 +1,106 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/custom_widget"
+require "autoinstall/widgets/storage/filesystem"
+require "autoinstall/widgets/storage/mount_point"
+require "autoinstall/widgets/storage/format_filesystem"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # File system specific widgets
+      #
+      # This is a custom widget that groups those that are file system specific.
+      class FilesystemAttrs < CWM::CustomWidget
+        # Constructor
+        #
+        # @param controller [Y2Autoinstallation::StorageController] UI controller
+        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+        #   of the profile
+        def initialize(controller, section)
+          super()
+          textdomain "autoinst"
+          @controller = controller
+          @section = section
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          ""
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          VBox(
+            Left(filesystem_widget),
+            Left(mount_point_widget),
+            Left(format_filesystem_widget)
+          )
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          format_filesystem_widget.value = !!section.format
+          # FIXME: Disable the filesystem if format is set to false
+          filesystem_widget.value = section.filesystem.to_s if section.filesystem
+          mount_point_widget.value = section.mount
+        end
+
+        # Returns the widgets values
+        #
+        # @return [Hash<Symbol,Object>]
+        def values
+          widget_values = {
+            format: format_filesystem_widget.value,
+            mount:  mount_point_widget.value
+          }
+
+          if widget_values[:format] && filesystem_widget.value
+            widget_values[:filesystem] = filesystem_widget.value.to_sym
+          end
+
+          widget_values
+        end
+
+      private
+
+        attr_reader :controller, :section
+
+        # Mount point widget
+        #
+        # @return [MountPoint]
+        def mount_point_widget
+          @mount_point_widget ||= MountPoint.new
+        end
+
+        # Filesystem type widget
+        def filesystem_widget
+          @filesystem_widget ||= Filesystem.new
+        end
+
+        # Format filesystem widget
+        def format_filesystem_widget
+          @format_filesystem_widget ||= FormatFilesystem.new
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/format_filesystem.rb
+++ b/src/lib/autoinstall/widgets/storage/format_filesystem.rb
@@ -32,7 +32,7 @@ module Y2Autoinstallation
           super
         end
 
-        # @macro
+        # @macro seeAbstractWidget
         def label
           _("Format")
         end

--- a/src/lib/autoinstall/widgets/storage/format_filesystem.rb
+++ b/src/lib/autoinstall/widgets/storage/format_filesystem.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Determines whether the file system should be formatted or not
+      #
+      # It corresponds to the `format` element in a `partition` section of the profile.
+      class FormatFilesystem < CWM::CheckBox
+        def initialize
+          textdomain "autoinst"
+          super
+        end
+
+        # @macro
+        def label
+          _("Format")
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/md_level.rb
+++ b/src/lib/autoinstall/widgets/storage/md_level.rb
@@ -48,7 +48,7 @@ module Y2Autoinstallation
           Y2Storage::MdLevel::RAID4,
           Y2Storage::MdLevel::RAID5,
           Y2Storage::MdLevel::RAID6,
-          Y2Storage::MdLevel::RAID10,
+          Y2Storage::MdLevel::RAID10
         ].freeze
         private_constant :ITEMS
 

--- a/src/lib/autoinstall/widgets/storage/md_level.rb
+++ b/src/lib/autoinstall/widgets/storage/md_level.rb
@@ -1,0 +1,62 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+require "y2storage"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to select the MD Level
+      #
+      # It corresponds to the `raid_level` element within the `raid_options`
+      # of an AutoYaST profile.
+      class MdLevel < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super()
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("RAID Level")
+        end
+
+        # We are only interested in these levels.
+        # @see https://github.com/openSUSE/libstorage-ng/blob/ffdd9abc800f8db14523979d5e8f2a237e97aeb6/storage/Devices/Md.h#L41-L44
+        ITEMS = [
+          Y2Storage::MdLevel::RAID0,
+          Y2Storage::MdLevel::RAID1,
+          Y2Storage::MdLevel::RAID4,
+          Y2Storage::MdLevel::RAID5,
+          Y2Storage::MdLevel::RAID6,
+          Y2Storage::MdLevel::RAID10,
+        ].freeze
+        private_constant :ITEMS
+
+        # @macro seeComboBox
+        def items
+          ITEMS.map { |i| [i.to_s, i.to_human_string] }
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -21,6 +21,7 @@ require "cwm"
 require "cwm/tree_pager"
 require "autoinstall/widgets/storage/overview_tree"
 require "autoinstall/widgets/storage/disk_page"
+require "autoinstall/widgets/storage/raid_page"
 require "autoinstall/widgets/storage/partition_page"
 require "autoinstall/widgets/storage/add_drive_button"
 require "autoinstall/ui_state"
@@ -85,23 +86,31 @@ module Y2Autoinstallation
         # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section
         # @return [CWM::PagerTreeItem] Tree item
         def drive_item(section)
-          case section.type
-          when :CT_DISK
-            disk_item(section)
-          end
+          page_klass = page_klass_for(section.type)
+          page = page_klass.new(controller, section)
+          CWM::PagerTreeItem.new(page, children: partition_items(section))
         end
 
-        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
-        #   to a disk
-        def disk_item(section)
-          children = section.partitions.map do |part|
+        # Determines the widget class for the given type
+        def page_klass_for(type)
+          type ||= :CT_DISK
+          name = type.to_s.split("_", 2).last.downcase
+          Y2Autoinstallation::Widgets::Storage.const_get("#{name.capitalize}Page")
+        rescue NameError
+          Y2Autoinstallation::Widgets::Storage::DiskPage
+        end
+
+        # Returns the pages for a given list of partition sections
+        #
+        # @param partitions [Array<Y2Storage::AutoinstProfile::PartitionSection>]
+        #   List of partition partition sections
+        def partition_items(drive)
+          drive.partitions.map do |part|
             part_page = Y2Autoinstallation::Widgets::Storage::PartitionPage.new(
-              controller, section, part
+              controller, drive, part
             )
             CWM::PagerTreeItem.new(part_page)
           end
-          page = Y2Autoinstallation::Widgets::Storage::DiskPage.new(controller, section)
-          CWM::PagerTreeItem.new(page, children: children)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -102,7 +102,7 @@ module Y2Autoinstallation
 
         # Returns the pages for a given list of partition sections
         #
-        # @param partitions [Array<Y2Storage::AutoinstProfile::PartitionSection>]
+        # @param drive [Y2Storage::AutoinstProfile::DriveSection]
         #   List of partition partition sections
         def partition_items(drive)
           drive.partitions.map do |part|

--- a/src/lib/autoinstall/widgets/storage/parity_algorithm.rb
+++ b/src/lib/autoinstall/widgets/storage/parity_algorithm.rb
@@ -1,0 +1,50 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+require "y2storage"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Widget to select the parity algorithm for a RAID
+      #
+      # It corresponds to the `parity_algorithm` element within a `raid_options` section
+      # of an AutoYaST profile.
+      class ParityAlgorithm < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super()
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Parity Algorithm")
+        end
+
+        # @macro seeComboBox
+        def items
+          Y2Storage::MdParity.all.map { |p| [p.to_s, p.to_human_string] }
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -117,8 +117,6 @@ module Y2Autoinstallation
         end
 
         # Updates the replace point with the content corresponding to the UsedAs widget value
-        #
-        # @param used_as [Symbol] :filesystem, :raid
         def update_replace_point
           replace_point.replace(selected_widget)
         end

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -19,8 +19,11 @@
 
 require "yast"
 require "cwm/page"
+require "cwm/replace_point"
 require "autoinstall/widgets/storage/add_children_button"
-require "autoinstall/widgets/storage/mount_point"
+require "autoinstall/widgets/storage/filesystem_attrs"
+require "autoinstall/widgets/storage/raid_attrs"
+require "autoinstall/widgets/storage/used_as"
 
 module Y2Autoinstallation
   module Widgets
@@ -44,26 +47,22 @@ module Y2Autoinstallation
           @drive = drive
           super()
           self.widget_id = "partition_page:#{section.object_id}"
+          self.handle_all_events = true
         end
 
         # @macro seeAbstractWidget
         def label
-          if section.mount && !section.mount.empty?
-            format(_("Partition at %{mount_point}"), mount_point: section.mount)
-          else
-            _("Partition")
-          end
+          send("label_as_#{controller.partition_usage(section)}")
         end
 
         # @macro seeCustomWidget
         def contents
           VBox(
             Left(Heading(_("Partition"))),
-            Left(
-              VBox(
-                mount_point_widget,
-                VStretch()
-              )
+            VBox(
+              Left(used_as_widget),
+              Left(replace_point),
+              VStretch()
             ),
             HBox(
               HStretch(),
@@ -74,12 +73,20 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def init
-          mount_point_widget.value = section.mount
+          used_as_widget.value = controller.partition_usage(section).to_s
+          update_replace_point
+        end
+
+        # @macro seeAbstractWidget
+        def handle(event)
+          update_replace_point if event["ID"] == "used_as"
+          nil
         end
 
         # @macro seeAbstractWidget
         def store
-          section.mount = mount_point_widget.value
+          controller.update_partition(section, selected_widget.values)
+          nil
         end
 
       private
@@ -93,11 +100,52 @@ module Y2Autoinstallation
         # @return [Y2Storage::AutoinstProfile::PartitionSection]
         attr_reader :section
 
-        # Mount point widget
+        def used_as_widget
+          @used_as_widget ||= UsedAs.new
+        end
+
+        def filesystem_widget
+          @filesystem_widget ||= FilesystemAttrs.new(controller, section)
+        end
+
+        def raid_widget
+          @raid_widget ||= RaidAttrs.new(controller, section)
+        end
+
+        def replace_point
+          @replace_point ||= CWM::ReplacePoint.new(id: "attrs", widget: filesystem_widget)
+        end
+
+        # Updates the replace point with the content corresponding to the UsedAs widget value
         #
-        # @return [MountPoint]
-        def mount_point_widget
-          @mount_point_widget ||= MountPoint.new
+        # @param used_as [Symbol] :filesystem, :raid
+        def update_replace_point
+          replace_point.replace(selected_widget)
+        end
+
+        # Returns the selected widget according to the UsedAs widget
+        #
+        # @return [CWM::AbstractWidget]
+        def selected_widget
+          send("#{used_as_widget.value}_widget")
+        end
+
+        # Returns the label when the partition is used as file system
+        #
+        # @return [String]
+        def label_as_filesystem
+          if section.mount && !section.mount.empty?
+            format(_("Partition at %{mount_point}"), mount_point: section.mount)
+          else
+            _("Partition")
+          end
+        end
+
+        # Returns the label when the partition is used as RAID member
+        #
+        # @return [String]
+        def label_as_raid
+          format(_("Part of %{device}"), device: section.raid_name)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/partition_table.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_table.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/common_widgets"
+require "y2storage"
 
 module Y2Autoinstallation
   module Widgets

--- a/src/lib/autoinstall/widgets/storage/raid_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_attrs.rb
@@ -1,0 +1,84 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/custom_widget"
+require "autoinstall/widgets/storage/raid_name"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # File system specific widgets
+      #
+      # This is a custom widget that groups those that are RAID specific.
+      class RaidAttrs < CWM::CustomWidget
+        # Constructor
+        #
+        # @param controller [Y2Autoinstallation::StorageController] UI controller
+        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
+        #   of the profile
+        def initialize(controller, section)
+          textdomain "autoinst"
+          super()
+          @controller = controller
+          @section = section
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          ""
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          VBox(
+            Left(raid_name_widget)
+          )
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          raid_name_widget.value = section.raid_name
+        end
+
+        # Returns the widgets values
+        #
+        # @return [Hash<Symbol,Object>]
+        def values
+          { raid_name: raid_name_widget.value }
+        end
+
+      private
+
+        # @return [Y2Autoinstallation::StorageController]
+        attr_reader :controller
+
+        # @return [Y2Storage::AutoinstProfile::PartitionSection]
+        attr_reader :section
+
+        # RAID name widget
+        #
+        # @return [RaidName]
+        def raid_name_widget
+          @raid_name_widget ||= RaidName.new
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/raid_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_attrs.rb
@@ -59,9 +59,9 @@ module Y2Autoinstallation
 
         # Returns the widgets values
         #
-        # @return [Hash<Symbol,Object>]
+        # @return [Hash<String,Object>]
         def values
-          { raid_name: raid_name_widget.value }
+          { "raid_name" => raid_name_widget.value }
         end
 
       private

--- a/src/lib/autoinstall/widgets/storage/raid_name.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_name.rb
@@ -17,10 +17,27 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/used_as"
-require "cwm/rspec"
+require "yast"
+require "cwm/common_widgets"
 
-describe Y2Autoinstallation::Widgets::Storage::UsedAs do
-  include_examples "CWM::ComboBox"
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Determines a RAID name
+      #
+      # NOTE: perhaps this widget should be an editable combo box
+      #   containing the names of the already defined RAIDs.
+      class RaidName < CWM::InputField
+        def initalize
+          textdomain "autoinst"
+          super
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("RAID name")
+        end
+      end
+    end
+  end
 end

--- a/src/lib/autoinstall/widgets/storage/raid_page.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_page.rb
@@ -1,0 +1,92 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/page"
+require "autoinstall/widgets/storage/add_children_button"
+require "autoinstall/widgets/storage/raid_name"
+# require "autoinstall/widgets/storage/raid_options"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # This page allows to edit a `drive` section representing a RAID device
+      class RaidPage < ::CWM::Page
+        # Constructor
+        #
+        # @param controller [Y2Autoinstallation::StorageController] UI controller
+        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
+        #   to a RAID
+        def initialize(controller, section)
+          textdomain "autoinst"
+          @controller = controller
+          @section = section
+          super()
+          self.widget_id = "raid_page:#{section.object_id}"
+          self.handle_all_events = true
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          format(_("RAID %{device}"), device: section.device)
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          VBox(
+            Left(Heading(_("RAID"))),
+            VBox(
+              Left(raid_name_widget),
+              VStretch()
+            ),
+            HBox(
+              HStretch(),
+              AddChildrenButton.new(controller, section)
+            )
+          )
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          raid_name_widget.value = section.device
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          section.device = raid_name_widget.value
+        end
+
+      private
+
+        # @return [Y2Autoinstallation::StorageController]
+        attr_reader :controller
+
+        # @return [Y2Storage::AutoinstProfile::DriveSection]
+        attr_reader :section
+
+        # RAID name input field
+        #
+        # @return [RaidName]
+        def raid_name_widget
+          Y2Autoinstallation::Widgets::Storage::RaidName.new
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/raid_page.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_page.rb
@@ -80,12 +80,21 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def store
-          section.device = raid_name_widget.value
-          section.raid_options ||= Y2Storage::AutoinstProfile::RaidOptionsSection.new
-          raid_options = section.raid_options
-          raid_options.raid_type = md_level_widget.value
-          raid_options.parity_algorithm = parity_algorithm_widget.value
-          raid_options.chunk_size = chunk_size_widget.value
+          controller.update_drive(section, values)
+        end
+
+        # Returns the widgets values
+        #
+        # @return [Hash<String,Object>]
+        def values
+          {
+            "device"       => raid_name_widget.value,
+            "raid_options" => {
+              "raid_type"        => md_level_widget.value,
+              "parity_algorithm" => parity_algorithm_widget.value,
+              "chunk_size"       => chunk_size_widget.value
+            }
+          }
         end
 
       private

--- a/src/lib/autoinstall/widgets/storage/raid_page.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_page.rb
@@ -21,7 +21,9 @@ require "yast"
 require "cwm/page"
 require "autoinstall/widgets/storage/add_children_button"
 require "autoinstall/widgets/storage/raid_name"
-# require "autoinstall/widgets/storage/raid_options"
+require "autoinstall/widgets/storage/md_level"
+require "autoinstall/widgets/storage/chunk_size"
+require "autoinstall/widgets/storage/parity_algorithm"
 
 module Y2Autoinstallation
   module Widgets
@@ -53,6 +55,9 @@ module Y2Autoinstallation
             Left(Heading(_("RAID"))),
             VBox(
               Left(raid_name_widget),
+              Left(md_level_widget),
+              Left(parity_algorithm_widget),
+              Left(chunk_size_widget),
               VStretch()
             ),
             HBox(
@@ -65,11 +70,22 @@ module Y2Autoinstallation
         # @macro seeAbstractWidget
         def init
           raid_name_widget.value = section.device
+          raid_options = section.raid_options
+          if raid_options
+            md_level_widget.value = raid_options.raid_type.to_s
+            parity_algorithm_widget.value = raid_options.parity_algorithm
+            chunk_size_widget.value = raid_options.chunk_size
+          end
         end
 
         # @macro seeAbstractWidget
         def store
           section.device = raid_name_widget.value
+          section.raid_options ||= Y2Storage::AutoinstProfile::RaidOptionsSection.new
+          raid_options = section.raid_options
+          raid_options.raid_type = md_level_widget.value
+          raid_options.parity_algorithm = parity_algorithm_widget.value
+          raid_options.chunk_size = chunk_size_widget.value
         end
 
       private
@@ -84,7 +100,28 @@ module Y2Autoinstallation
         #
         # @return [RaidName]
         def raid_name_widget
-          Y2Autoinstallation::Widgets::Storage::RaidName.new
+          @raid_name_widget ||= RaidName.new
+        end
+
+        # RAID level widget
+        #
+        # @return [MdLevel]
+        def md_level_widget
+          @md_level_widget ||= MdLevel.new
+        end
+
+        # Parity algorithm
+        #
+        # @return [ParityAlgorithm]
+        def parity_algorithm_widget
+          @parity_algorithm_widget ||= ParityAlgorithm.new
+        end
+
+        # Chunk size
+        #
+        # @return [ChunkSize]
+        def chunk_size_widget
+          @chunk_size_widget ||= ChunkSize.new
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/used_as.rb
+++ b/src/lib/autoinstall/widgets/storage/used_as.rb
@@ -1,0 +1,61 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+require "cwm/custom_widget"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Determines how a partition will be used
+      class UsedAs < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super
+          self.widget_id = "used_as"
+        end
+
+        # @macro seeAbstractWidget
+        def opt
+          [:notify]
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Used as")
+        end
+
+        # @macro seeComboBox
+        def items
+          # FIXME: uncomment when support for each time is added
+          [
+            ["filesystem", _("File system")],
+            ["raid", _("RAID member")]
+            # ["lvm_pv", _("LVM physical volume")],
+            # ["bcache_caching", _("Bcache caching device")],
+            # ["bcache_backing", _("Bcache backing device")],
+            # ["btrfs_member", _("Btrfs multi-device member")]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/used_as.rb
+++ b/src/lib/autoinstall/widgets/storage/used_as.rb
@@ -29,7 +29,7 @@ module Y2Autoinstallation
         # Constructor
         def initialize
           textdomain "autoinst"
-          super
+          super()
           self.widget_id = "used_as"
         end
 

--- a/test/lib/storage_controller_test.rb
+++ b/test/lib/storage_controller_test.rb
@@ -20,6 +20,7 @@
 require_relative "../test_helper"
 require "autoinstall/storage_controller"
 require "y2storage/autoinst_profile/partitioning_section"
+require "y2storage/autoinst_profile/partition_section"
 
 describe Y2Autoinstallation::StorageController do
   subject { described_class.new(partitioning) }
@@ -39,11 +40,9 @@ describe Y2Autoinstallation::StorageController do
   describe "#update_partition" do
     let(:section) do
       Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes(
-        {
-          filesystem: :btrfs,
-          mount: "/",
-          raid_name: "/dev/md0",
-        }
+        filesystem: :btrfs,
+        mount:      "/",
+        raid_name:  "/dev/md0"
       )
     end
 
@@ -78,6 +77,28 @@ describe Y2Autoinstallation::StorageController do
         subject.update_partition(section, values)
         expect(section.filesystem).to be_nil
         expect(section.mount).to be_nil
+      end
+    end
+  end
+
+  describe "#partition_usage" do
+    let(:section) do
+      Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes(attrs)
+    end
+
+    context "when the section refers to a file system" do
+      let(:attrs) { { filesystem: :ext4 } }
+
+      it "returns :filesystem" do
+        expect(subject.partition_usage(section)).to eq(:filesystem)
+      end
+    end
+
+    context "when the section referes to a RAID member" do
+      let(:attrs) { { raid_name: "/dev/md0" } }
+
+      it "returns :raid" do
+        expect(subject.partition_usage(section)).to eq(:raid)
       end
     end
   end

--- a/test/lib/storage_controller_test.rb
+++ b/test/lib/storage_controller_test.rb
@@ -35,4 +35,50 @@ describe Y2Autoinstallation::StorageController do
       expect(new_drive.type).to eq(:CT_DISK)
     end
   end
+
+  describe "#update_partition" do
+    let(:section) do
+      Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes(
+        {
+          filesystem: :btrfs,
+          mount: "/",
+          raid_name: "/dev/md0",
+        }
+      )
+    end
+
+    context "when file system attributes are given" do
+      let(:values) do
+        { filesystem: :ext4, mount: "/home" }
+      end
+
+      it "sets the file system attributes" do
+        subject.update_partition(section, values)
+        expect(section.filesystem).to eq(:ext4)
+        expect(section.mount).to eq("/home")
+      end
+
+      it "clears non filesystem specific attributes" do
+        subject.update_partition(section, values)
+        expect(section.raid_name).to be_nil
+      end
+    end
+
+    context "when RAID attributes are given" do
+      let(:values) do
+        { raid_name: "/dev/md1" }
+      end
+
+      it "sets the RAID attributes" do
+        subject.update_partition(section, values)
+        expect(section.raid_name).to eq("/dev/md1")
+      end
+
+      it "clears non RAID specific attributes" do
+        subject.update_partition(section, values)
+        expect(section.filesystem).to be_nil
+        expect(section.mount).to be_nil
+      end
+    end
+  end
 end

--- a/test/lib/widgets/storage/add_drive_button_test.rb
+++ b/test/lib/widgets/storage/add_drive_button_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/add_drive_button"
+require "autoinstall/storage_controller"
 
 describe Y2Autoinstallation::Widgets::Storage::AddDriveButton do
   subject { described_class.new(controller) }
@@ -29,13 +30,24 @@ describe Y2Autoinstallation::Widgets::Storage::AddDriveButton do
   end
 
   describe "#handle" do
-    let(:event) do
-      { "ID" => :add_disk }
+    context "adding a disk" do
+      let(:event) do
+        { "ID" => :add_disk }
+      end
+
+      it "adds a disk" do
+        expect(controller).to receive(:add_drive).with(:disk)
+        subject.handle(event)
+      end
     end
 
     context "adding a disk" do
+      let(:event) do
+        { "ID" => :add_raid }
+      end
+
       it "adds a disk" do
-        expect(controller).to receive(:add_drive).with(:disk)
+        expect(controller).to receive(:add_drive).with(:raid)
         subject.handle(event)
       end
     end

--- a/test/lib/widgets/storage/chunk_size_test.rb
+++ b/test/lib/widgets/storage/chunk_size_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/chunk_size"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::ChunkSize do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+end

--- a/test/lib/widgets/storage/filesystem_attrs_test.rb
+++ b/test/lib/widgets/storage/filesystem_attrs_test.rb
@@ -18,9 +18,21 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/used_as"
+require "y2storage"
+require "autoinstall/storage_controller"
+require "autoinstall/widgets/storage/filesystem_attrs"
 require "cwm/rspec"
 
-describe Y2Autoinstallation::Widgets::Storage::UsedAs do
-  include_examples "CWM::ComboBox"
+describe Y2Autoinstallation::Widgets::Storage::FilesystemAttrs do
+  subject { described_class.new(controller, section) }
+
+  let(:controller) do
+    instance_double(Y2Autoinstallation::StorageController)
+  end
+
+  let(:section) do
+    Y2Storage::AutoinstProfile::PartitionSection.new
+  end
+
+  include_examples "CWM::CustomWidget"
 end

--- a/test/lib/widgets/storage/filesystem_test.rb
+++ b/test/lib/widgets/storage/filesystem_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/filesystem"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::Filesystem do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+end

--- a/test/lib/widgets/storage/format_filesystem_test.rb
+++ b/test/lib/widgets/storage/format_filesystem_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/format_filesystem"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::FormatFilesystem do
+  subject { described_class.new }
+
+  include_examples "CWM::CheckBox"
+end

--- a/test/lib/widgets/storage/md_level_test.rb
+++ b/test/lib/widgets/storage/md_level_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/md_level"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::MdLevel do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+end

--- a/test/lib/widgets/storage/parity_algorithm_test.rb
+++ b/test/lib/widgets/storage/parity_algorithm_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/parity_algorithm"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::ParityAlgorithm do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+end

--- a/test/lib/widgets/storage/partition_page_test.rb
+++ b/test/lib/widgets/storage/partition_page_test.rb
@@ -41,7 +41,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
   describe "#label" do
     context "when the partition is used as a filesystem" do
       context "when the partition mount point is defined" do
-        let(:partition_hash) { { "mount" => "/opt"} }
+        let(:partition_hash) { { "mount" => "/opt" } }
 
         it "includes the mount point" do
           expect(subject.label).to include("/opt")

--- a/test/lib/widgets/storage/partition_page_test.rb
+++ b/test/lib/widgets/storage/partition_page_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/partition_page"
+require "autoinstall/storage_controller"
 require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
@@ -27,51 +28,57 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
 
   let(:partitioning) do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
-      [{ "type" => :CT_DISK, "partitions" => [{ "mount" => "/" }] }]
+      [{ "type" => :CT_DISK, "partitions" => [partition_hash] }]
     )
   end
   let(:drive) { partitioning.drives.first }
   let(:partition) { drive.partitions.first }
   let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+  let(:partition_hash) { {} }
 
   include_examples "CWM::Page"
 
   describe "#label" do
-    before { partition.mount = mount }
+    context "when the partition is used as a filesystem" do
+      context "when the partition mount point is defined" do
+        let(:partition_hash) { { "mount" => "/opt"} }
 
-    context "when the partition mount point is defined" do
-      let(:mount) { "/opt" }
+        it "includes the mount point" do
+          expect(subject.label).to include("/opt")
+        end
+      end
 
-      it "includes the mount point" do
-        expect(subject.label).to include("/opt")
+      context "when the filesystem point is not defined" do
+        let(:partition_hash) { { "filesystem" => :ext4 } }
+
+        it "does not include the mount point" do
+          expect(subject.label).to eq("Partition")
+        end
       end
     end
 
-    context "when the partition mount point is not defined" do
-      let(:mount) { "" }
+    context "when the partition will be used as RAID member" do
+      let(:partition_hash) { { "raid_name" => "/dev/md0" } }
 
-      it "does not include the mount point" do
-        expect(subject.label).to eq("Partition")
+      it "returns a description" do
+        expect(subject.label).to eq("Part of /dev/md0")
       end
     end
   end
 
   describe "#store" do
-    let(:mount_point_widget) do
-      instance_double(
-        Y2Autoinstallation::Widgets::Storage::MountPoint,
-        value: "/boot"
-      )
+    let(:used_as_widget) do
+      instance_double(Y2Autoinstallation::Widgets::Storage::UsedAs, value: "filesystem")
     end
 
     before do
-      allow(Y2Autoinstallation::Widgets::Storage::MountPoint)
-        .to receive(:new).and_return(mount_point_widget)
+      allow(Y2Autoinstallation::Widgets::Storage::UsedAs).to receive(:new)
+        .and_return(used_as_widget)
     end
 
-    it "sets the section values" do
+    it "sets the partition section attributes" do
+      expect(controller).to receive(:update_partition).with(partition, anything)
       subject.store
-      expect(partition.mount).to eq("/boot")
     end
   end
 end

--- a/test/lib/widgets/storage/raid_attrs_test.rb
+++ b/test/lib/widgets/storage/raid_attrs_test.rb
@@ -18,9 +18,21 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/used_as"
+require "y2storage"
+require "autoinstall/storage_controller"
+require "autoinstall/widgets/storage/raid_attrs"
 require "cwm/rspec"
 
-describe Y2Autoinstallation::Widgets::Storage::UsedAs do
-  include_examples "CWM::ComboBox"
+describe Y2Autoinstallation::Widgets::Storage::RaidAttrs do
+  subject { described_class.new(controller, section) }
+
+  let(:controller) do
+    instance_double(Y2Autoinstallation::StorageController)
+  end
+
+  let(:section) do
+    Y2Storage::AutoinstProfile::PartitionSection.new
+  end
+
+  include_examples "CWM::CustomWidget"
 end

--- a/test/lib/widgets/storage/raid_page_test.rb
+++ b/test/lib/widgets/storage/raid_page_test.rb
@@ -1,0 +1,55 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/raid_page"
+require "autoinstall/storage_controller"
+require "y2storage/autoinst_profile"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::RaidPage do
+  subject { described_class.new(controller, drive) }
+
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+      [{ "device" => "/dev/md0", "type" => :CT_RAID }]
+    )
+  end
+  let(:drive) { partitioning.drives.first }
+  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+
+  let(:raid_name_widget) do
+    instance_double(
+      Y2Autoinstallation::Widgets::Storage::RaidName,
+      value: "/dev/md1"
+    )
+  end
+
+  before do
+    allow(Y2Autoinstallation::Widgets::Storage::RaidName)
+      .to receive(:new).and_return(raid_name_widget)
+  end
+
+  describe "#init" do
+    it "sets the widget initial values" do
+      expect(raid_name_widget).to receive(:value=).with("/dev/md0")
+      subject.init
+    end
+  end
+end

--- a/test/lib/widgets/storage/used_as_test.rb
+++ b/test/lib/widgets/storage/used_as_test.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/used_as"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::UsedAs do
+  subject { described_class.new }
+
+  include_examples "CWM::ComboBox"
+end


### PR DESCRIPTION
Among other fixes and improvements, this PR adds support to define and edit RAID devices.

* Extends the edition of partition sections so the user can decide how the partition is going to be used. For the time being, only *File system* and *RAID member* are available.
* Adds support to add a drive section with type `:CT_RAID`.

![new-storage-ui-edit-partition](https://user-images.githubusercontent.com/15836/79516616-d00e8c80-8043-11ea-8f6d-eb9f5169810a.png)

![new-storage-ui-raid](https://user-images.githubusercontent.com/15836/79516913-a86bf400-8044-11ea-92ad-f918350f5429.png)


