### PR TITLE
ayast_setup: Do not add networking section when not defined explicitly

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May  6 08:47:13 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- ayast_setup: Do not add a 'networking' section to the profile
+  when it is not defined explicitly as it is not needed anymore
+  since keeping the configured network is the default option during
+  autoconfiguration (bsc#1170821)
+- 4.2.35
+
+-------------------------------------------------------------------
 Tue Apr  1 11:51:35 UTC 2020 - schubi@suse.de
 
 - Service for init scripts: Try to start "network-online.target" 

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.34
+Version:        4.2.35
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/test/lib/clients/ayast_setup_test.rb
+++ b/test/lib/clients/ayast_setup_test.rb
@@ -21,7 +21,23 @@
 require_relative "../../test_helper"
 require "autoinstall/clients/ayast_setup"
 
-describe Y2Autoinstall::Clients::AyastSetup do
+require "yast"
+
+module Yast
+  class DummyClient < Module
+    include Y2Autoinstall::Clients::AyastSetup
+    attr_accessor :dopackages
+  end
+end
+
+Yast.import "Profile"
+
+describe "Y2Autoinstall::Clients::AyastSetup" do
+  let(:subject) { Yast::DummyClient.new }
+  let(:profile) { { "software" => { "post-packages" => packages } } }
+  let(:packages) { ["vim"] }
+  let(:dopackages) { false }
+
   let(:client) do
     instance_double(Y2Autoinstall::Clients::AyastSetup, Setup: true)
   end
@@ -29,6 +45,70 @@ describe Y2Autoinstall::Clients::AyastSetup do
   describe "#main" do
     it "Start the ayast_setup client" do
       expect(client.Setup).to eq true
+    end
+  end
+
+  describe "#Setup" do
+    before do
+      Yast::Profile.current = profile
+      allow(Yast::AutoInstall).to receive(:Save)
+      allow(Yast::WFM).to receive(:CallFunction)
+      allow(Yast::Mode).to receive(:SetMode)
+      allow(Yast::Stage).to receive(:Set)
+      allow(Yast::PackageSystem).to receive(:Installed).and_return(true)
+      allow(Yast::Pkg).to receive(:TargetInit)
+      allow(subject).to receive(:restart_initscripts)
+      subject.dopackages = dopackages
+    end
+
+    it "saves the current profile if modified" do
+      expect(Yast::AutoInstall).to receive(:Save)
+
+      subject.Setup
+    end
+
+    it "calls the inst_autopost client" do
+      expect(Yast::WFM).to receive(:CallFunction).with("inst_autopost", [])
+
+      subject.Setup
+    end
+
+    context "when dopackages is enabled" do
+      let(:dopackages) { true }
+
+      it "installs given post installation packages / patterns when not installed yet" do
+        expect(Yast::PackageSystem).to receive(:Installed).and_return(false)
+        expect(Yast::AutoinstSoftware).to receive(:addPostPackages).with(["vim"])
+        expect(Yast::WFM).to receive(:CallFunction).with("inst_rpmcopy", [])
+
+        subject.Setup
+      end
+    end
+
+    context "when dopackages is disabled" do
+      it "does not try to install given post installation packages / patterns" do
+        expect(Yast::WFM).to_not receive(:CallFunction).with("inst_rpmcopy", [])
+
+        subject.Setup
+      end
+    end
+
+    it "runs inst_autoconfigure client" do
+      expect(Yast::WFM).to receive(:CallFunction).with("inst_autoconfigure", [])
+
+      subject.Setup
+    end
+
+    it "restarts AutoYaST initscripts" do
+      expect(subject).to receive(:restart_initscripts)
+
+      subject.Setup
+    end
+
+    it "does not add a networking section when it is not defined in the profile" do
+      expect(Yast::Profile.current.keys).to_not include("networking")
+      subject.Setup
+      expect(Yast::Profile.current.keys).to_not include("networking")
     end
   end
 end


### PR DESCRIPTION
## Problem

When ayast_setup is called without a `networking` section it modifies the profile adding it with the `keep_install_network => true` option. Thus, lan_auto client is called in order to write the configuration which crashes because there is no config imported to write (a problem with Modified detection)

- https://bugzilla.suse.com/show_bug.cgi?id=1170821

## Solution

Remove the addition of the section when it is not defined as the Network should not be removed anymore since keeping the installed network is the default option (see https://github.com/yast/yast-autoinstallation/pull/221)

## Test

- Added unit test
- Tested manually

## Screenshots

Using the same profile, with only a user to be added:

```xml
  <users config:type="list">
    <user>
      <username>yast</username>
      ...
    </user>
  </users>
```

And calling `yast2 ayast_setup setup filename=/tmp/network.xml`

| Before the fix  | After the fix  | 
|---|---|
| ![BeforeTheFix](https://user-images.githubusercontent.com/7056681/81164450-4a1d9b80-8f88-11ea-8c67-02f7101ac7ad.png) | ![AfterTheFix](https://user-images.githubusercontent.com/7056681/81164455-4be75f00-8f88-11ea-8699-9ba99fcb0352.png) |

The network_auto client is not called anymore if not defined explictly
