### PR TITLE
Move network configuration to the 1st stage by default

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri May 22 09:58:24 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- The network configuration is applied during the first stage by
+  default, removing the 'networking' and 'host' section in case
+  of defined and imported (bsc#1171922)
+- 4.3.4
+
+-------------------------------------------------------------------
 Thu May 21 13:51:22 UTC 2020 - David Díaz <dgonzalez@suse.com>
 
 - Revamp the storage client user interface, adapting it to the

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -2,8 +2,7 @@
 Fri May 22 09:58:24 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - The network configuration is applied during the first stage by
-  default, removing the 'networking' and 'host' section in case
-  of defined and imported (bsc#1171922)
+  default (bsc#1171922)
 - 4.3.4
 
 -------------------------------------------------------------------

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -128,21 +128,6 @@ module Yast
         Ops.get_string(d, "res", "")
       end)
 
-      # keep network on AutoYaST ugprade
-      if !Mode.autoupgrade
-        if !Builtins.haskey(Profile.current, "networking")
-          removeNetwork([]) # no networking section -> no network
-        elsif Ops.get_boolean(
-          Profile.current,
-          ["networking", "keep_install_network"],
-          true
-        ) == false
-          removeNetwork(
-            Ops.get_list(Profile.current, ["networking", "interfaces"], [])
-          ) # networking section without keeping the install network
-        end
-      end
-
       Builtins.foreach(@deps) do |r|
         p = Ops.get_string(r, "res", "")
         d = Ops.get_map(r, "data", {})
@@ -415,54 +400,6 @@ module Yast
       end
       Builtins.y2milestone("MatchInterface id:%1 ret:%2", id, ret)
       ret
-    end
-
-    def removeNetwork(ilist)
-      ilist = deep_copy(ilist)
-      Yast.import "NetworkInterfaces"
-      Builtins.y2milestone("removeNetwork ifaces:%1", ilist)
-      ilist = Builtins.maplist(ilist) do |i|
-        if Builtins.substring(Ops.get_string(i, "device", ""), 0, 7) == "eth-id-"
-          Ops.set(i, "device", MatchInterface(Ops.get_string(i, "device", "")))
-        end
-        deep_copy(i)
-      end
-      Builtins.y2milestone("removeNetwork ifaces:%1", ilist)
-      l = SCR.Read(path(".target.dir"), ["/etc/sysconfig/network", []])
-      netlist = []
-      Builtins.y2milestone("removeNetwork list:%1", l)
-      Builtins.foreach(
-        Convert.convert(l, from: "any", to: "list <string>")
-      ) do |s|
-        if Builtins.issubstring(s, "ifcfg-") &&
-            !Builtins.issubstring(s, "ifcfg-lo")
-          if Builtins.substring(s, 0, 6) == "ifcfg-" && s != "ifcfg-lo"
-            net = Builtins.substring(s, 6)
-            tmp = Builtins.filter(ilist) do |l2|
-              Ops.get_string(l2, "device", "") == net
-            end
-            if Builtins.isempty(tmp)
-              Builtins.y2milestone("removeNetwork net:%1", net)
-              NetworkInterfaces.Delete(net)
-              netlist = Builtins.add(netlist, net)
-              Builtins.y2milestone(
-                "removing installation network: /etc/sysconfig/network/%1",
-                s
-              )
-              SCR.Execute(
-                path(".target.remove"),
-                Builtins.sformat("/etc/sysconfig/network/%1", s)
-              )
-            end
-          end
-        end
-      end
-      Builtins.y2milestone("removeNetwork netlist:%1", netlist)
-      if !Builtins.isempty(netlist)
-        NetworkInterfaces.Commit
-        # NetworkInterfaces::Write( ".*" );
-      end
-      nil
     end
 
     def processWait(resource, stage)

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -202,7 +202,10 @@ module Yast
         AutoinstConfig.network_before_proposal = true
       end
 
-      Call.Function("lan_auto", ["Write"]) if AutoinstConfig.network_before_proposal
+      if AutoinstConfig.network_before_proposal
+        Call.Function("lan_auto", ["Write"])
+        Profile.remove_sections("networking") if Profile.current["networking"]
+      end
 
       if Builtins.haskey(Profile.current, "add-on")
         Progress.Title(_("Handling Add-On Products..."))

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -81,7 +81,6 @@ module Y2Autoinstallation
     def suse_register
       return true unless registration_module_available? # do nothing
 
-      general_section = Yast::Profile.current["general"] || {}
       # autoupgrade detects itself if system is registered and if needed do migration via scc
       if Yast::Profile.current[REGISTER_SECTION] || Yast::Mode.autoupgrade
         Yast::WFM.CallFunction(
@@ -98,10 +97,58 @@ module Y2Autoinstallation
 
         # failed relnotes download is not fatal, ignore ret code
         Yast::WFM.CallFunction("inst_download_release_notes")
-      elsif general_section["semi-automatic"]&.include?("scc")
+      elsif semi_auto?("scc")
         Yast::WFM.CallFunction("inst_scc", ["enable_next" => true])
       end
       true
+    end
+
+    # Convenience method to fetch the general profile section
+    #
+    # @return [Hash] the general section from the current profile when present;
+    #   an empty hash when not
+    def general_section
+      Yast::Profile.current["general"] || {}
+    end
+
+    # Convenienve method to check whether a particular client should be run to
+    # be configured manually during the autoinstallation according to the
+    # semi-automatic section
+    #
+    # @return [Boolean]
+    def semi_auto?(name)
+      !!general_section["semi-automatic"]&.include?(name)
+    end
+
+    # Autosetup the network
+    def autosetup_network
+      if Yast::Profile.current["networking"]
+        if Yast::Profile.current["networking"]["setup_before_proposal"]
+          log.info("Networking setup before the proposal")
+          Yast::AutoinstConfig.network_before_proposal = true
+        else
+          log.info("Networking setup at the end of first installation stage")
+        end
+
+        log.info("Importing Network settings from configuration file")
+        Yast::WFM.CallFunction("lan_auto", ["Import", Yast::Profile.current["networking"]])
+        Yast::Profile.remove_sections("networking")
+
+        # Import also the host section in order to resolve hosts only available
+        # with the network configuration and the host entry
+        if Yast::Profile.current["host"] && Yast::AutoinstConfig.network_before_proposal
+          Yast::WFM.CallFunction("host_auto", ["Import", Yast::Profile.current["host"]])
+          Yast::Profile.remove_sections("host")
+        end
+      end
+
+      if semi_auto?("networking")
+        log.info("Networking manual setup before proposal")
+        Yast::WFM.CallFunction("inst_lan", ["enable_next" => true])
+        Yast::AutoinstConfig.network_before_proposal = true
+      end
+
+      Yast::WFM.CallFunction("lan_auto", ["Write"]) if Yast::AutoinstConfig.network_before_proposal
     end
 
   private

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -76,6 +76,11 @@ module Y2Autoinstallation
 
         Yast::Progress.Finish
 
+        # TODO: In case that a specific network configuration is needed and
+        # defined in the profile, with the online media, this configuration
+        # will not be available. Maybe we should configure the network at this
+        # point
+
         # when installing from the online installation medium we need to
         # register the system earlier because the medium does not contain any
         # repositories, we need the repositories from the registration server

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -154,9 +154,6 @@ module Yast
       # Running autoyast second_stage
       @second_stage = true
 
-      # Network is configured during the first stage before the proposal
-      @network_before_proposal = false
-
       @OriginalURI = ""
 
       @message = ""
@@ -569,7 +566,6 @@ module Yast
     publish variable: :Confirm, type: "boolean"
     publish variable: :cio_ignore, type: "boolean"
     publish variable: :second_stage, type: "boolean"
-    publish variable: :network_before_proposal, type: "boolean"
     publish variable: :OriginalURI, type: "string"
     publish variable: :message, type: "string"
     publish variable: :dontmerge, type: "list <string>"

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -254,7 +254,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
 
         it "sets the network config to be written before the proposal" do
           expect { client.autosetup_network }
-            .to change { Yast::AutoinstConfig.network_before_proposal }
+            .to change { client.network_before_proposal? }
             .from(false).to(true)
         end
 
@@ -286,14 +286,16 @@ describe Y2Autoinstallation::AutosetupHelpers do
 
       it "sets the network config to be written before the proposal" do
         expect { client.autosetup_network }
-          .to change { Yast::AutoinstConfig.network_before_proposal }
+          .to change { client.network_before_proposal? }
           .from(false).to(true)
       end
     end
 
     context "in case it was definitely se to be configured before the proposal" do
+      before do
+        allow(client).to receive(:network_before_proposal?).and_return(true)
+      end
       it "writes the network configuration calling the auto client" do
-        Yast::AutoinstConfig.network_before_proposal = true
         expect(Yast::WFM).to receive(:CallFunction).with("lan_auto", ["Write"])
 
         client.autosetup_network


### PR DESCRIPTION
## Problem

Historically, AutoYaST has been divided in two stages, doing the installation during the first stage and the configuration during the second.

We have been moving some of the logic to the first stage, but it was still not the default and was only the default when there was no second stage defined.

- https://trello.com/c/s0QL7jvT/1840-8-move-network-configuration-to-1st-stage

## Solution

Consider the first stage as the default stage for configuring the network. That is, if the `networking` section is defined in the profile, it will be imported, merging it with the current network config (linuxrc) unless it is specified to not keep the current config (**keep_install_network** option is defined in the profile as **false**)

From here, there are different options that could happen:

1. Setup the network before the proposal
  The lan_auto client will be called for writing the config
2. Semiauto network configuration
  The inst_lan client will be called in order to configure the network
3. Write the network configuration at the end of the installation

While **1** and **2** steps occurs in `inst_autosetup`(https://github.com/yast/yast-autoinstallation/pull/606/files#diff-0100ef44fa49d992794bb1d6b470d681R168), step **3** is done by save_network client in yast2-network (https://github.com/yast/yast-network/blob/master/src/clients/save_network.rb)