### PR TITLE
[Storage UI] Fine tuning the interface

### DIFF
--- a/src/lib/autoinstall/presenters/partition.rb
+++ b/src/lib/autoinstall/presenters/partition.rb
@@ -83,6 +83,13 @@ module Y2Autoinstallation
         drive_presenter.type
       end
 
+      # Whether the section is an LVM Logical Volume
+      #
+      # @return [Boolean] true when belongs to an LVM drive; false otherwise
+      def logical_volume?
+        drive_type.to_sym == :CT_LVM
+      end
+
       # Values to suggest for bcache devices fields
       #
       # @return [Array<String>]

--- a/src/lib/autoinstall/storage_controller.rb
+++ b/src/lib/autoinstall/storage_controller.rb
@@ -65,6 +65,19 @@ module Y2Autoinstallation
       self.section = drive.partitions.last
     end
 
+    # Removes currently selected section
+    def delete_section
+      return unless section
+
+      if section.section_name == "drives"
+        drives.delete(section)
+        self.section = drives.first
+      else
+        section.parent.partitions.delete(section)
+        self.section = section.parent
+      end
+    end
+
     # It determines whether the profile was modified
     #
     # @todo Implement logic to detect whether the partitioning
@@ -80,14 +93,14 @@ module Y2Autoinstallation
       drives.map { |d| Presenters::Drive.new(d) }
     end
 
-  private
-
     # Drive sections inside the partitioning one
     #
     # @return [Array<Y2Storage::AutoinstProfile::DriveSection>]
     def drives
       partitioning.drives
     end
+
+  private
 
     # Drive section that is currently selected directly or indirectly (ie.
     # because one of its partition sections is selected)

--- a/src/lib/autoinstall/widgets/storage/delete_section_button.rb
+++ b/src/lib/autoinstall/widgets/storage/delete_section_button.rb
@@ -1,0 +1,54 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Button to remove the selected section
+      class DeleteSectionButton < CWM::PushButton
+        # Constructor
+        #
+        # @param controller [Y2Autoinstallation::StorageController] UI controller
+        def initialize(controller)
+          textdomain "autoinst"
+          @controller = controller
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Delete")
+        end
+
+        # @macro seeAbstractWidget
+        def handle
+          controller.delete_section
+          :redraw
+        end
+
+      private
+
+        # @return [Y2Autoinstallation::StorageController]
+        attr_reader :controller
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/disk_page.rb
+++ b/src/lib/autoinstall/widgets/storage/disk_page.rb
@@ -22,7 +22,7 @@ require "autoinstall/widgets/storage/drive_page"
 require "autoinstall/widgets/storage/disk_device"
 require "autoinstall/widgets/storage/init_drive"
 require "autoinstall/widgets/storage/disk_usage"
-require "autoinstall/widgets/storage/partition_table"
+require "autoinstall/widgets/storage/disklabel"
 
 module Y2Autoinstallation
   module Widgets
@@ -41,7 +41,7 @@ module Y2Autoinstallation
             HSquash(MinWidth(15, disk_device_widget)),
             init_drive_widget,
             disk_usage_widget,
-            partition_table_widget
+            disklabel_widget
           ]
         end
 
@@ -50,7 +50,7 @@ module Y2Autoinstallation
           disk_device_widget.value = drive.device
           init_drive_widget.value = !!drive.initialize_attr
           disk_usage_widget.value = drive.use
-          partition_table_widget.value = drive.disklabel
+          disklabel_widget.value = drive.disklabel
           set_disk_usage_status
         end
 
@@ -60,7 +60,7 @@ module Y2Autoinstallation
             "device"          => disk_device_widget.value,
             "initialize_attr" => init_drive_widget.value,
             "use"             => disk_usage_widget.value,
-            "disklabel"       => partition_table_widget.value
+            "disklabel"       => disklabel_widget.value
           }
         end
 
@@ -83,8 +83,8 @@ module Y2Autoinstallation
         end
 
         # Widget for setting the disk partition table
-        def partition_table_widget
-          @partition_table_widget ||= PartitionTable.new
+        def disklabel_widget
+          @disklabel_widget ||= Disklabel.new
         end
 
         # Widget for settings if disk should be initialize

--- a/src/lib/autoinstall/widgets/storage/disklabel.rb
+++ b/src/lib/autoinstall/widgets/storage/disklabel.rb
@@ -27,7 +27,7 @@ module Y2Autoinstallation
       # Widget to set the type of partition table to use
       #
       # It corresponds to the `disklabel` element in the profile.
-      class PartitionTable < CWM::ComboBox
+      class Disklabel < CWM::ComboBox
         # Constructor
         def initialize
           textdomain "autoinst"
@@ -36,7 +36,7 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def label
-          _("Partition Table")
+          _("Disklabel")
         end
 
         # We are only interested in these types.

--- a/src/lib/autoinstall/widgets/storage/not_lvm_partition_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/not_lvm_partition_attrs.rb
@@ -52,7 +52,7 @@ module Y2Autoinstallation
               HBox(
                 HSquash(MinWidth(15, partition_id_widget)),
                 HSpacing(2),
-                HSquash(MinWidth(15, partition_type_widget))
+                partition_type_widget
               )
             )
           )

--- a/src/lib/autoinstall/widgets/storage/not_lvm_partition_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/not_lvm_partition_attrs.rb
@@ -1,0 +1,94 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/custom_widget"
+require "autoinstall/widgets/storage/partition_id"
+require "autoinstall/widgets/storage/partition_type"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Not LVM partitions specific widgets
+      #
+      # It holds widgets managing specific attributes for a partition not related to a CT_LVM drive.
+      #
+      # @see PartitionGeneralTab
+      class NotLvmPartitionAttrs < CWM::CustomWidget
+        # Constructor
+        #
+        # @param section [Presenters::Partition] presenter for the partition section
+        def initialize(section)
+          textdomain "autoinst"
+          super()
+          @section = section
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          ""
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          VBox(
+            Left(
+              HBox(
+                HSquash(MinWidth(15, partition_id_widget)),
+                HSpacing(2),
+                HSquash(MinWidth(15, partition_type_widget))
+              )
+            )
+          )
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          partition_id_widget.value   = section.partition_id
+          partition_type_widget.value = section.partition_type
+        end
+
+        # Returns the widgets values
+        #
+        # @return [Hash<String,Object>]
+        def values
+          {
+            "partition_id"   => partition_id_widget.value,
+            "partition_type" => partition_type_widget.value
+          }
+        end
+
+      private
+
+        # @return [Presenters::Partition] presenter for the partition section
+        attr_reader :section
+
+        # Widget for setting the partition id
+        def partition_id_widget
+          @partition_id_widget ||= PartitionId.new
+        end
+
+        # Widget for setting the partition type
+        def partition_type_widget
+          @partition_type_widget ||= PartitionType.new
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
+++ b/src/lib/autoinstall/widgets/storage/overview_tree_pager.rb
@@ -28,6 +28,7 @@ require "autoinstall/widgets/storage/btrfs_page"
 require "autoinstall/widgets/storage/partition_page"
 require "autoinstall/widgets/storage/add_drive_button"
 require "autoinstall/widgets/storage/add_partition_button"
+require "autoinstall/widgets/storage/delete_section_button"
 require "autoinstall/ui_state"
 
 module Y2Autoinstallation
@@ -50,7 +51,8 @@ module Y2Autoinstallation
             Left(
               HBox(
                 AddDriveButton.new(controller),
-                AddPartitionButton.new(controller)
+                AddPartitionButton.new(controller),
+                delete_button
               )
             )
           )
@@ -61,6 +63,13 @@ module Y2Autoinstallation
           controller.drive_presenters.each_with_object([]) do |drive, all|
             all << drive_item(drive)
           end
+        end
+
+        # Extends the events management to control the DeleteSectionButton status
+        def handle(event)
+          super
+          set_delete_button_status
+          nil
         end
 
         # Switch to the given page
@@ -89,6 +98,27 @@ module Y2Autoinstallation
 
         def tree
           @tree ||= OverviewTree.new(items)
+        end
+
+        # Widget for removing currently selected section
+        #
+        # @return [DeleteSectionButton]
+        def delete_button
+          @delete_button ||= DeleteSectionButton.new(controller)
+        end
+
+        # Changes the #delete_button status according to selected section
+        def set_delete_button_status
+          if drive_selected? && controller.drives.size == 1
+            delete_button.disable
+          else
+            delete_button.enable
+          end
+        end
+
+        # Whether selected section is a Y2Storage::AutoinstProfileDriveSection
+        def drive_selected?
+          controller.section.is_a?(Y2Storage::AutoinstProfile::DriveSection)
         end
 
         def controller_page

--- a/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
@@ -23,6 +23,7 @@ require "cwm/replace_point"
 require "cwm/common_widgets"
 require "autoinstall/widgets/storage/common_partition_attrs"
 require "autoinstall/widgets/storage/lvm_partition_attrs"
+require "autoinstall/widgets/storage/encryption_attrs"
 
 module Y2Autoinstallation
   module Widgets
@@ -52,6 +53,8 @@ module Y2Autoinstallation
               common_partition_attrs,
               VSpacing(0.5),
               section_related_attrs,
+              VSpacing(0.5),
+              encryption_attrs,
               VStretch()
             )
           )
@@ -81,11 +84,12 @@ module Y2Autoinstallation
         def relevant_widgets
           [
             common_partition_attrs,
-            lvm_partition_attrs
+            lvm_partition_attrs,
+            encryption_attrs
           ]
         end
 
-        # Convenience method to call proper widget depending on the drive type
+        # Convenience method to display attributes related to the drive type
         def section_related_attrs
           method_name = "#{partition.drive_type}_partition_attrs".downcase
 
@@ -106,6 +110,11 @@ module Y2Autoinstallation
         # @return [LvmPartitionAttrs]
         def lvm_partition_attrs
           @lvm_partition_attrs ||= LvmPartitionAttrs.new(partition)
+        end
+
+        # Options for setting attributes related to encryption
+        def encryption_attrs
+          @encryption_attrs ||= EncryptionAttrs.new(partition)
         end
       end
     end

--- a/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
@@ -21,6 +21,7 @@ require "yast"
 require "cwm/tabs"
 require "cwm/replace_point"
 require "cwm/common_widgets"
+require "autoinstall/widgets/storage/partition_tab"
 require "autoinstall/widgets/storage/common_partition_attrs"
 require "autoinstall/widgets/storage/lvm_partition_attrs"
 require "autoinstall/widgets/storage/not_lvm_partition_attrs"
@@ -30,59 +31,24 @@ module Y2Autoinstallation
   module Widgets
     module Storage
       # The tab used to present the general and common options for a partition section
-      class PartitionGeneralTab < ::CWM::Tab
-        # Constructor
-        #
-        # @param partition [Presenters::Partition] presenter for a partition section of the profile
-        def initialize(partition)
-          textdomain "autoinst"
-
-          @partition = partition
-        end
-
+      class PartitionGeneralTab < PartitionTab
         # @macro seeAbstractWidget
         def label
           # TRANSLATORS: name of the tab to display common options
           _("General")
         end
 
-        def contents
-          MarginBox(
-            0.4,
-            0.4,
-            VBox(
-              common_partition_attrs,
-              VSpacing(0.5),
-              section_related_attrs,
-              VSpacing(0.5),
-              encryption_attrs,
-              VStretch()
-            )
-          )
+        # @see PartitionTab#visible_widgets
+        def visible_widgets
+          [
+            common_partition_attrs,
+            section_related_attrs,
+            encryption_attrs
+          ]
         end
 
-        # @macro seeAbstractWidget
-        def values
-          relevant_widgets.reduce({}) do |hsh, widget|
-            hsh.merge(widget.values)
-          end
-        end
-
-        # @macro seeAbstractWidget
-        def store
-          partition.update(values)
-          nil
-        end
-
-      private
-
-        # @return [Presenters::Partition] presenter for the partition section
-        attr_reader :partition
-
-        # Convenience method to retrieve all widgets holding profile attributes
-        #
-        # @return [Array<CWW::CustomWidget>]
-        def relevant_widgets
+        # @see PartitionTab#widgets
+        def widgets
           [
             common_partition_attrs,
             lvm_partition_attrs,
@@ -90,6 +56,8 @@ module Y2Autoinstallation
             encryption_attrs
           ]
         end
+
+      private
 
         # Convenience method to display attributes related to the drive type
         def section_related_attrs

--- a/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
@@ -32,6 +32,14 @@ module Y2Autoinstallation
     module Storage
       # The tab used to present the general and common options for a partition section
       class PartitionGeneralTab < PartitionTab
+        # Constructor
+        #
+        # @param partition [Presenters::Partition] presenter for a partition section of the profile
+        def initialize(partition)
+          textdomain "autoinst"
+          super
+        end
+
         # @macro seeAbstractWidget
         def label
           # TRANSLATORS: name of the tab to display common options

--- a/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_general_tab.rb
@@ -23,6 +23,7 @@ require "cwm/replace_point"
 require "cwm/common_widgets"
 require "autoinstall/widgets/storage/common_partition_attrs"
 require "autoinstall/widgets/storage/lvm_partition_attrs"
+require "autoinstall/widgets/storage/not_lvm_partition_attrs"
 require "autoinstall/widgets/storage/encryption_attrs"
 
 module Y2Autoinstallation
@@ -85,17 +86,18 @@ module Y2Autoinstallation
           [
             common_partition_attrs,
             lvm_partition_attrs,
+            not_lvm_partition_attrs,
             encryption_attrs
           ]
         end
 
         # Convenience method to display attributes related to the drive type
         def section_related_attrs
-          method_name = "#{partition.drive_type}_partition_attrs".downcase
-
-          send(method_name)
-        rescue NoMethodError
-          Empty()
+          if partition.logical_volume?
+            lvm_partition_attrs
+          else
+            not_lvm_partition_attrs
+          end
         end
 
         # Options for a all partitions
@@ -110,6 +112,13 @@ module Y2Autoinstallation
         # @return [LvmPartitionAttrs]
         def lvm_partition_attrs
           @lvm_partition_attrs ||= LvmPartitionAttrs.new(partition)
+        end
+
+        # Options for a partition not related to an LVM drive section
+        #
+        # @return [LvmPartitionAttrs]
+        def not_lvm_partition_attrs
+          @not_lvm_partition_attrs ||= NotLvmPartitionAttrs.new(partition)
         end
 
         # Options for setting attributes related to encryption

--- a/src/lib/autoinstall/widgets/storage/partition_id.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_id.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Determines the partition id
+      class PartitionId < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Partition Id")
+        end
+
+        # @macro seeComboBox
+        def items
+          @items ||= [
+            ["", ""],
+            ["130", "130"], # Swap
+            ["131", "131"], # Linux
+            ["142", "142"], # LVM
+            ["253", "253"], # MD RAID
+            ["259", "259"]  # EFI Partition
+          ]
+        end
+
+        # Returns partition id
+        #
+        # @return [String, Integer]
+        def value
+          partition_id = super
+
+          partition_id.to_s.empty? ? partition_id : partition_id.to_i
+        end
+
+        # @macro seeComboBox
+        def value=(id)
+          super(id.to_s)
+        end
+
+        # @macro seeAbstractWidget
+        def opt
+          [:editable]
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/partition_id.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_id.rb
@@ -45,7 +45,8 @@ module Y2Autoinstallation
             ["131", "131"], # Linux
             ["142", "142"], # LVM
             ["253", "253"], # MD RAID
-            ["259", "259"]  # EFI Partition
+            ["259", "259"], # EFI Partition
+            ["263", "263"]  # Bios Boot
           ]
         end
 

--- a/src/lib/autoinstall/widgets/storage/partition_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_tab.rb
@@ -1,0 +1,90 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/tabs"
+require "cwm/replace_point"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Base class to create tabs for organizing the partition section attributes
+      class PartitionTab < ::CWM::Tab
+        # Constructor
+        #
+        # @param partition [Presenters::Partition] presenter for a partition section of the profile
+        def initialize(partition)
+          textdomain "autoinst"
+
+          @partition = partition
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          ""
+        end
+
+        def contents
+          MarginBox(
+            0.4,
+            0.4,
+            VBox(
+              *visible_widgets.flat_map { |widget| [Left(widget), VSpacing(0.5)] }.tap(&:pop),
+              VStretch()
+            )
+          )
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          attrs = widgets.reduce({}) { |result, widget| result.merge(widget.values) }
+          partition.update(attrs)
+          nil
+        end
+
+        # Return widgets to be shown
+        #
+        # This method must be defined by derived tabs
+        #
+        # @return [Array<Yast::Term, CWM::AbstractWidget]
+        def visible_widgets
+          []
+        end
+
+        # Returns all widgets managed by the tab
+        #
+        # This method must be defined by derived tabs since it is needed by the #store method to
+        # properly update the partition section setting only relevant attributes.
+        #
+        # @see Presenters::Section#update
+        #
+        # @return [Array<Yast::Term, CWM::AbstractWidget]
+        def widgets
+          []
+        end
+
+      private
+
+        # @return [Presenters::Partition] presenter for the partition section
+        attr_reader :partition
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/partition_type.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_type.rb
@@ -1,0 +1,56 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+require "cwm/common_widgets"
+
+module Y2Autoinstallation
+  module Widgets
+    module Storage
+      # Determines the partition id
+      class PartitionType < CWM::ComboBox
+        # Constructor
+        def initialize
+          textdomain "autoinst"
+          super
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Partition Type")
+        end
+
+        # @macro seeComboBox
+        def items
+          @items ||= [
+            ["", ""],
+            ["primary", "primary"],
+            ["logical", "logical"]
+          ]
+        end
+
+        # @macro seeAbstractWidget
+        def opt
+          [:editable]
+        end
+      end
+    end
+  end
+end

--- a/src/lib/autoinstall/widgets/storage/partition_type.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_type.rb
@@ -45,11 +45,6 @@ module Y2Autoinstallation
             ["logical", "logical"]
           ]
         end
-
-        # @macro seeAbstractWidget
-        def opt
-          [:editable]
-        end
       end
     end
   end

--- a/src/lib/autoinstall/widgets/storage/partition_usage_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_usage_tab.rb
@@ -21,6 +21,7 @@ require "yast"
 require "cwm/tabs"
 require "cwm/replace_point"
 require "cwm/common_widgets"
+require "autoinstall/widgets/storage/partition_tab"
 require "autoinstall/widgets/storage/filesystem_attrs"
 require "autoinstall/widgets/storage/raid_attrs"
 require "autoinstall/widgets/storage/lvm_pv_attrs"
@@ -33,14 +34,12 @@ module Y2Autoinstallation
     module Storage
       # Tab to manage the partition section options that depend on its usage (file system, LVM PV,
       # RAID member, etc).
-      class PartitionUsageTab < ::CWM::Tab
+      class PartitionUsageTab < PartitionTab
         # Constructor
         #
         # @param partition [Presenters::Partition] presenter for a partition section of the profile
         def initialize(partition)
-          textdomain "autoinst"
-
-          @partition = partition
+          super
           self.handle_all_events = true
         end
 
@@ -48,19 +47,6 @@ module Y2Autoinstallation
         def label
           # TRANSLATORS: name of the tab to display the partition section options based on its usage
           _("Used As")
-        end
-
-        def contents
-          MarginBox(
-            0.4,
-            0.4,
-            VBox(
-              Left(used_as_widget),
-              VSpacing(0.5),
-              replace_point,
-              VStretch()
-            )
-          )
         end
 
         # @macro seeAbstractWidget
@@ -76,28 +62,16 @@ module Y2Autoinstallation
           nil
         end
 
-        # @macro seeAbstractWidget
-        def values
-          relevant_widgets.reduce({}) do |hsh, widget|
-            hsh.merge(widget.values)
-          end
+        # @see PartitionTab#visible_widgets
+        def visible_widgets
+          [
+            Left(used_as_widget),
+            replace_point
+          ]
         end
 
-        # @macro seeAbstractWidget
-        def store
-          partition.update(values)
-          nil
-        end
-
-      private
-
-        # @return [Presenters::Partition] presenter for the partition section
-        attr_reader :partition
-
-        # Convenience method to retrieve all widgets holding profile attributes
-        #
-        # @return [Array<CWW::CustomWidget>]
-        def relevant_widgets
+        # @see PartitionTab#widgets
+        def widgets
           [
             filesystem_widget,
             raid_widget,
@@ -106,6 +80,8 @@ module Y2Autoinstallation
             btrfs_member_widget
           ]
         end
+
+      private
 
         # Widget grouping related file system attributes
         def filesystem_widget

--- a/src/lib/autoinstall/widgets/storage/partition_usage_tab.rb
+++ b/src/lib/autoinstall/widgets/storage/partition_usage_tab.rb
@@ -39,6 +39,7 @@ module Y2Autoinstallation
         #
         # @param partition [Presenters::Partition] presenter for a partition section of the profile
         def initialize(partition)
+          textdomain "autoinst"
           super
           self.handle_all_events = true
         end

--- a/src/lib/autoinstall/widgets/storage/uuid.rb
+++ b/src/lib/autoinstall/widgets/storage/uuid.rb
@@ -34,7 +34,7 @@ module Y2Autoinstallation
 
         # @macro seeAbstractWidget
         def label
-          _("Partition UUID")
+          _("UUID")
         end
       end
     end

--- a/test/lib/presenters/partition_test.rb
+++ b/test/lib/presenters/partition_test.rb
@@ -128,6 +128,24 @@ describe Y2Autoinstallation::Presenters::Partition do
     end
   end
 
+  describe "#logical_volume?" do
+    context "when the partition belongs to a :CT_LVM drive section" do
+      let(:part_hashes) { [{ "type" => :CT_LVM }] }
+
+      it "returns true" do
+        expect(subject.logical_volume?).to eq(true)
+      end
+    end
+
+    context "when the partition does not belong to a :CT_LVM drive section" do
+      let(:part_hashes) { [{ "type" => :CT_BCACHE }] }
+
+      it "returns false" do
+        expect(subject.logical_volume?).to eq(false)
+      end
+    end
+  end
+
   describe "#available_lvm_groups" do
     context "when there are no LVM drive sections" do
       it "returns an empty collection" do

--- a/test/lib/storage_controller_test.rb
+++ b/test/lib/storage_controller_test.rb
@@ -37,4 +37,54 @@ describe Y2Autoinstallation::StorageController do
       expect(new_drive.type).to eq(:CT_DISK)
     end
   end
+
+  describe "#delete_section" do
+    let(:partitioning) do
+      Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+        [
+          { "type" => :CT_DISK, "partitions" => [{ "create" => true }] },
+          { "type" => :CT_DISK, "partitions" => [{ "create" => false, "size" => "1 TiB" }] },
+          { "type" => :CT_RAID, "partitions" => [{ "create" => true }, { "create" => false }] },
+          { "type" => :CT_DISK, "partitions" => [{ "create" => true }] }
+        ]
+      )
+    end
+    let(:part_hash) do
+    end
+
+    let(:drive) { partitioning.drives[2] }
+    let(:first_partition) { drive.partitions.first }
+
+    context "when deleting a partition section" do
+      it "removes selected section" do
+        subject.section = first_partition
+        subject.delete_section
+
+        expect(drive.partitions).to_not include(first_partition)
+      end
+
+      it "sets its parent drive section as selected" do
+        subject.section = first_partition
+        subject.delete_section
+
+        expect(subject.section).to eq(drive)
+      end
+    end
+
+    context "when deleting a drive section" do
+      it "removes selected section" do
+        subject.section = drive
+        subject.delete_section
+
+        expect(subject.drives).to_not include(drive)
+      end
+
+      it "sets the first drive section as selected" do
+        subject.section = drive
+        subject.delete_section
+
+        expect(subject.section).to eq(subject.drives.first)
+      end
+    end
+  end
 end

--- a/test/lib/widgets/storage/delete_section_button_test.rb
+++ b/test/lib/widgets/storage/delete_section_button_test.rb
@@ -1,0 +1,34 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/delete_section_button"
+require "autoinstall/storage_controller"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::DeleteSectionButton do
+  subject { described_class.new(controller) }
+
+  let(:controller) { Y2Autoinstallation::StorageController.new(partitioning) }
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes([])
+  end
+
+  include_examples "CWM::PushButton"
+end

--- a/test/lib/widgets/storage/disk_page_test.rb
+++ b/test/lib/widgets/storage/disk_page_test.rb
@@ -56,7 +56,7 @@ describe Y2Autoinstallation::Widgets::Storage::DiskPage do
     )
   end
 
-  let(:partition_table_widget) do
+  let(:disklabel_widget) do
     instance_double(
       Y2Autoinstallation::Widgets::Storage::DiskUsage,
       value: "gpt"
@@ -70,8 +70,8 @@ describe Y2Autoinstallation::Widgets::Storage::DiskPage do
       .to receive(:new).and_return(init_drive_widget)
     allow(Y2Autoinstallation::Widgets::Storage::DiskUsage)
       .to receive(:new).and_return(disk_usage_widget)
-    allow(Y2Autoinstallation::Widgets::Storage::PartitionTable)
-      .to receive(:new).and_return(partition_table_widget)
+    allow(Y2Autoinstallation::Widgets::Storage::Disklabel)
+      .to receive(:new).and_return(disklabel_widget)
   end
 
   include_examples "CWM::Page"

--- a/test/lib/widgets/storage/disklabel_test.rb
+++ b/test/lib/widgets/storage/disklabel_test.rb
@@ -18,11 +18,31 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
-require "autoinstall/widgets/storage/partition_table"
+require "autoinstall/widgets/storage/disklabel"
 require "cwm/rspec"
 
-describe Y2Autoinstallation::Widgets::Storage::PartitionTable do
-  subject { described_class.new }
+describe Y2Autoinstallation::Widgets::Storage::Disklabel do
+  subject(:disklabel_widget) { described_class.new }
 
   include_examples "CWM::ComboBox"
+
+  describe "#items" do
+    let(:items) { disklabel_widget.items.map { |i| i[0] } }
+
+    it "includes 'none'" do
+      expect(items).to include("none")
+    end
+
+    it "includes 'msdos'" do
+      expect(items).to include("msdos")
+    end
+
+    it "includes 'gpt'" do
+      expect(items).to include("gpt")
+    end
+
+    it "includes 'dasd'" do
+      expect(items).to include("dasd")
+    end
+  end
 end

--- a/test/lib/widgets/storage/overview_tree_pager_test.rb
+++ b/test/lib/widgets/storage/overview_tree_pager_test.rb
@@ -61,4 +61,58 @@ describe Y2Autoinstallation::Widgets::Storage::OverviewTreePager do
       end
     end
   end
+
+  describe "#handle" do
+    let(:delete_button) do
+      instance_double(Y2Autoinstallation::Widgets::Storage::DeleteSectionButton)
+    end
+
+    let(:event) { { "ID" => :whatever } }
+    let(:drive) { partitioning.drives.first }
+
+    before do
+      allow(Y2Autoinstallation::Widgets::Storage::DeleteSectionButton).to receive(:new)
+        .and_return(delete_button)
+    end
+
+    context "when there are more than one drive section" do
+      it "enables the deletion button" do
+        expect(delete_button).to receive(:enable)
+
+        subject.handle(event)
+      end
+    end
+
+    context "when there is only one drive" do
+      let(:attrs) do
+        [
+          { "type" => :CT_DISK, "device" => "/dev/sda", "partitions" => [{ "mount" => "/" }] }
+        ]
+      end
+
+      context "and it is selected" do
+        before do
+          controller.section = drive
+        end
+
+        it "disables the deletion button" do
+          expect(delete_button).to receive(:disable)
+
+          subject.handle(event)
+        end
+      end
+
+      context "but a partition is selected" do
+        before do
+          controller.section = drive.partitions.first
+        end
+
+        it "enables the deletion button" do
+          expect(delete_button).to receive(:enable)
+
+          subject.handle(event)
+        end
+      end
+    end
+  end
 end

--- a/test/lib/widgets/storage/partition_general_tab_test.rb
+++ b/test/lib/widgets/storage/partition_general_tab_test.rb
@@ -49,6 +49,13 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
     }
   end
 
+  let(:not_lv_attributes) do
+    {
+      "partition_id"   => 131,
+      "partition_type" => "primary"
+    }
+  end
+
   let(:lv_attributes) do
     {
       "lv_name"     => "lv-home",
@@ -58,6 +65,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
       "stripe_size" => 4
     }
   end
+
   let(:encryption_attributes) do
     {
       "crypt_method" => :luks1,
@@ -84,6 +92,14 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
 
     context "when the partition belongs to a disk" do
       let(:type) { :CT_DISK }
+
+      it "contains not LVM attributes" do
+        widget = subject.contents.nested_find do |w|
+          w.is_a?(Y2Autoinstallation::Widgets::Storage::NotLvmPartitionAttrs)
+        end
+
+        expect(widget).to_not be_nil
+      end
 
       it "does not contain LVM partition attributes" do
         widget = subject.contents.nested_find do |w|
@@ -114,6 +130,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
       values = subject.values
 
       expect(values.keys).to include(*common_attributes.keys)
+      expect(values.keys).to include(*not_lv_attributes.keys)
       expect(values.keys).to include(*lv_attributes.keys)
       expect(values.keys).to include(*encryption_attributes.keys)
     end
@@ -124,6 +141,12 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
       instance_double(
         Y2Autoinstallation::Widgets::Storage::CommonPartitionAttrs,
         values: common_attributes
+      )
+    end
+    let(:not_lvm_attrs_widget) do
+      instance_double(
+        Y2Autoinstallation::Widgets::Storage::NotLvmPartitionAttrs,
+        values: not_lv_attributes
       )
     end
     let(:lvm_attrs_widget) do
@@ -144,6 +167,8 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
         .and_return(common_attrs_widget)
       allow(Y2Autoinstallation::Widgets::Storage::LvmPartitionAttrs).to receive(:new)
         .and_return(lvm_attrs_widget)
+      allow(Y2Autoinstallation::Widgets::Storage::NotLvmPartitionAttrs).to receive(:new)
+        .and_return(not_lvm_attrs_widget)
       allow(Y2Autoinstallation::Widgets::Storage::EncryptionAttrs).to receive(:new)
         .and_return(encryption_attrs_widget)
     end
@@ -157,6 +182,9 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
       expect(partition.size).to eq("10G")
       expect(partition.partition_nr).to eq(2)
       expect(partition.uuid).to eq("partition-uuid")
+
+      expect(partition.partition_id).to eq(131)
+      expect(partition.partition_type).to eq("primary")
 
       expect(partition.lv_name).to eq("lv-home")
       expect(partition.pool).to eq(false)

--- a/test/lib/widgets/storage/partition_general_tab_test.rb
+++ b/test/lib/widgets/storage/partition_general_tab_test.rb
@@ -18,15 +18,13 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
+require_relative "./shared_examples"
 require "autoinstall/widgets/storage/partition_general_tab"
 require "autoinstall/presenters"
 require "y2storage/autoinst_profile"
-require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
   subject { described_class.new(partition) }
-
-  include_examples "CWM::Page"
 
   let(:partitioning) do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
@@ -38,40 +36,7 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
   let(:partition) { drive.partitions.first }
   let(:partition_hash) { {} }
 
-  let(:common_attributes) do
-    {
-      "create"       => true,
-      "format"       => true,
-      "resize"       => false,
-      "size"         => "10G",
-      "partition_nr" => 2,
-      "uuid"         => "partition-uuid"
-    }
-  end
-
-  let(:not_lv_attributes) do
-    {
-      "partition_id"   => 131,
-      "partition_type" => "primary"
-    }
-  end
-
-  let(:lv_attributes) do
-    {
-      "lv_name"     => "lv-home",
-      "pool"        => false,
-      "used_pool"   => "my_thin_pool",
-      "stripes"     => 2,
-      "stripe_size" => 4
-    }
-  end
-
-  let(:encryption_attributes) do
-    {
-      "crypt_method" => :luks1,
-      "crypt_key"    => "xxxxx"
-    }
-  end
+  include_examples "Y2Autoinstallation::Widgets::Storage::PartitionTab"
 
   describe "#contents" do
     it "contains common partition attributes" do
@@ -123,77 +88,29 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionGeneralTab do
     end
   end
 
-  describe "#values" do
-    let(:type) { :CT_DISK }
-
-    it "contains attributes not related to its usage" do
-      values = subject.values
-
-      expect(values.keys).to include(*common_attributes.keys)
-      expect(values.keys).to include(*not_lv_attributes.keys)
-      expect(values.keys).to include(*lv_attributes.keys)
-      expect(values.keys).to include(*encryption_attributes.keys)
-    end
-  end
-
   describe "#store" do
-    let(:common_attrs_widget) do
-      instance_double(
-        Y2Autoinstallation::Widgets::Storage::CommonPartitionAttrs,
-        values: common_attributes
-      )
-    end
-    let(:not_lvm_attrs_widget) do
-      instance_double(
-        Y2Autoinstallation::Widgets::Storage::NotLvmPartitionAttrs,
-        values: not_lv_attributes
-      )
-    end
-    let(:lvm_attrs_widget) do
-      instance_double(
-        Y2Autoinstallation::Widgets::Storage::LvmPartitionAttrs,
-        values: lv_attributes
-      )
-    end
-    let(:encryption_attrs_widget) do
-      instance_double(
-        Y2Autoinstallation::Widgets::Storage::EncryptionAttrs,
-        values: encryption_attributes
-      )
-    end
-
-    before do
-      allow(Y2Autoinstallation::Widgets::Storage::CommonPartitionAttrs).to receive(:new)
-        .and_return(common_attrs_widget)
-      allow(Y2Autoinstallation::Widgets::Storage::LvmPartitionAttrs).to receive(:new)
-        .and_return(lvm_attrs_widget)
-      allow(Y2Autoinstallation::Widgets::Storage::NotLvmPartitionAttrs).to receive(:new)
-        .and_return(not_lvm_attrs_widget)
-      allow(Y2Autoinstallation::Widgets::Storage::EncryptionAttrs).to receive(:new)
-        .and_return(encryption_attrs_widget)
-    end
-
     it "sets section attributes not related to its usage" do
+      expect(partition).to receive(:update).with(
+        hash_including(
+          "create",
+          "format",
+          "resize",
+          "size",
+          "partition_nr",
+          "uuid",
+          "partition_id",
+          "partition_type",
+          "lv_name",
+          "pool",
+          "used_pool",
+          "stripes",
+          "stripe_size",
+          "crypt_method",
+          "crypt_key"
+        )
+      )
+
       subject.store
-
-      expect(partition.create).to eq(true)
-      expect(partition.format).to eq(true)
-      expect(partition.resize).to eq(false)
-      expect(partition.size).to eq("10G")
-      expect(partition.partition_nr).to eq(2)
-      expect(partition.uuid).to eq("partition-uuid")
-
-      expect(partition.partition_id).to eq(131)
-      expect(partition.partition_type).to eq("primary")
-
-      expect(partition.lv_name).to eq("lv-home")
-      expect(partition.pool).to eq(false)
-      expect(partition.used_pool).to eq("my_thin_pool")
-      expect(partition.stripes).to eq(2)
-      expect(partition.stripe_size).to eq(4)
-
-      expect(partition.crypt_method).to eq(:luks1)
-      expect(partition.crypt_key).to eq("xxxxx")
     end
   end
 end

--- a/test/lib/widgets/storage/partition_id_test.rb
+++ b/test/lib/widgets/storage/partition_id_test.rb
@@ -26,6 +26,34 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionId do
 
   include_examples "CWM::ComboBox"
 
+  describe "#items" do
+    let(:partition_ids) { widget.items.map { |i| i[0].to_i } }
+
+    it "includes the swap partition id (130)" do
+      expect(partition_ids).to include(130)
+    end
+
+    it "includes the Linux partition id (131)" do
+      expect(partition_ids).to include(131)
+    end
+
+    it "includes the LVM partition id (142)" do
+      expect(partition_ids).to include(142)
+    end
+
+    it "includes the MD RAID partition id (253)" do
+      expect(partition_ids).to include(142)
+    end
+
+    it "includes the EFI partition id (259)" do
+      expect(partition_ids).to include(142)
+    end
+
+    it "includes the BIOS_BOOT partition id (263)" do
+      expect(partition_ids).to include(142)
+    end
+  end
+
   describe "#value" do
     before do
       allow(Yast::UI).to receive(:QueryWidget).with(Id(widget.widget_id), :Value)

--- a/test/lib/widgets/storage/partition_id_test.rb
+++ b/test/lib/widgets/storage/partition_id_test.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/partition_id"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::PartitionId do
+  subject(:widget) { described_class.new }
+
+  include_examples "CWM::ComboBox"
+
+  describe "#value" do
+    before do
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(widget.widget_id), :Value)
+        .and_return(value)
+    end
+
+    describe "when nothing is given or selected" do
+      let(:value) { "" }
+
+      it "returns empty" do
+        expect(widget.value).to be_empty
+      end
+    end
+
+    describe "when a value is given or selected" do
+      let(:value) { "256" }
+
+      it "returns its integer representation" do
+        expect(widget.value).to eq(256)
+      end
+    end
+  end
+end

--- a/test/lib/widgets/storage/partition_tab_test.rb
+++ b/test/lib/widgets/storage/partition_tab_test.rb
@@ -1,0 +1,38 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require_relative "./shared_examples"
+require "autoinstall/widgets/storage/partition_tab"
+require "autoinstall/presenters"
+require "y2storage/autoinst_profile"
+
+describe Y2Autoinstallation::Widgets::Storage::PartitionTab do
+  subject { described_class.new(partition) }
+
+  let(:partitioning) do
+    Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+      [{ "type" => :CT_DISK, "partitions" => [{ "create" => true }] }]
+    )
+  end
+  let(:drive) { Y2Autoinstallation::Presenters::Drive.new(partitioning.drives.first) }
+  let(:partition) { drive.partitions.first }
+
+  include_examples "Y2Autoinstallation::Widgets::Storage::PartitionTab"
+end

--- a/test/lib/widgets/storage/partition_type_test.rb
+++ b/test/lib/widgets/storage/partition_type_test.rb
@@ -1,0 +1,44 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "autoinstall/widgets/storage/partition_type"
+require "cwm/rspec"
+
+describe Y2Autoinstallation::Widgets::Storage::PartitionType do
+  subject(:widget) { described_class.new }
+
+  include_examples "CWM::ComboBox"
+
+  describe "#items" do
+    let(:items) { widget.items.map { |i| i[0] } }
+
+    it "includes an empty item" do
+      expect(items).to include("")
+    end
+
+    it "includes 'primary'" do
+      expect(items).to include("primary")
+    end
+
+    it "includes 'logical'" do
+      expect(items).to include("primary")
+    end
+  end
+end

--- a/test/lib/widgets/storage/partition_usage_tab_test.rb
+++ b/test/lib/widgets/storage/partition_usage_tab_test.rb
@@ -18,15 +18,13 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
+require_relative "./shared_examples"
 require "autoinstall/widgets/storage/partition_usage_tab"
 require "autoinstall/presenters"
 require "y2storage/autoinst_profile"
-require "cwm/rspec"
 
 describe Y2Autoinstallation::Widgets::Storage::PartitionUsageTab do
   subject { described_class.new(partition) }
-
-  include_examples "CWM::Page"
 
   let(:partitioning) do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
@@ -43,6 +41,8 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionUsageTab do
   let(:used_as_widget) do
     instance_double(Y2Autoinstallation::Widgets::Storage::UsedAs)
   end
+
+  include_examples "Y2Autoinstallation::Widgets::Storage::PartitionTab"
 
   describe "#init" do
     before do
@@ -143,57 +143,25 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionUsageTab do
     end
   end
 
-  describe "#values" do
-    it "contains all section attributes related to its usage" do
-      expect(subject.values.keys).to contain_exactly(
-        "filesystem",
-        "fstab_options",
-        "label",
-        "lvm_group",
-        "mkfs_options",
-        "mount",
-        "mountby",
-        "raid_name",
-        "bcache_backing_for",
-        "btrfs_name",
-        "create_subvolumes"
-      )
-    end
-  end
-
   describe "#store" do
-    let(:filesystem_attrs) do
-      {
-        "filesystem"    => :ext3,
-        "label"         => "mydata",
-        "mount"         => "swap",
-        "mountby"       => :label,
-        "fstab_options" => "ro,noatime,user",
-        "mkfs_options"  => "-I 128"
-      }
-    end
-
-    let(:filesystem_attrs_widget) do
-      instance_double(
-        Y2Autoinstallation::Widgets::Storage::FilesystemAttrs,
-        values: filesystem_attrs
-      )
-    end
-
-    before do
-      allow(Y2Autoinstallation::Widgets::Storage::FilesystemAttrs).to receive(:new)
-        .and_return(filesystem_attrs_widget)
-    end
-
     it "sets section attributes related to its usage" do
-      subject.store
+      expect(partition).to receive(:update).with(
+        hash_including(
+          "filesystem",
+          "label",
+          "mount",
+          "mountby",
+          "fstab_options",
+          "mkfs_options",
+          "raid_name",
+          "lvm_group",
+          "bcache_backing_for",
+          "btrfs_name",
+          "create_subvolumes"
+        )
+      )
 
-      expect(partition.filesystem).to eq(:ext3)
-      expect(partition.label).to eq("mydata")
-      expect(partition.mount).to eq("swap")
-      expect(partition.mountby).to eq(:label)
-      expect(partition.fstab_options).to eq("ro,noatime,user")
-      expect(partition.mkfs_options).to eq("-I 128")
+      subject.store
     end
   end
 end

--- a/test/lib/widgets/storage/shared_examples.rb
+++ b/test/lib/widgets/storage/shared_examples.rb
@@ -344,3 +344,19 @@ RSpec.shared_examples "Y2Autoinstallation::Widgets::Storage::BtrfsRaidLevel" do
     end
   end
 end
+
+RSpec.shared_examples "Y2Autoinstallation::Widgets::Storage::PartitionTab" do
+  include_examples "CWM::Page"
+
+  describe "#widgets" do
+    it "returns an array" do
+      expect(subject.widgets).to be_a(Array)
+    end
+  end
+
+  describe "#visible_widgets" do
+    it "returns an array" do
+      expect(subject.visible_widgets).to be_a(Array)
+    end
+  end
+end


### PR DESCRIPTION
One step more in the path to `The New AutoYaST Storage UI` (see #592).

According to what was discussed offline, this PR 

* Move the encryption attributes to the _General_ tab
* Change some attributes labels (namely, _Partition UUID_ is now _UUID_ and _Partition table_ is _Disklabel_)
* Display _Partition Id_ and _Partition Type_ attributes unless the partition belongs to a LVM drive section
* Add a button to remove currently selected section (except if it is the only drive section available)

And also reorganize a bit the partition tabs code using a base class in an attempt to reduce the code duplication.

|||
|-|-|
| ![Screenshot_openSUSE-IceWM_2020-05-19_16:06:46](https://user-images.githubusercontent.com/1691872/82343500-d8fbd080-99ea-11ea-81b7-6dd09cf346e1.png) | ![Screenshot from 2020-05-19 17-01-26](https://user-images.githubusercontent.com/1691872/82349831-81f9f980-99f2-11ea-9f35-4c00a2efa943.png) |
