### PR TITLE
Always re-probe storage after pre-scripts (bsc#1170082, bsc#1133045)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  5 08:32:31 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- Always re-probe storage after pre-scripts (bsc#1170082, bsc#1133045)
+- 4.1.15
+
+-------------------------------------------------------------------
 Tue Apr 14 11:43:20 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Update the Makefile to include restored icons (related to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.1.14
+Version:        4.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -1,5 +1,24 @@
 # encoding: utf-8
 
+# Copyright (c) [2013-2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 # File:    clients/inst_autosetup.ycp
 # Package: Auto-installation
 # Summary: Setup and prepare system for auto-installation
@@ -263,7 +282,6 @@ module Yast
       # moved here from autoinit for fate #301193
       # needs testing
       if Arch.s390
-        dasd_or_zfcp = Profile.current.key?("dasd") || Profile.current.key?("zfcp")
         if Builtins.haskey(Profile.current, "dasd")
           Builtins.y2milestone("dasd found")
           if Call.Function("dasd_auto", ["Import", Ops.get_map(Profile.current, "dasd", {})])
@@ -286,7 +304,11 @@ module Yast
 
       Progress.NextStage
 
-      probe_storage if modified_profile? || dasd_or_zfcp
+      # Pre-scripts can modify the AutoYaST profile. Even more, a pre-script could change the initial
+      # disks layout/configuration (e.g., by creating a new partition). It is difficult to evaluate
+      # whether a pre-script has modified something related to storage devices, so a re-probing is always
+      # performed here (related to bsc#1133045).
+      probe_storage
 
       if Profile.current["partitioning_advanced"] && !Profile.current["partitioning_advanced"].empty?
         write_storage = AutoinstStorage.ImportAdvanced(Profile.current["partitioning_advanced"])


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1170082
- https://trello.com/c/qC09yxJf

Autoinstallation doesn't see the activated iSCSI disks on the client because no re-probing of the storage data is triggered.

## Solution

Backport https://github.com/yast/yast-autoinstallation/pull/511 to SLE-15-SP1.