### PR TITLE
[Storage UI] Reorganize buttons and labels using Presentation Model pattern

### DIFF
--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -282,6 +282,7 @@ done
 %{yast_libdir}/autoinstall/dialogs/*.rb
 
 %{yast_libdir}/autoinstall/widgets
+%{yast_libdir}/autoinstall/presenters
 
 %dir %{yast_libdir}/autoinstall/clients
 %{yast_libdir}/autoinstall/clients/*.rb

--- a/src/lib/autoinstall/presenters.rb
+++ b/src/lib/autoinstall/presenters.rb
@@ -1,0 +1,32 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Autoinstallation
+  # Namespace for all the classes used to implement the Presentation Model pattern
+  # See https://martinfowler.com/eaaDev/PresentationModel.html
+  #
+  # Also inspired by the Presenter pattern used in Ruby on Rails
+  # See http://blog.jayfields.com/2007/03/rails-presenter-pattern.html
+  module Presenters
+  end
+end
+
+require "autoinstall/presenters/drive_type"
+require "autoinstall/presenters/drive"
+require "autoinstall/presenters/partition"

--- a/src/lib/autoinstall/presenters/drive.rb
+++ b/src/lib/autoinstall/presenters/drive.rb
@@ -1,0 +1,74 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "autoinstall/presenters/section"
+require "autoinstall/presenters/drive_type"
+require "autoinstall/presenters/partition"
+
+module Y2Autoinstallation
+  module Presenters
+    # Presenter for Y2Storage::AutoinstProfile::DriveSection
+    class Drive < Section
+      # Constructor
+      #
+      # @see Section#initialize
+      def initialize(section)
+        textdomain "autoinst"
+        super
+        @partitions = section.partitions.map { |part| Partition.new(part, self) }
+      end
+
+      # Presenters for the partition sections within this drive section
+      #
+      # @return [Array<Partition>]
+      attr_reader :partitions
+
+      # @return [DriveType]
+      def type
+        @type ||= DriveType.find(section.type) || DriveType::DISK
+      end
+
+      # Updates a drive section
+      #
+      # @param values [Hash] Values to update
+      def update(values)
+        partitions = section.partitions
+        super(values.merge("type" => section.type))
+        section.partitions = partitions
+      end
+
+      # Localized label to represent this section in the UI
+      #
+      # @return [String]
+      def ui_label
+        if device && !device.empty?
+          # TRANSLATORS: 'Drive' is the name of a section of the AutoYaST profile, translating
+          # the term is likely a bad idea.
+          # %{type} and %{name} are placeholders, do not translate them.
+          format(_("Drive (%{type}): %{name}"), type: type.label, name: section.device)
+        else
+          # TRANSLATORS: 'Drive' is the name of a section of the AutoYaST profile, translating
+          # the term is likely a bad idea. %s is substituted by the type of drive.
+          format(_("Drive (%s)"), type.label)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/presenters/drive_type.rb
+++ b/src/lib/autoinstall/presenters/drive_type.rb
@@ -1,0 +1,85 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+
+module Y2Autoinstallation
+  module Presenters
+    # Object-oriented representation of the type field of a <drive> section
+    class DriveType
+      include Yast::I18n
+      extend Yast::I18n
+
+      # Constructor
+      #
+      # @param id [Symbol] raw value of the field, like :CT_DISK, CT_LVM, etc.
+      # @param label [String]
+      def initialize(id, label)
+        @symbol = id
+        @label = label
+      end
+
+      # DriveType for CT_DISK
+      DISK = new(:CT_DISK, N_("Disk")).freeze
+      # DriveType for CT_LVM
+      LVM = new(:CT_LVM, N_("LVM")).freeze
+      # DriveType for CT_RAID
+      RAID = new(:CT_RAID, N_("RAID")).freeze
+
+      # All drive types
+      ALL = [DISK, RAID, LVM].freeze
+
+      # All possible types
+      #
+      # @return [Array<DriveType>]
+      def self.all
+        ALL.dup
+      end
+
+      # Type corresponding to the given raw value of the field
+      #
+      # @param id [#to_sym]
+      def self.find(id)
+        all.find { |type| type.to_sym == id.to_sym }
+      end
+
+      # Localized name of the type
+      #
+      # @return [String]
+      def label
+        _(@label)
+      end
+
+      # Raw value of the type in the section, like :CT_DISK
+      #
+      # @return [Symbol]
+      def to_sym
+        @symbol
+      end
+
+      # String representation of the type, like DISK
+      #
+      # @return [String]
+      def to_s
+        to_sym.to_s.delete_prefix("CT_")
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/presenters/drive_type.rb
+++ b/src/lib/autoinstall/presenters/drive_type.rb
@@ -32,6 +32,8 @@ module Y2Autoinstallation
       # @param id [Symbol] raw value of the field, like :CT_DISK, CT_LVM, etc.
       # @param label [String]
       def initialize(id, label)
+        textdomain "autoinst"
+
         @symbol = id
         @label = label
       end

--- a/src/lib/autoinstall/presenters/partition.rb
+++ b/src/lib/autoinstall/presenters/partition.rb
@@ -136,7 +136,7 @@ module Y2Autoinstallation
           if mount && !mount.empty?
             mount
           else
-            _("Not mounted")
+            _("Not Mounted")
           end
         when :raid
           # TRANSLATORS: %s is a placeholder for the name of a RAID

--- a/src/lib/autoinstall/presenters/partition.rb
+++ b/src/lib/autoinstall/presenters/partition.rb
@@ -1,0 +1,164 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "autoinstall/presenters/section"
+
+module Y2Autoinstallation
+  module Presenters
+    # Presenter for Y2Storage::AutoinstProfile::PartitionSection
+    #
+    # In an AutoYaST profile, a <partition> section is used to define a partition,
+    # a logical volume, a RAID member, etc.
+    class Partition < Section
+      include Yast::I18n
+
+      # Constructor
+      #
+      # @param section [Y2Storage::AutoinstProfile::PartitionSection] partition section
+      # @param drive [Drive] presenter of the parent drive section
+      def initialize(section, drive)
+        textdomain "autoinst"
+        super(section)
+        @drive_presenter = drive
+      end
+
+      # Determines the usage of the device described by the partition section
+      #
+      # @return [Symbol]
+      def usage
+        if raid_name
+          :raid
+        elsif lvm_group
+          :lvm_pv
+        else
+          :filesystem
+        end
+      end
+
+      # Localized label to represent this section in the UI
+      #
+      # @return [String]
+      def ui_label
+        parts = { device_type: device_type_label, usage: usage_label, name: device_name }
+        if device_name
+          # TRANSLATORS: this is how a <Partition> section of the AutoYaST profile is represented
+          # in the UI. All words are placeholders and should NOT be translated, use this string
+          # only to adapt the layout of the information.
+          "%{device_type}: %{name}, %{usage}" % parts
+        else
+          # TRANSLATORS: this is how a <Partition> section of the AutoYaST profile is represented
+          # in the UI. %{device_type} and %{usage} are placeholders and should NOT be translated,
+          # use this string only to adapt the layout of the information.
+          "%{device_type}: %{usage}" % parts
+        end
+      end
+
+      # Type of the parent drive section
+      #
+      # @return [DriveType]
+      def drive_type
+        drive_presenter.type
+      end
+
+      # Values to suggest for the lvm_group field
+      #
+      # @return [Array<String>]
+      def available_lvm_groups
+        vgs = drive.parent.drives.select {|d| d.type == :CT_LVM }
+        names = vgs.map(&:device).compact
+        names.map { |n| n.delete_prefix("/dev/") }
+      end
+
+    private
+
+      # @return [Drive] presenter of the parent drive section
+      attr_reader :drive_presenter
+
+      # Parent drive section
+      #
+      # @return [Y2Storage::AutoinstProfile::DriveSection]
+      def drive
+        drive_presenter.section
+      end
+
+      # @return [String, nil]
+      def device_name
+        if device_type == :lv && lv_name && !lv_name.empty?
+          lv_name
+        end
+      end
+
+      # @see #ui_label
+      #
+      # @return [String]
+      def device_type_label
+        case device_type
+        when :partition
+          # TRANSLATORS: this refers to the name of a section in the AutoYaST
+          # profile, so it's likely not a good idea to translate the term
+          _("Partition")
+        when :drive
+          # TRANSLATORS: these are names of sections in the AutoYaST profile,
+          # so it's likely not a good idea to translate the terms
+          _("Partition (Drive)")
+        when :lv
+          # TRANSLATORS: 'Partition' is the name of a section in the AutoYaST
+          # profile, so it's likely not a good idea to translate the term
+          _("Partition (LV)")
+        else
+          # TRANSLATORS: 'Partition' is the name of a section in the AutoYaST
+          # profile, so it's likely not a good idea to translate the term
+          _("Partition (Unused)")
+        end
+      end
+
+      # @see #ui_label
+      def usage_label
+        case usage
+        when :filesystem
+          if mount && !mount.empty?
+            mount
+          else
+            _("Not mounted")
+          end
+        when :raid
+          # TRANSLATORS: %s is a placeholder for the name of a RAID
+          _("Part of %s") % raid_name
+        when :lvm_pv
+          # TRANSLATORS: %s is a placeholder for the name of a RAID
+          _("Part of %s") % lvm_group
+        end
+      end
+
+      # Type of the device defined by the section
+      #
+      # @return [Symbol] :lv, :partition, :drive or :none
+      def device_type
+        return :lv if drive.type == :CT_LVM
+
+        if drive.unwanted_partitions?
+          return drive.master_partition == section ? :drive : :none
+        end
+
+        :partition
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/presenters/partition.rb
+++ b/src/lib/autoinstall/presenters/partition.rb
@@ -61,12 +61,12 @@ module Y2Autoinstallation
           # TRANSLATORS: this is how a <Partition> section of the AutoYaST profile is represented
           # in the UI. All words are placeholders and should NOT be translated, use this string
           # only to adapt the layout of the information.
-          "%{device_type}: %{name}, %{usage}" % parts
+          Kernel.format("%{device_type}: %{name}, %{usage}", parts)
         else
           # TRANSLATORS: this is how a <Partition> section of the AutoYaST profile is represented
           # in the UI. %{device_type} and %{usage} are placeholders and should NOT be translated,
           # use this string only to adapt the layout of the information.
-          "%{device_type}: %{usage}" % parts
+          Kernel.format("%{device_type}: %{usage}", parts)
         end
       end
 
@@ -81,7 +81,7 @@ module Y2Autoinstallation
       #
       # @return [Array<String>]
       def available_lvm_groups
-        vgs = drive.parent.drives.select {|d| d.type == :CT_LVM }
+        vgs = drive.parent.drives.select { |d| d.type == :CT_LVM }
         names = vgs.map(&:device).compact
         names.map { |n| n.delete_prefix("/dev/") }
       end
@@ -100,9 +100,9 @@ module Y2Autoinstallation
 
       # @return [String, nil]
       def device_name
-        if device_type == :lv && lv_name && !lv_name.empty?
-          lv_name
-        end
+        return nil unless device_type == :lv && lv_name && !lv_name.empty?
+
+        lv_name
       end
 
       # @see #ui_label
@@ -140,10 +140,10 @@ module Y2Autoinstallation
           end
         when :raid
           # TRANSLATORS: %s is a placeholder for the name of a RAID
-          _("Part of %s") % raid_name
+          Kernel.format(_("Part of %s"), raid_name)
         when :lvm_pv
           # TRANSLATORS: %s is a placeholder for the name of a RAID
-          _("Part of %s") % lvm_group
+          Kernel.format(_("Part of %s"), lvm_group)
         end
       end
 
@@ -153,11 +153,9 @@ module Y2Autoinstallation
       def device_type
         return :lv if drive.type == :CT_LVM
 
-        if drive.unwanted_partitions?
-          return drive.master_partition == section ? :drive : :none
-        end
+        return :partition unless drive.unwanted_partitions?
 
-        :partition
+        (drive.master_partition == section) ? :drive : :none
       end
     end
   end

--- a/src/lib/autoinstall/presenters/section.rb
+++ b/src/lib/autoinstall/presenters/section.rb
@@ -1,0 +1,106 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "delegate"
+
+module Y2Autoinstallation
+  module Presenters
+    # Base class to create presenters for objects that implement the interface
+    # defined by Y2Storage::AutoinstProfile::SectionWithAttributes
+    #
+    # The current implementation relies on SimpleDelegator, which means
+    # all methods of the corresponding section class are exposed. That may
+    # change in the future in favor of a more granular approach (eg. using
+    # Forwardable).
+    class Section < SimpleDelegator
+      include Yast::I18n
+
+      # Constructor
+      #
+      # @param section [Y2Storage::AutoinstProfile::SectionWithAttributes] the
+      #   concrete type of section depends on the presenter subclass
+      def initialize(section)
+        textdomain "autoinst"
+        __setobj__(section)
+      end
+
+      # Original profile section
+      #
+      # @return [Y2Storage::AutoinstProfile::SectionWithAttributes] presented object
+      def section
+        __getobj__
+      end
+
+      # String representation of the object
+      #
+      # @return [String]
+      def to_s
+        # By default, SimpleDelegator forwards this to the wrapped object. That can be
+        # pretty confusing, so let's implement the typical Ruby #to_s.
+        "#<#{obj_str}>"
+      end
+
+      # String representation of the state of the object
+      #
+      # @return [String]
+      def inspect
+        # Avoid SimpleDelegator forwarding to the wrapped section, see comment at #to_s
+        "#<#{obj_str} @section=#{section.inspect}>"
+      end
+
+      # Id that can be used to identify the section object
+      #
+      # This can be used, for example, to create ids for the widgets related to
+      # the presented section.
+      #
+      # @return [Integer]
+      def section_id
+        section.object_id
+      end
+
+      # Updates the Autoinst section
+      #
+      # @param values [Hash] Values to update
+      def update(values)
+        # FIXME: this cleanup should be implemented by the section class,
+        # directly in #init_from_hashes or in any similar method
+        clean_section
+        section.init_from_hashes(values)
+      end
+
+    private
+
+      # Resets all known attributes in the section
+      #
+      # FIXME: ideally we wouldn't need to implement this kind of things in
+      # the presenter
+      def clean_section
+        section.class.attributes.each do |attr|
+          section.public_send("#{attr[:name]}=", nil)
+        end
+      end
+
+      # See {#to_s} and {#inspect}
+      def obj_str
+        "#{self.class}:#{object_id}"
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -33,7 +33,7 @@ module Y2Autoinstallation
 
     # Sub-section of {#partitioning} that is currently selected to be modified
     #
-    # @return [Y2Storage::AutoinstProfile::DriveSection, Y2Storage::AutoinstProfile::PartitionSection, nil]
+    # @return [Y2Storage::AutoinstProfile::SectionWithAttributes, nil]
     attr_accessor :section
 
     # Constructor
@@ -96,7 +96,7 @@ module Y2Autoinstallation
     def drive
       return nil unless section
 
-      section.section_name == "partitions" ? section.parent : section
+      (section.section_name == "partitions") ? section.parent : section
     end
   end
 end

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -19,16 +19,22 @@
 
 require "yast"
 require "y2storage"
+require "autoinstall/presenters"
 
 module Y2Autoinstallation
-  # Controller for the editing the partitioning section of a profile
+  # Controller for editing the <partitioning> section of a profile
   #
-  # It is supposed to be used internally by
-  # {Y2Autoinstallation::Dialogs::Storage}.
+  # It is intended to be used internally by {Dialogs::Storage}.
   class StorageController
+    # Partitioning section that is being edited
+    #
     # @return [Y2Storage::AutoinstProfile::PartitioningSection]
-    #   Partition section
     attr_reader :partitioning
+
+    # Sub-section of {#partitioning} that is currently selected to be modified
+    #
+    # @return [Y2Storage::AutoinstProfile::DriveSection, Y2Storage::AutoinstProfile::PartitionSection, nil]
+    attr_accessor :section
 
     # Constructor
     #
@@ -36,71 +42,27 @@ module Y2Autoinstallation
     #   Partitioning section of the profile
     def initialize(partitioning)
       @partitioning = partitioning
+      @section = partitioning.drives.first
       @modified = false
     end
 
-    TYPES_MAP = {
-      disk: :CT_DISK,
-      raid: :CT_RAID,
-      lvm:  :CT_LVM
-    }.freeze
-
     # Adds a new drive section of the given type
     #
-    # @param type [Symbol]
+    # @param type [Presenters::DriveType]
     def add_drive(type)
-      section = Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(type: TYPES_MAP[type])
+      self.section = Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(
+        { type: type.to_sym },
+        partitioning
+      )
       partitioning.drives << section
     end
 
-    # Adds a new partition section under the given section
-    #
-    # @param parent [Y2Storage::AutoinstProfile::DriveSection] Parent section
-    def add_partition(parent)
-      parent.partitions << Y2Storage::AutoinstProfile::PartitionSection.new(parent)
-    end
+    # Adds a new partition section to the current drive section
+    def add_partition
+      return unless drive
 
-    # Updates a drive section
-    # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-    # @param values [Hash] Values to update
-    def update_drive(section, values)
-      partitions = section.partitions
-      section.init_from_hashes(values.merge("type" => section.type))
-      section.partitions = partitions
-    end
-
-    # Updates a partition section
-    #
-    # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-    # @param values [Hash] Values to update
-    def update_partition(section, values)
-      clean_section(section)
-      section.init_from_hashes(values)
-    end
-
-    # Determines the partition usage
-    #
-    # NOTE: perhaps this logic should live in the PartitionSection class.
-    #
-    # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-    # @return [Symbol]
-    def partition_usage(section)
-      use =
-        if section.mount
-          :filesystem
-        elsif section.raid_name
-          :raid
-        elsif section.lvm_group
-          :lvm_pv
-        end
-      use || :filesystem
-    end
-
-    # Returns a collection of LVM devices based on LVM group names
-    #
-    # @return [Array<String>]
-    def lvm_devices
-      drives(type: :lvm).map { |d| d.device.delete_prefix("/dev/") }
+      drive.partitions << Y2Storage::AutoinstProfile::PartitionSection.new(drive)
+      self.section = drive.partitions.last
     end
 
     # It determines whether the profile was modified
@@ -111,26 +73,30 @@ module Y2Autoinstallation
       true
     end
 
-  private
-
-    # Cleans a profile section
+    # Presenters for all the drive sections
     #
-    # Resets all known attributes
-    # @param section [Y2Storage::AutoinstProfile::SectionWithAttributes]
-    def clean_section(section)
-      section.class.attributes.each do |attr|
-        section.public_send("#{attr[:name]}=", nil)
-      end
+    # @return [Array<Presenters::Drive>]
+    def drive_presenters
+      drives.map { |d| Presenters::Drive.new(d) }
     end
 
-    # Returns drive sections
-    #
-    # @param type [Symbol] an specific drive type, such as :lvm, :disk, :raid
-    # @return [Array<Y2Storage::AutoinstProfile::DriveSection>] drive sections
-    def drives(type: nil)
-      return partitioning.drives unless type
+  private
 
-      partitioning.drives.select { |d| d.type == TYPES_MAP[type] }
+    # Drive sections inside the partitioning one
+    #
+    # @return [Array<Y2Storage::AutoinstProfile::DriveSection>]
+    def drives
+      partitioning.drives
+    end
+
+    # Drive section that is currently selected directly or indirectly (ie.
+    # because one of its partition sections is selected)
+    #
+    # @return [Y2Storage::AutoinstProfile::DriveSection]
+    def drive
+      return nil unless section
+
+      section.section_name == "partitions" ? section.parent : section
     end
   end
 end

--- a/src/lib/autoinstall/widgets/storage/add_partition_button.rb
+++ b/src/lib/autoinstall/widgets/storage/add_partition_button.rb
@@ -25,7 +25,6 @@ module Y2Autoinstallation
     module Storage
       # Button to add a new <partition> section to the current drive
       class AddPartitionButton < CWM::PushButton
-
         # Constructor
         #
         # @param controller [Y2Autoinstallation::StorageController] UI controller

--- a/src/lib/autoinstall/widgets/storage/add_partition_button.rb
+++ b/src/lib/autoinstall/widgets/storage/add_partition_button.rb
@@ -23,38 +23,25 @@ require "cwm/common_widgets"
 module Y2Autoinstallation
   module Widgets
     module Storage
-      # This class provides a button to add 'partition' sections
-      #
-      # In an AutoYaST profile, a 'partition' section is used to define a
-      # partition, a logical volume, a RAID member, etc.
-      class AddChildrenButton < CWM::PushButton
-        extend Yast::I18n
+      # Button to add a new <partition> section to the current drive
+      class AddPartitionButton < CWM::PushButton
 
         # Constructor
         #
         # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section of the profile
-        def initialize(controller, section)
+        def initialize(controller)
           textdomain "autoinst"
           @controller = controller
-          @section = section
         end
 
-        TYPE_LABELS = {
-          CT_DISK: N_("Partition"),
-          CT_RAID: N_("Partition"),
-          CT_LVM:  N_("Partition")
-        }.freeze
-
+        # @macro seeAbstractWidget
         def label
-          type_label = _(TYPE_LABELS[section.type])
-          format(_("Add %{type_label}"), type_label: type_label)
+          _("Add Partition")
         end
 
         # @macro seeAbstractWidget
         def handle
-          # FIXME: the controller could keep track of the current section
-          controller.add_partition(section)
+          controller.add_partition
           :redraw
         end
 
@@ -62,9 +49,6 @@ module Y2Autoinstallation
 
         # @return [Y2Autoinstallation::StorageController]
         attr_reader :controller
-
-        # @return [Y2Storage::AutoinstProfile::DriveSection]
-        attr_reader :section
       end
     end
   end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -18,8 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "cwm/page"
-require "autoinstall/widgets/storage/add_children_button"
+require "autoinstall/widgets/storage/drive_page"
 require "autoinstall/widgets/storage/disk_device"
 require "autoinstall/widgets/storage/init_drive"
 require "autoinstall/widgets/storage/disk_usage"
@@ -29,61 +28,26 @@ module Y2Autoinstallation
   module Widgets
     module Storage
       # This page allows to edit usage information for a disk
-      class DiskPage < ::CWM::Page
-        # Constructor
-        #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
-        #   to a disk
-        def initialize(controller, section)
-          textdomain "autoinst"
-          @controller = controller
-          @section = section
-          super()
-          self.widget_id = "disk_page:#{section.object_id}"
-          self.handle_all_events = true
-        end
-
-        # @macro seeAbstractWidget
-        def label
-          if section.device && !section.device.empty?
-            # TRANSLATORS: disk device name used in a `drive` section of an AutoYaST profile
-            format(_("Disk %{device}"), device: section.device)
-          else
-            format(_("Disk"))
-          end
-        end
-
+      class DiskPage < DrivePage
         # @macro seeCustomWidget
         def contents
           VBox(
             Left(Heading(_("Disk"))),
-            VBox(
-              Left(disk_device_widget),
-              Left(init_drive_widget),
-              Left(disk_usage_widget),
-              Left(partition_table_widget),
-              VStretch()
-            ),
-            HBox(
-              HStretch(),
-              AddChildrenButton.new(controller, section)
-            )
+            Left(disk_device_widget),
+            Left(init_drive_widget),
+            Left(disk_usage_widget),
+            Left(partition_table_widget),
+            VStretch()
           )
         end
 
         # @macro seeAbstractWidget
         def init
-          disk_device_widget.value = section.device
-          init_drive_widget.value = !!section.initialize_attr
-          disk_usage_widget.value = section.use
-          partition_table_widget.value = section.disklabel
+          disk_device_widget.value = drive.device
+          init_drive_widget.value = !!drive.initialize_attr
+          disk_usage_widget.value = drive.use
+          partition_table_widget.value = drive.disklabel
           set_disk_usage_status
-        end
-
-        # @macro seeAbstractWidget
-        def store
-          controller.update_drive(section, values)
         end
 
         # Returns widget values
@@ -105,12 +69,6 @@ module Y2Autoinstallation
         end
 
       private
-
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
-
-        # @return [Y2Storage::AutoinstProfile::DriveSection]
-        attr_reader :section
 
         # Disk device selector
         #

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -29,6 +29,12 @@ module Y2Autoinstallation
     module Storage
       # This page allows to edit usage information for a disk
       class DiskPage < DrivePage
+        # @see DrivePage#initialize
+        def initialize(*args)
+          textdomain "autoinst"
+          super
+        end
+
         # @macro seeCustomWidget
         def contents
           VBox(

--- a/src/lib/autoinstall/widgets/storage/drive_page.rb
+++ b/src/lib/autoinstall/widgets/storage/drive_page.rb
@@ -28,11 +28,9 @@ module Y2Autoinstallation
       class DrivePage < ::CWM::Page
         # Constructor
         #
-        # @param controller [StorageController] UI controller
         # @param drive [Presenters::Drive] presenter for the drive section of the profile
-        def initialize(controller, drive)
+        def initialize(drive)
           textdomain "autoinst"
-          @controller = controller
           @drive = drive
           super()
           self.widget_id = "drive_page:#{drive.section_id}"
@@ -57,9 +55,6 @@ module Y2Autoinstallation
         end
 
       private
-
-        # @return [StorageController]
-        attr_reader :controller
 
         # @return [Presenters::Drive]
         attr_reader :drive

--- a/src/lib/autoinstall/widgets/storage/drive_page.rb
+++ b/src/lib/autoinstall/widgets/storage/drive_page.rb
@@ -18,59 +18,51 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "cwm/common_widgets"
-require "autoinstall/presenters"
+require "y2storage"
+require "cwm/page"
 
 module Y2Autoinstallation
   module Widgets
     module Storage
-      # Button to add new drive sections
-      #
-      # This button allows to add new drive sections of different types
-      # (`CT_DISK`, `CT_LVM`, `CT_RAID`, etc.).
-      class AddDriveButton < CWM::MenuButton
-        include Yast::Logger
-
+      # Base class for all the pages allowing to edit a <drive> section
+      class DrivePage < ::CWM::Page
         # Constructor
         #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        def initialize(controller)
+        # @param controller [StorageController] UI controller
+        # @param drive [Presenters::Drive] presenter for the drive section of the profile
+        def initialize(controller, drive)
           textdomain "autoinst"
-          super()
           @controller = controller
+          @drive = drive
+          super()
+          self.widget_id = "drive_page:#{drive.section_id}"
           self.handle_all_events = true
         end
 
         # @macro seeAbstractWidget
         def label
-          _("Add Drive")
+          drive.ui_label
         end
 
-        # Returns the list of possible actions
-        #
-        # @return [Array<Symbol,String>]
-        def items
-          Presenters::DriveType.all.map do |type|
-            [:"add_#{type.to_sym}", type.label]
-          end
+        # @macro seeAbstractWidget
+        def store
+          drive.update(values)
         end
 
-        # Handles the events
+        # Drive section that is being edited
         #
-        # @param event [Hash] Event to handle
-        def handle(event)
-          event_id = event["ID"].to_s
-          return unless event_id.start_with?("add_")
-
-          type = event_id.split("_", 2).last
-          controller.add_drive(Presenters::DriveType.find(type))
-          :redraw
+        # @return [Y2Storage::AutoinstProfile::DriveSection]
+        def section
+          drive.section
         end
 
       private
 
-        # @return [Y2Autoinstallation::StorageController]
+        # @return [StorageController]
         attr_reader :controller
+
+        # @return [Presenters::Drive]
+        attr_reader :drive
       end
     end
   end

--- a/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
@@ -32,13 +32,10 @@ module Y2Autoinstallation
       class FilesystemAttrs < CWM::CustomWidget
         # Constructor
         #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-        #   of the profile
-        def initialize(controller, section)
+        # @param section [Presenters::Partition] presenter for the partition section
+        def initialize(section)
           super()
           textdomain "autoinst"
-          @controller = controller
           @section = section
         end
 
@@ -82,7 +79,8 @@ module Y2Autoinstallation
 
       private
 
-        attr_reader :controller, :section
+        # @return [Presenters::Partition] presenter for the partition section
+        attr_reader :section
 
         # Mount point widget
         #

--- a/src/lib/autoinstall/widgets/storage/lvm_page.rb
+++ b/src/lib/autoinstall/widgets/storage/lvm_page.rb
@@ -19,8 +19,7 @@
 
 require "yast"
 require "y2storage"
-require "cwm/page"
-require "autoinstall/widgets/storage/add_children_button"
+require "autoinstall/widgets/storage/drive_page"
 require "autoinstall/widgets/storage/vg_device"
 require "autoinstall/widgets/storage/vg_extent_size"
 require "autoinstall/widgets/storage/md_level"
@@ -31,51 +30,21 @@ module Y2Autoinstallation
   module Widgets
     module Storage
       # This page allows to edit a `drive` section representing an LVM
-      class LvmPage < ::CWM::Page
-        # Constructor
-        #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
-        #   to a RAID
-        def initialize(controller, section)
-          textdomain "autoinst"
-          @controller = controller
-          @section = section
-          super()
-          self.widget_id = "raid_page:#{section.object_id}"
-          self.handle_all_events = true
-        end
-
-        # @macro seeAbstractWidget
-        def label
-          format(_("LVM %{device}"), device: section.device)
-        end
-
+      class LvmPage < DrivePage
         # @macro seeCustomWidget
         def contents
           VBox(
             Left(Heading(_("LVM"))),
-            VBox(
-              Left(vg_device_widget),
-              Left(vg_pesize_widget),
-              VStretch()
-            ),
-            HBox(
-              HStretch(),
-              AddChildrenButton.new(controller, section)
-            )
+            Left(vg_device_widget),
+            Left(vg_pesize_widget),
+            VStretch()
           )
         end
 
         # @macro seeAbstractWidget
         def init
-          vg_device_widget.value = section.device
-          vg_pesize_widget.value = section.pesize
-        end
-
-        # @macro seeAbstractWidget
-        def store
-          controller.update_drive(section, values)
+          vg_device_widget.value = drive.device
+          vg_pesize_widget.value = drive.pesize
         end
 
         # Returns the widgets values
@@ -89,12 +58,6 @@ module Y2Autoinstallation
         end
 
       private
-
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
-
-        # @return [Y2Storage::AutoinstProfile::DriveSection]
-        attr_reader :section
 
         # LVM VG name input field
         #

--- a/src/lib/autoinstall/widgets/storage/lvm_page.rb
+++ b/src/lib/autoinstall/widgets/storage/lvm_page.rb
@@ -22,9 +22,6 @@ require "y2storage"
 require "autoinstall/widgets/storage/drive_page"
 require "autoinstall/widgets/storage/vg_device"
 require "autoinstall/widgets/storage/vg_extent_size"
-require "autoinstall/widgets/storage/md_level"
-require "autoinstall/widgets/storage/chunk_size"
-require "autoinstall/widgets/storage/parity_algorithm"
 
 module Y2Autoinstallation
   module Widgets

--- a/src/lib/autoinstall/widgets/storage/lvm_page.rb
+++ b/src/lib/autoinstall/widgets/storage/lvm_page.rb
@@ -31,6 +31,12 @@ module Y2Autoinstallation
     module Storage
       # This page allows to edit a `drive` section representing an LVM
       class LvmPage < DrivePage
+        # @see DrivePage#initialize
+        def initialize(*args)
+          textdomain "autoinst"
+          super
+        end
+
         # @macro seeCustomWidget
         def contents
           VBox(

--- a/src/lib/autoinstall/widgets/storage/lvm_partition_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/lvm_partition_attrs.rb
@@ -30,13 +30,10 @@ module Y2Autoinstallation
       class LvmPartitionAttrs < CWM::CustomWidget
         # Constructor
         #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-        #   of the profile
-        def initialize(controller, section)
+        # @param section [Presenters::Partition] presenter for the partition section
+        def initialize(section)
           textdomain "autoinst"
           super()
-          @controller = controller
           @section = section
         end
 
@@ -66,10 +63,7 @@ module Y2Autoinstallation
 
       private
 
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
-
-        # @return [Y2Storage::AutoinstProfile::PartitionSection]
+        # @return [Presenters::Partition] presenter for the partition section
         attr_reader :section
 
         # LVM LV name widget

--- a/src/lib/autoinstall/widgets/storage/lvm_pv_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/lvm_pv_attrs.rb
@@ -54,7 +54,7 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def init
-          lvm_group_widget.items = controller.lvm_devices
+          lvm_group_widget.items = section.available_lvm_groups
           lvm_group_widget.value = section.lvm_group
         end
 

--- a/src/lib/autoinstall/widgets/storage/lvm_pv_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/lvm_pv_attrs.rb
@@ -30,13 +30,10 @@ module Y2Autoinstallation
       class LvmPvAttrs < CWM::CustomWidget
         # Constructor
         #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-        #   of the profile
-        def initialize(controller, section)
+        # @param section [Presenters::Partition] presenter for the partition section
+        def initialize(section)
           textdomain "autoinst"
           super()
-          @controller = controller
           @section = section
         end
 
@@ -67,10 +64,7 @@ module Y2Autoinstallation
 
       private
 
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
-
-        # @return [Y2Storage::AutoinstProfile::PartitionSection]
+        # @return [Presenters::Partition] presenter for the partition section
         attr_reader :section
 
         # LVM Group widget

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -101,7 +101,7 @@ module Y2Autoinstallation
         # @return [CWM::PagerTreeItem] Tree item
         def drive_item(section)
           page_klass = page_klass_for(section.type)
-          page = page_klass.new(controller, section)
+          page = page_klass.new(section)
           CWM::PagerTreeItem.new(page, children: partition_items(section))
         end
 
@@ -118,7 +118,7 @@ module Y2Autoinstallation
         #   List of partition partition sections
         def partition_items(drive)
           drive.partitions.map do |part|
-            part_page = Y2Autoinstallation::Widgets::Storage::PartitionPage.new(controller, part)
+            part_page = Y2Autoinstallation::Widgets::Storage::PartitionPage.new(part)
             CWM::PagerTreeItem.new(part_page)
           end
         end

--- a/src/lib/autoinstall/widgets/storage/partition_page.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_page.rb
@@ -38,11 +38,9 @@ module Y2Autoinstallation
       class PartitionPage < ::CWM::Page
         # Constructor
         #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
         # @param partition [Presenters::Partition] presenter for a partition section of the profile
-        def initialize(controller, partition)
+        def initialize(partition)
           textdomain "autoinst"
-          @controller = controller
           @partition = partition
           super()
           self.widget_id = "partition_page:#{partition.section_id}"
@@ -101,9 +99,7 @@ module Y2Autoinstallation
 
       private
 
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
-
+        # @return [Presenters::Partition] presenter for the partition section
         attr_reader :partition
 
         def size_widget
@@ -115,15 +111,15 @@ module Y2Autoinstallation
         end
 
         def filesystem_widget
-          @filesystem_widget ||= FilesystemAttrs.new(controller, partition)
+          @filesystem_widget ||= FilesystemAttrs.new(partition)
         end
 
         def raid_widget
-          @raid_widget ||= RaidAttrs.new(controller, partition)
+          @raid_widget ||= RaidAttrs.new(partition)
         end
 
         def lvm_pv_widget
-          @lvm_pv_widget ||= LvmPvAttrs.new(controller, partition)
+          @lvm_pv_widget ||= LvmPvAttrs.new(partition)
         end
 
         def drive_dependent_attrs_widget
@@ -131,7 +127,7 @@ module Y2Autoinstallation
             begin
               drive_type = partition.drive_type.to_s
               widget = "#{drive_type.capitalize}PartitionAttrs"
-              Y2Autoinstallation::Widgets::Storage.const_get(widget).new(controller, partition)
+              Y2Autoinstallation::Widgets::Storage.const_get(widget).new(partition)
             rescue NameError
               CWM::Empty.new("drive_dependent_attrs")
             end

--- a/src/lib/autoinstall/widgets/storage/raid_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_attrs.rb
@@ -30,13 +30,10 @@ module Y2Autoinstallation
       class RaidAttrs < CWM::CustomWidget
         # Constructor
         #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::PartitionSection] Partition section
-        #   of the profile
-        def initialize(controller, section)
+        # @param section [Presenters::Partition] presenter for the partition section
+        def initialize(section)
           textdomain "autoinst"
           super()
-          @controller = controller
           @section = section
         end
 
@@ -65,9 +62,6 @@ module Y2Autoinstallation
         end
 
       private
-
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
 
         # @return [Y2Storage::AutoinstProfile::PartitionSection]
         attr_reader :section

--- a/src/lib/autoinstall/widgets/storage/raid_page.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_page.rb
@@ -18,8 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "cwm/page"
-require "autoinstall/widgets/storage/add_children_button"
+require "autoinstall/widgets/storage/drive_page"
 require "autoinstall/widgets/storage/raid_name"
 require "autoinstall/widgets/storage/md_level"
 require "autoinstall/widgets/storage/chunk_size"
@@ -29,58 +28,28 @@ module Y2Autoinstallation
   module Widgets
     module Storage
       # This page allows to edit a `drive` section representing a RAID device
-      class RaidPage < ::CWM::Page
-        # Constructor
-        #
-        # @param controller [Y2Autoinstallation::StorageController] UI controller
-        # @param section [Y2Storage::AutoinstProfile::DriveSection] Drive section corresponding
-        #   to a RAID
-        def initialize(controller, section)
-          textdomain "autoinst"
-          @controller = controller
-          @section = section
-          super()
-          self.widget_id = "raid_page:#{section.object_id}"
-          self.handle_all_events = true
-        end
-
-        # @macro seeAbstractWidget
-        def label
-          format(_("RAID %{device}"), device: section.device)
-        end
-
+      class RaidPage < DrivePage
         # @macro seeCustomWidget
         def contents
           VBox(
             Left(Heading(_("RAID"))),
-            VBox(
-              Left(raid_name_widget),
-              Left(md_level_widget),
-              Left(parity_algorithm_widget),
-              Left(chunk_size_widget),
-              VStretch()
-            ),
-            HBox(
-              HStretch(),
-              AddChildrenButton.new(controller, section)
-            )
+            Left(raid_name_widget),
+            Left(md_level_widget),
+            Left(parity_algorithm_widget),
+            Left(chunk_size_widget),
+            VStretch()
           )
         end
 
         # @macro seeAbstractWidget
         def init
-          raid_name_widget.value = section.device
-          raid_options = section.raid_options
+          raid_name_widget.value = drive.device
+          raid_options = drive.raid_options
           if raid_options
             md_level_widget.value = raid_options.raid_type.to_s
             parity_algorithm_widget.value = raid_options.parity_algorithm
             chunk_size_widget.value = raid_options.chunk_size
           end
-        end
-
-        # @macro seeAbstractWidget
-        def store
-          controller.update_drive(section, values)
         end
 
         # Returns the widgets values
@@ -98,12 +67,6 @@ module Y2Autoinstallation
         end
 
       private
-
-        # @return [Y2Autoinstallation::StorageController]
-        attr_reader :controller
-
-        # @return [Y2Storage::AutoinstProfile::DriveSection]
-        attr_reader :section
 
         # RAID name input field
         #

--- a/src/lib/autoinstall/widgets/storage/raid_page.rb
+++ b/src/lib/autoinstall/widgets/storage/raid_page.rb
@@ -29,6 +29,12 @@ module Y2Autoinstallation
     module Storage
       # This page allows to edit a `drive` section representing a RAID device
       class RaidPage < DrivePage
+        # @see DrivePage#initialize
+        def initialize(*args)
+          textdomain "autoinst"
+          super
+        end
+
         # @macro seeCustomWidget
         def contents
           VBox(

--- a/src/lib/autoinstall/widgets/storage/vg_device.rb
+++ b/src/lib/autoinstall/widgets/storage/vg_device.rb
@@ -49,10 +49,20 @@ module Y2Autoinstallation
 
         # Ensure that device starts with /dev/
         #
-        # @param device [String] device name to check
+        # @param device [String, nil] device name to check
         # @return [String] the device name properly prefixed
         def prefix(device)
+          return "" if blank?(device)
+
           device.start_with?("/dev/") ? device : "/dev/#{device}"
+        end
+
+        # Checks whether the given value is blank
+        #
+        # @param val [String, nil] value to check
+        # @return [Boolean]
+        def blank?(val)
+          val.nil? || val.empty?
         end
       end
     end

--- a/test/lib/presenters/partition_test.rb
+++ b/test/lib/presenters/partition_test.rb
@@ -1,0 +1,133 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "autoinstall/presenters"
+require "y2storage/autoinst_profile/partitioning_section"
+require "y2storage/autoinst_profile/partition_section"
+
+describe Y2Autoinstallation::Presenters::Partition do
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(part_hashes)
+  end
+
+  let(:part_hashes) do
+    [{ "type" => :CT_DISK }]
+  end
+
+  let(:section) { Y2Storage::AutoinstProfile::PartitionSection.new }
+
+  let(:drive_section) do
+    sect = partitioning.drives.first
+    sect.partitions << section
+    sect
+  end
+
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(drive_section) }
+
+  subject { drive.partitions.first }
+
+  describe "#update" do
+    context "when file system attributes are given" do
+      let(:values) do
+        { filesystem: :ext4, mount: "/home" }
+      end
+
+      it "sets the file system attributes" do
+        subject.update(values)
+        expect(subject.section.filesystem).to eq(:ext4)
+        expect(subject.section.mount).to eq("/home")
+      end
+
+      it "clears non filesystem specific attributes" do
+        subject.update(values)
+        expect(subject.section.raid_name).to be_nil
+      end
+    end
+
+    context "when RAID attributes are given" do
+      let(:values) do
+        { raid_name: "/dev/md1" }
+      end
+
+      it "sets the RAID attributes" do
+        subject.update(values)
+        expect(section.raid_name).to eq("/dev/md1")
+      end
+
+      it "clears non RAID specific attributes" do
+        subject.update(values)
+        expect(section.filesystem).to be_nil
+        expect(section.mount).to be_nil
+      end
+    end
+  end
+
+  describe "#usage" do
+    let(:section) do
+      Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes(attrs)
+    end
+
+    context "when the section refers to a file system" do
+      let(:attrs) { { filesystem: :ext4 } }
+
+      it "returns :filesystem" do
+        expect(subject.usage).to eq(:filesystem)
+      end
+    end
+
+    context "when the section refers to a RAID member" do
+      let(:attrs) { { raid_name: "/dev/md0" } }
+
+      it "returns :raid" do
+        expect(subject.usage).to eq(:raid)
+      end
+    end
+
+    context "when the section refers to an LVM PV" do
+      let(:attrs) { { lvm_group: "system" } }
+
+      it "returns :lvm_pv" do
+        expect(subject.usage).to eq(:lvm_pv)
+      end
+    end
+  end
+
+  describe "#available_lvm_groups" do
+    context "when there are no LVM drive sections" do
+      it "returns an empty collection" do
+        expect(subject.available_lvm_groups).to eq([])
+      end
+    end
+
+    context "when there are LVM drive section" do
+      let(:part_hashes) do
+        [
+          { "type" => :CT_DISK },
+          { "type" => :CT_LVM, "device" => "/dev/vg-0" },
+          { "type" => :CT_LVM, "device" => "/dev/vg-1" }
+        ]
+      end
+
+      it "returns a collection of LVM drive sections device" do
+        expect(subject.available_lvm_groups).to eq(["vg-0", "vg-1"])
+      end
+    end
+  end
+end

--- a/test/lib/storage_controller_test.rb
+++ b/test/lib/storage_controller_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../test_helper"
 require "autoinstall/storage_controller"
+require "autoinstall/presenters"
 require "y2storage/autoinst_profile/partitioning_section"
 require "y2storage/autoinst_profile/partition_section"
 
@@ -29,110 +30,11 @@ describe Y2Autoinstallation::StorageController do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([])
   end
 
-  describe "#add" do
+  describe "#add_drive" do
     it "adds a new section with the given type" do
-      subject.add_drive(:disk)
+      subject.add_drive(Y2Autoinstallation::Presenters::DriveType::DISK)
       new_drive = partitioning.drives.first
       expect(new_drive.type).to eq(:CT_DISK)
-    end
-  end
-
-  describe "#update_partition" do
-    let(:section) do
-      Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes(
-        filesystem: :btrfs,
-        mount:      "/",
-        raid_name:  "/dev/md0"
-      )
-    end
-
-    context "when file system attributes are given" do
-      let(:values) do
-        { filesystem: :ext4, mount: "/home" }
-      end
-
-      it "sets the file system attributes" do
-        subject.update_partition(section, values)
-        expect(section.filesystem).to eq(:ext4)
-        expect(section.mount).to eq("/home")
-      end
-
-      it "clears non filesystem specific attributes" do
-        subject.update_partition(section, values)
-        expect(section.raid_name).to be_nil
-      end
-    end
-
-    context "when RAID attributes are given" do
-      let(:values) do
-        { raid_name: "/dev/md1" }
-      end
-
-      it "sets the RAID attributes" do
-        subject.update_partition(section, values)
-        expect(section.raid_name).to eq("/dev/md1")
-      end
-
-      it "clears non RAID specific attributes" do
-        subject.update_partition(section, values)
-        expect(section.filesystem).to be_nil
-        expect(section.mount).to be_nil
-      end
-    end
-  end
-
-  describe "#partition_usage" do
-    let(:section) do
-      Y2Storage::AutoinstProfile::PartitionSection.new_from_hashes(attrs)
-    end
-
-    context "when the section refers to a file system" do
-      let(:attrs) { { filesystem: :ext4 } }
-
-      it "returns :filesystem" do
-        expect(subject.partition_usage(section)).to eq(:filesystem)
-      end
-    end
-
-    context "when the section refers to a RAID member" do
-      let(:attrs) { { raid_name: "/dev/md0" } }
-
-      it "returns :raid" do
-        expect(subject.partition_usage(section)).to eq(:raid)
-      end
-    end
-
-    context "when the section refers to an LVM PV" do
-      let(:attrs) { { lvm_group: "system" } }
-
-      it "returns :lvm_pv" do
-        expect(subject.partition_usage(section)).to eq(:lvm_pv)
-      end
-    end
-  end
-
-  describe "#lvm_devices" do
-    context "when there are no LVM drive sections" do
-      it "returns an empty collection" do
-        expect(subject.lvm_devices).to eq([])
-      end
-    end
-
-    context "when there are LVM drive section" do
-      before do
-        subject.add_drive(:lvm)
-        subject.add_drive(:lvm)
-
-        vg0 = subject.partitioning.drives[0]
-        vg1 = subject.partitioning.drives[1]
-
-        subject.update_drive(vg0, device: "/dev/vg-0")
-        subject.update_drive(vg1, device: "/dev/vg-1")
-      end
-
-      it "returns a collection of LVM drive sections device" do
-        expect(subject.lvm_devices).to eq(["vg-0", "vg-1"])
-      end
     end
   end
 end

--- a/test/lib/widgets/storage/add_children_button_test.rb
+++ b/test/lib/widgets/storage/add_children_button_test.rb
@@ -18,30 +18,25 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/add_children_button"
+require "autoinstall/widgets/storage/add_partition_button"
 require "autoinstall/storage_controller"
 require "cwm/rspec"
 
-describe Y2Autoinstallation::Widgets::Storage::AddChildrenButton do
-  subject(:widget) { described_class.new(controller, section) }
+describe Y2Autoinstallation::Widgets::Storage::AddPartitionButton do
+  subject(:widget) { described_class.new(controller) }
 
   include_examples "CWM::PushButton"
 
   let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
   let(:partitioning) do
-    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([])
-  end
-  let(:section) do
-    Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(
-      type:       :CT_DISK,
-      filesystem: :btrfs,
-      mount:      "/home"
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+      [{ type: :CT_DISK, device: "/dev/sda" }]
     )
   end
 
   describe "#handle" do
     it "adds new partition section" do
-      expect(controller).to receive(:add_partition).with(section)
+      expect(controller).to receive(:add_partition)
       widget.handle
     end
   end

--- a/test/lib/widgets/storage/add_drive_button_test.rb
+++ b/test/lib/widgets/storage/add_drive_button_test.rb
@@ -30,35 +30,33 @@ describe Y2Autoinstallation::Widgets::Storage::AddDriveButton do
   end
 
   describe "#handle" do
+    let(:event) do
+      { "ID" => :"add_#{type.to_sym}" }
+    end
+
     context "adding a disk" do
-      let(:event) do
-        { "ID" => :add_disk }
-      end
+      let(:type) { Y2Autoinstallation::Presenters::DriveType::DISK }
 
       it "adds a disk drive section" do
-        expect(controller).to receive(:add_drive).with(:disk)
+        expect(controller).to receive(:add_drive).with(type)
         subject.handle(event)
       end
     end
 
     context "adding a RAID" do
-      let(:event) do
-        { "ID" => :add_raid }
-      end
+      let(:type) { Y2Autoinstallation::Presenters::DriveType::RAID }
 
       it "adds a RAID drive section" do
-        expect(controller).to receive(:add_drive).with(:raid)
+        expect(controller).to receive(:add_drive).with(type)
         subject.handle(event)
       end
     end
 
     context "adding an LVM" do
-      let(:event) do
-        { "ID" => :add_lvm }
-      end
+      let(:type) { Y2Autoinstallation::Presenters::DriveType::LVM }
 
       it "adds an LVM drive section" do
-        expect(controller).to receive(:add_drive).with(:lvm)
+        expect(controller).to receive(:add_drive).with(type)
         subject.handle(event)
       end
     end

--- a/test/lib/widgets/storage/disk_page_test.rb
+++ b/test/lib/widgets/storage/disk_page_test.rb
@@ -19,12 +19,12 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/disk_page"
-require "autoinstall/storage_controller"
+require "autoinstall/presenters"
 require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::DiskPage do
-  subject { described_class.new(controller, drive) }
+  subject { described_class.new(drive) }
 
   include_examples "CWM::Page"
 
@@ -33,8 +33,7 @@ describe Y2Autoinstallation::Widgets::Storage::DiskPage do
       [{ "type" => :CT_DISK }]
     )
   end
-  let(:drive) { partitioning.drives.first }
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(partitioning.drives.first) }
 
   let(:disk_device_widget) do
     instance_double(
@@ -92,7 +91,7 @@ describe Y2Autoinstallation::Widgets::Storage::DiskPage do
       let(:device) { "" }
 
       it "does not include the device" do
-        expect(subject.label).to eq("Disk")
+        expect(subject.label).to eq("Drive (Disk)")
       end
     end
   end

--- a/test/lib/widgets/storage/filesystem_attrs_test.rb
+++ b/test/lib/widgets/storage/filesystem_attrs_test.rb
@@ -19,16 +19,11 @@
 
 require_relative "../../../test_helper"
 require "y2storage"
-require "autoinstall/storage_controller"
 require "autoinstall/widgets/storage/filesystem_attrs"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::FilesystemAttrs do
-  subject { described_class.new(controller, section) }
-
-  let(:controller) do
-    instance_double(Y2Autoinstallation::StorageController)
-  end
+  subject { described_class.new(section) }
 
   let(:section) do
     Y2Storage::AutoinstProfile::PartitionSection.new

--- a/test/lib/widgets/storage/lvm_page_test.rb
+++ b/test/lib/widgets/storage/lvm_page_test.rb
@@ -19,17 +19,16 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/lvm_page"
-require "autoinstall/storage_controller"
+require "autoinstall/presenters"
 require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::LvmPage do
-  subject { described_class.new(controller, drive) }
+  subject { described_class.new(drive) }
 
   include_examples "CWM::Page"
 
-  let(:drive) { partitioning.drives.first }
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(partitioning.drives.first) }
 
   let(:partitioning) do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(

--- a/test/lib/widgets/storage/lvm_partition_attrs_test.rb
+++ b/test/lib/widgets/storage/lvm_partition_attrs_test.rb
@@ -19,16 +19,11 @@
 
 require_relative "../../../test_helper"
 require "y2storage"
-require "autoinstall/storage_controller"
 require "autoinstall/widgets/storage/lvm_partition_attrs"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::LvmPartitionAttrs do
-  subject(:widget) { described_class.new(controller, section) }
-
-  let(:controller) do
-    instance_double(Y2Autoinstallation::StorageController)
-  end
+  subject(:widget) { described_class.new(section) }
 
   let(:section) do
     Y2Storage::AutoinstProfile::PartitionSection.new

--- a/test/lib/widgets/storage/lvm_pv_attrs_test.rb
+++ b/test/lib/widgets/storage/lvm_pv_attrs_test.rb
@@ -19,21 +19,24 @@
 
 require_relative "../../../test_helper"
 require "y2storage"
-require "autoinstall/storage_controller"
+require "autoinstall/presenters"
 require "autoinstall/widgets/storage/lvm_pv_attrs"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::LvmPvAttrs do
-  subject(:widget) { described_class.new(controller, section) }
+  subject(:widget) { described_class.new(section) }
 
   include_examples "CWM::CustomWidget"
 
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
-  let(:section) { Y2Storage::AutoinstProfile::PartitionSection.new }
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(partitioning.drives.first) }
+  let(:section) { drive.partitions.first }
 
   let(:partitioning) do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
-      [{ "device" => "/dev/system", "type" => :CT_LVM, "pesize" => "64" }]
+      [
+        { "type" => :CT_DISK, "partitions" => [{}] },
+        { "device" => "/dev/system", "type" => :CT_LVM, "pesize" => "64" }
+      ]
     )
   end
 

--- a/test/lib/widgets/storage/overview_tree_pager_test.rb
+++ b/test/lib/widgets/storage/overview_tree_pager_test.rb
@@ -48,7 +48,7 @@ describe Y2Autoinstallation::Widgets::Storage::OverviewTreePager do
         [{ "type" => :CT_UNKNOWN }]
       end
 
-      it "uses considers that the section corresponds to a disk" do
+      it "considers that the section corresponds to a disk" do
         expect(subject.items.map(&:page)).to contain_exactly(
           an_instance_of(Y2Autoinstallation::Widgets::Storage::DiskPage)
         )

--- a/test/lib/widgets/storage/partition_page_test.rb
+++ b/test/lib/widgets/storage/partition_page_test.rb
@@ -19,12 +19,12 @@
 
 require_relative "../../../test_helper"
 require "autoinstall/widgets/storage/partition_page"
-require "autoinstall/storage_controller"
+require "autoinstall/presenters"
 require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
-  subject { described_class.new(controller, drive, partition) }
+  subject { described_class.new(partition) }
 
   include_examples "CWM::Page"
 
@@ -34,9 +34,8 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
     )
   end
   let(:type) { :CT_DISK }
-  let(:drive) { partitioning.drives.first }
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(partitioning.drives.first) }
   let(:partition) { drive.partitions.first }
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
   let(:partition_hash) { {} }
 
   describe "#label" do
@@ -53,7 +52,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
         let(:partition_hash) { { "filesystem" => :ext4 } }
 
         it "does not include the mount point" do
-          expect(subject.label).to eq("Partition")
+          expect(subject.label).to eq("Partition: Not Mounted")
         end
       end
     end
@@ -62,7 +61,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
       let(:partition_hash) { { "raid_name" => "/dev/md0" } }
 
       it "returns a description" do
-        expect(subject.label).to eq("Part of /dev/md0")
+        expect(subject.label).to eq("Partition: Part of /dev/md0")
       end
     end
 
@@ -70,7 +69,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
       let(:partition_hash) { { "lvm_group" => "/dev/system" } }
 
       it "returns a description" do
-        expect(subject.label).to eq("Partition for PV /dev/system")
+        expect(subject.label).to eq("Partition: Part of /dev/system")
       end
     end
   end
@@ -108,7 +107,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionPage do
     end
 
     it "sets the partition section attributes" do
-      expect(controller).to receive(:update_partition).with(partition, anything)
+      expect(partition).to receive(:update)
       subject.store
     end
   end

--- a/test/lib/widgets/storage/raid_attrs_test.rb
+++ b/test/lib/widgets/storage/raid_attrs_test.rb
@@ -19,16 +19,11 @@
 
 require_relative "../../../test_helper"
 require "y2storage"
-require "autoinstall/storage_controller"
 require "autoinstall/widgets/storage/raid_attrs"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::RaidAttrs do
-  subject { described_class.new(controller, section) }
-
-  let(:controller) do
-    instance_double(Y2Autoinstallation::StorageController)
-  end
+  subject { described_class.new(section) }
 
   let(:section) do
     Y2Storage::AutoinstProfile::PartitionSection.new

--- a/test/lib/widgets/storage/raid_page_test.rb
+++ b/test/lib/widgets/storage/raid_page_test.rb
@@ -18,13 +18,13 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
+require "autoinstall/presenters"
 require "autoinstall/widgets/storage/raid_page"
-require "autoinstall/storage_controller"
 require "y2storage/autoinst_profile"
 require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::RaidPage do
-  subject { described_class.new(controller, drive) }
+  subject { described_class.new(drive) }
 
   include_examples "CWM::Page"
 
@@ -33,8 +33,7 @@ describe Y2Autoinstallation::Widgets::Storage::RaidPage do
       [{ "device" => "/dev/md0", "type" => :CT_RAID }]
     )
   end
-  let(:drive) { partitioning.drives.first }
-  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(partitioning.drives.first) }
 
   let(:raid_name_widget) do
     instance_double(


### PR DESCRIPTION
Reorganization of buttons and labels in the interface.

![buttons](https://user-images.githubusercontent.com/3638289/81196112-e9f61c00-8fbe-11ea-8431-384666f0d61f.png)

To better organize the code, this pull request implements the [Presentation Model pattern](https://martinfowler.com/eaaDev/PresentationModel.html). Our concrete implementation is also inspired by the [Presenter pattern](http://blog.jayfields.com/2007/03/rails-presenter-pattern.html) used in Ruby on Rails.

It contains some code that should likely be moved to `Y2Storage::Autoinst`. See the FIXMEs in `Presenters::Section`.