### PR TITLE
Move network configuration to autoinit client in case of online medium

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed May 27 14:03:50 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- When running an autoinstallation with the Online mediun, the
+  network configuration based on the profile can be written before
+  the registration takes place (bsc#1171922)
+- 4.3.6
+
+-------------------------------------------------------------------
 Wed May 27 08:26:35 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not propose insecure signature handling settings when

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -158,11 +158,9 @@ module Yast
       AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
 
       # configure general settings
-      AutoinstGeneral.Import(Ops.get_map(Profile.current, "general", {}))
-      Builtins.y2milestone(
-        "general: %1",
-        Ops.get_map(Profile.current, "general", {})
-      )
+      general_section = profile_section("general")
+      AutoinstGeneral.Import(general_section)
+      log.info("general: #{general_section}")
       AutoinstGeneral.Write
 
       autosetup_network

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -158,7 +158,7 @@ module Yast
       AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
 
       # configure general settings
-      general_section = profile_section("general")
+      general_section = Profile.current["general"] || {}
       AutoinstGeneral.Import(general_section)
       log.info("general: #{general_section}")
       AutoinstGeneral.Write

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -160,6 +160,9 @@ module Y2Autoinstallation
     # Convenience method to fetch the content of the given section name from
     # the current {Yast::Profile}
     #
+    # @note not all the sections are expected to return a hash like the
+    #   partitioning one; in these cases please avoid to use it
+    #
     # @param name [String] section name to be fetched from the profile
     # @return [Hash] the profile section with the given name when present;
     #   an empty hash when not

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -158,7 +158,7 @@ module Y2Autoinstallation
     end
 
     # Defines convenience methods to check the existence and the content of
-    # the {Yast::Profile.current} sections
+    # the current {Yast::Profile} sections
     #
     # @example networking section methods
     #

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -109,7 +109,8 @@ module Y2Autoinstallation
     #
     # @return [Boolean]
     def semi_auto?(name)
-      !!profile_section("general")["semi-automatic"]&.include?(name)
+      general_section = Yast::Profile.current["general"] || {}
+      !!general_section["semi-automatic"]&.include?(name)
     end
 
     # Autosetup the network
@@ -154,29 +155,9 @@ module Y2Autoinstallation
     def network_before_proposal?
       return @network_before_proposal unless @network_before_proposal.nil?
 
-      @network_before_proposal = profile_section("networking").fetch("setup_before_proposal", false)
-    end
+      networking_section = Yast::Profile.current["networking"] || {}
 
-    # Convenience method to fetch the content of the given section name from
-    # the current {Yast::Profile}
-    #
-    # @note not all the sections are expected to return a hash like the
-    #   partitioning one; in these cases please avoid to use it
-    #
-    # @param name [String] section name to be fetched from the profile
-    # @return [Hash] the profile section with the given name when present;
-    #   an empty hash when not
-    def profile_section(name)
-      Yast::Profile.current[name] || {}
-    end
-
-    # Convenience method to check whether the current {Yast::Profile} contains
-    # a specific section
-    #
-    # @param name [String] profile section name
-    # @return [Boolean] true when the section is present; false when not
-    def profile_section?(name)
-      Yast::Profile.current.key?(name)
+      @network_before_proposal = networking_section.fetch("setup_before_proposal", false)
     end
 
   private

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -159,6 +159,15 @@ module Y2Autoinstallation
 
     # Defines convenience methods to check the existence and the content of
     # the {Yast::Profile.current} sections
+    #
+    # @example networking section methods
+    #
+    #   profile = { "networking" => { "setup_before_proposal" => true } }
+    #   Yast::Profile.current = profile
+    #
+    #   client.networking_section? #=> true
+    #   client.networking_section["setup_before_proposal"] #=> true
+    #   client.not_present_section? #=> false
     def method_missing(method, *arguments, &block)
       case method.to_s
       when /(.+)_section$/
@@ -167,6 +176,15 @@ module Y2Autoinstallation
         Yast::Profile.current.keys.include?(Regexp.last_match(1))
       else
         super
+      end
+    end
+
+    def respond_to_missing?(method, _include_private = false)
+      case method.to_s
+      when /(.+)_section$/, /(.+)_section\?$/
+        true
+      else
+        false
       end
     end
 

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -109,7 +109,7 @@ module Y2Autoinstallation
     #
     # @return [Boolean]
     def semi_auto?(name)
-      !!general_section["semi-automatic"]&.include?(name)
+      !!profile_section("general")["semi-automatic"]&.include?(name)
     end
 
     # Autosetup the network
@@ -154,38 +154,26 @@ module Y2Autoinstallation
     def network_before_proposal?
       return @network_before_proposal unless @network_before_proposal.nil?
 
-      @network_before_proposal = networking_section.fetch("setup_before_proposal", false)
+      @network_before_proposal = profile_section("networking").fetch("setup_before_proposal", false)
     end
 
-    # Defines convenience methods to check the existence and the content of
-    # the current {Yast::Profile} sections
+    # Convenience method to fetch the content of the given section name from
+    # the current {Yast::Profile}
     #
-    # @example networking section methods
-    #
-    #   profile = { "networking" => { "setup_before_proposal" => true } }
-    #   Yast::Profile.current = profile
-    #
-    #   client.networking_section? #=> true
-    #   client.networking_section["setup_before_proposal"] #=> true
-    #   client.not_present_section? #=> false
-    def method_missing(method, *arguments, &block)
-      case method.to_s
-      when /(.+)_section$/
-        Yast::Profile.current[Regexp.last_match(1)] || {}
-      when /(.+)_section\?$/
-        Yast::Profile.current.keys.include?(Regexp.last_match(1))
-      else
-        super
-      end
+    # @param name [String] section name to be fetched from the profile
+    # @return [Hash] the profile section with the given name when present;
+    #   an empty hash when not
+    def profile_section(name)
+      Yast::Profile.current[name] || {}
     end
 
-    def respond_to_missing?(method, _include_private = false)
-      case method.to_s
-      when /(.+)_section$/, /(.+)_section\?$/
-        true
-      else
-        false
-      end
+    # Convenience method to check whether the current {Yast::Profile} contains
+    # a specific section
+    #
+    # @param name [String] profile section name
+    # @return [Boolean] true when the section is present; false when not
+    def profile_section?(name)
+      Yast::Profile.current.key?(name)
     end
 
   private

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -76,15 +76,12 @@ module Y2Autoinstallation
 
         Yast::Progress.Finish
 
-        # TODO: In case that a specific network configuration is needed and
-        # defined in the profile, with the online media, this configuration
-        # will not be available. Maybe we should configure the network at this
-        # point
-
         # when installing from the online installation medium we need to
         # register the system earlier because the medium does not contain any
         # repositories, we need the repositories from the registration server
         if Y2Packager::MediumType.online? && !Yast::Mode.autoupgrade
+          autosetup_network if network_before_proposal?
+
           res = register_system
           return res if res
         # offline registration need here to init software management according to picked product

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -297,7 +297,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
   end
 
-  describe "#method_missing" do
+  describe "#profile_section" do
     let(:profile) { general_section }
     let(:general_section) { { "general" => { "semi-automatic" => ["networking"] } } }
     let(:register_section) { { "suse_register" => { "reg_code" => "12345" } } }
@@ -306,82 +306,38 @@ describe Y2Autoinstallation::AutosetupHelpers do
       Yast::Profile.current = profile
     end
 
-    context "when the method name matchs /(?<section_name>.*)_section/'" do
-      it "returns the profile section with the matched :section_name when present" do
-        expect(client.general_section).to eql(general_section["general"])
-      end
-
-      it "returns an empty hash when the section with the matched :section_name is not present" do
-        expect(client.networking_section).to eql({})
-      end
-    end
-
-    context "when the method name matchs /(?<section_name>.*)_section?/'" do
-      it "returns true if the profile section with the matched name is defined" do
-        expect(client.general_section?).to eql(true)
-      end
-
-      it "returns false if the matched section name is not defined in the profile" do
-        expect(client.suse_register_section?).to eql(false)
-      end
-    end
-  end
-
-  describe "#respond_to_missing?" do
-    it "returns true if the method name matchs /(?<section_name>.*)_section/'" do
-      expect(client.respond_to?("general_section")).to eql(true)
-    end
-
-    it "returns true if the method name matchs /(?<section_name>.*)_section?/'" do
-      expect(client.respond_to?("suse_register_section")).to eql(true)
-    end
-
-    it "returns false otherwise" do
-      expect(client.respond_to?("wrong_section_method_name")).to eql(false)
-    end
-  end
-
-  describe "#general_section" do
-    let(:profile) { general_section }
-    let(:general_section) { { "general" => { "semi-automatic" => ["networking"] } } }
-    let(:register_section) { { "suse_register" => { "reg_code" => "12345" } } }
-
-    before do
-      Yast::Profile.current = profile
-    end
-
-    context "when the profile contains the general section" do
+    context "when the profile contains the given section" do
       it "returns it" do
-        expect(client.general_section).to eql(general_section["general"])
+        expect(client.profile_section("general")).to eql(general_section["general"])
       end
     end
 
-    context "when the profile does not contain the general section" do
+    context "when the profile does not contain the given section" do
       let(:profile) { register_section }
       it "returns and empty hash" do
-        expect(client.general_section).to eql({})
+        expect(client.profile_section("general")).to eql({})
       end
     end
   end
 
-  describe "#general_section?" do
+  describe "#profile_section?" do
     let(:profile) { { "general" => { "semi-automatic" => ["networking"] } } }
 
     before do
       Yast::Profile.current = profile
     end
 
-    context "when the profile contains the section" do
+    context "when the profile contains the given section" do
       it "returns true" do
-        expect(client.general_section?).to eql(true)
+        expect(client.profile_section?("general")).to eql(true)
       end
     end
 
-    context "when the profile does not contain the section" do
+    context "when the profile does not contain the given section" do
       let(:profile) { { "suse_register" => { "reg_code" => "12345" } } }
 
       it "returns false" do
-        expect(client.general_section?).to eql(false)
+        expect(client.profile_section?("general")).to eql(false)
       end
     end
   end

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -297,51 +297,6 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
   end
 
-  describe "#profile_section" do
-    let(:profile) { general_section }
-    let(:general_section) { { "general" => { "semi-automatic" => ["networking"] } } }
-    let(:register_section) { { "suse_register" => { "reg_code" => "12345" } } }
-
-    before do
-      Yast::Profile.current = profile
-    end
-
-    context "when the profile contains the given section" do
-      it "returns it" do
-        expect(client.profile_section("general")).to eql(general_section["general"])
-      end
-    end
-
-    context "when the profile does not contain the given section" do
-      let(:profile) { register_section }
-      it "returns and empty hash" do
-        expect(client.profile_section("general")).to eql({})
-      end
-    end
-  end
-
-  describe "#profile_section?" do
-    let(:profile) { { "general" => { "semi-automatic" => ["networking"] } } }
-
-    before do
-      Yast::Profile.current = profile
-    end
-
-    context "when the profile contains the given section" do
-      it "returns true" do
-        expect(client.profile_section?("general")).to eql(true)
-      end
-    end
-
-    context "when the profile does not contain the given section" do
-      let(:profile) { { "suse_register" => { "reg_code" => "12345" } } }
-
-      it "returns false" do
-        expect(client.profile_section?("general")).to eql(false)
-      end
-    end
-  end
-
   describe "#semi_auto?" do
     let(:profile) { general_section }
     let(:general_section) { { "general" => { "semi-automatic" => ["networking"] } } }

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -252,12 +252,6 @@ describe Y2Autoinstallation::AutosetupHelpers do
         let(:profile) { networking_section.merge(host_section) }
         let(:networking_section) { { "networking" => { "setup_before_proposal" => true } } }
 
-        it "sets the network config to be written before the proposal" do
-          expect { client.autosetup_network }
-            .to change { client.network_before_proposal? }
-            .from(false).to(true)
-        end
-
         context "and a host section is defined" do
           it "imports the /etc/hosts config from the profile" do
             expect(Yast::WFM)

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -297,6 +297,50 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
   end
 
+  describe "#method_missing" do
+    let(:profile) { general_section }
+    let(:general_section) { { "general" => { "semi-automatic" => ["networking"] } } }
+    let(:register_section) { { "suse_register" => { "reg_code" => "12345" } } }
+
+    before do
+      Yast::Profile.current = profile
+    end
+
+    context "when the method name matchs /(?<section_name>.*)_section/'" do
+      it "returns the profile section with the matched :section_name when present" do
+        expect(client.general_section).to eql(general_section["general"])
+      end
+
+      it "returns an empty hash when the section with the matched :section_name is not present" do
+        expect(client.networking_section).to eql({})
+      end
+    end
+
+    context "when the method name matchs /(?<section_name>.*)_section?/'" do
+      it "returns true if the profile section with the matched name is defined" do
+        expect(client.general_section?).to eql(true)
+      end
+
+      it "returns false if the matched section name is not defined in the profile" do
+        expect(client.suse_register_section?).to eql(false)
+      end
+    end
+  end
+
+  describe "#respond_to_missing?" do
+    it "returns true if the method name matchs /(?<section_name>.*)_section/'" do
+      expect(client.respond_to?("general_section")).to eql(true)
+    end
+
+    it "returns true if the method name matchs /(?<section_name>.*)_section?/'" do
+      expect(client.respond_to?("suse_register_section")).to eql(true)
+    end
+
+    it "returns false otherwise" do
+      expect(client.respond_to?("wrong_section_method_name")).to eql(false)
+    end
+  end
+
   describe "#general_section" do
     let(:profile) { general_section }
     let(:general_section) { { "general" => { "semi-automatic" => ["networking"] } } }
@@ -316,6 +360,28 @@ describe Y2Autoinstallation::AutosetupHelpers do
       let(:profile) { register_section }
       it "returns and empty hash" do
         expect(client.general_section).to eql({})
+      end
+    end
+  end
+
+  describe "#general_section?" do
+    let(:profile) { { "general" => { "semi-automatic" => ["networking"] } } }
+
+    before do
+      Yast::Profile.current = profile
+    end
+
+    context "when the profile contains the section" do
+      it "returns true" do
+        expect(client.general_section?).to eql(true)
+      end
+    end
+
+    context "when the profile does not contain the section" do
+      let(:profile) { { "suse_register" => { "reg_code" => "12345" } } }
+
+      it "returns false" do
+        expect(client.general_section?).to eql(false)
       end
     end
   end

--- a/test/lib/clients/inst_autoinit_test.rb
+++ b/test/lib/clients/inst_autoinit_test.rb
@@ -36,7 +36,6 @@ describe Y2Autoinstallation::Clients::InstAutoinit do
     allow(Yast::AutoinstFunctions).to receive(:available_base_products).and_return([])
     allow(Y2Packager::MediumType).to receive(:online?).and_return(true)
     Yast::AutoinstConfig.ProfileInRootPart = false
-
   end
 
   describe "#run" do
@@ -95,40 +94,82 @@ describe Y2Autoinstallation::Clients::InstAutoinit do
       subject.run
     end
 
-    it "reports error for installation with full medium without specified product" do
-      allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
-      allow(Y2Packager::MediumType).to receive(:offline?).and_return(true)
-      allow(Yast::Mode).to receive(:autoupgrade).and_return(false)
+    context "when using the Full medium" do
+      it "reports an error when the product is not specified" do
+        allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
+        allow(Y2Packager::MediumType).to receive(:offline?).and_return(true)
+        allow(Yast::Mode).to receive(:autoupgrade).and_return(false)
 
-      expect(Yast::Popup).to receive(:LongError)
+        expect(Yast::Popup).to receive(:LongError)
 
-      expect(subject.run).to eq :abort
+        expect(subject.run).to eq :abort
+      end
     end
 
-    it "registers system for installation with online medium" do
-      map = { "suse_register" => { "do_registration" => true } }
-      allow(Yast::Mode).to receive(:autoupgrade).and_return(false)
-      allow(Yast::Profile).to receive(:current).and_return(map)
-      expect(Yast::WFM).to receive(:CallFunction)
-        .with("scc_auto", ["Import", map["suse_register"]])
-      expect(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"])
-      # fake that registration is available to avoid build requires
-      allow(subject).to receive(:registration_module_available?).and_return(true)
-      allow(Yast::Profile).to receive(:remove_sections)
+    context "when using the Online medium for an installation" do
+      let(:do_registration) { false }
+      let(:setup_before_proposal) { false }
+      let(:profile) do
+        {
+          "suse_register" => { "do_registration" => do_registration },
+          "networking"    => { "setup_before_proposal" => setup_before_proposal }
+        }
+      end
 
-      subject.run
-    end
+      before do
+        allow(Yast::Mode).to receive(:autoupgrade).and_return(false)
+        allow(Yast::Profile).to receive(:current).and_return(profile)
+      end
 
-    it "reports error for installation with online medium without register section" do
-      map = { "suse_register" => { "do_registration" => false } }
-      allow(Yast::Mode).to receive(:autoupgrade).and_return(false)
-      allow(Yast::Profile).to receive(:current).and_return(map)
-      expect(Yast::WFM).to_not receive(:CallFunction)
-        .with("scc_auto", ["Import", map["suse_register"]])
-      expect(Yast::WFM).to_not receive(:CallFunction).with("scc_auto", ["Write"])
-      expect(Yast::Popup).to receive(:LongError)
+      context "and the network is requested to be configured before the proposal" do
+        let(:setup_before_proposal) { true }
 
-      expect(subject.run).to eq :abort
+        it "configures the network" do
+          expect(subject).to receive(:autosetup_network)
+
+          subject.run
+        end
+      end
+
+      context "and the registration is disabled or not present in the profile" do
+        let(:do_registration) { false }
+
+        it "does not try to register the system" do
+          expect(Yast::WFM).to_not receive(:CallFunction)
+            .with("scc_auto", ["Import", profile["suse_register"]])
+          expect(Yast::WFM).to_not receive(:CallFunction).with("scc_auto", ["Write"])
+
+          subject.run
+        end
+
+        it "reports an error" do
+          expect(Yast::WFM).to_not receive(:CallFunction)
+            .with("scc_auto", ["Import", profile["suse_register"]])
+          expect(Yast::WFM).to_not receive(:CallFunction).with("scc_auto", ["Write"])
+          expect(Yast::Popup).to receive(:LongError)
+
+          subject.run
+        end
+
+        it "returns :abort" do
+          expect(subject.run).to eq :abort
+        end
+      end
+
+      context "and the registration is enabled according to the profile" do
+        let(:do_registration) { true }
+
+        it "registers system" do
+          expect(Yast::WFM).to receive(:CallFunction)
+            .with("scc_auto", ["Import", profile["suse_register"]])
+          expect(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"])
+          # fake that registration is available to avoid build requires
+          allow(subject).to receive(:registration_module_available?).and_return(true)
+          allow(Yast::Profile).to receive(:remove_sections)
+
+          subject.run
+        end
+      end
     end
 
     #  TODO: more test for profile processing

--- a/test/lib/clients/inst_autoinit_test.rb
+++ b/test/lib/clients/inst_autoinit_test.rb
@@ -159,7 +159,7 @@ describe Y2Autoinstallation::Clients::InstAutoinit do
       context "and the registration is enabled according to the profile" do
         let(:do_registration) { true }
 
-        it "registers system" do
+        it "registers the system" do
           expect(Yast::WFM).to receive(:CallFunction)
             .with("scc_auto", ["Import", profile["suse_register"]])
           expect(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"])


### PR DESCRIPTION
## Problem

Since **SLE-15-SP2**, there is an **Online** Media which needs to register the system in order to add the repositories from **SCC**. This registration is done a step earlier than it is done with the Full media and was added by [this](https://github.com/yast/yast-autoinstallation/pull/530) PR.

In order to register the system, a network configuration is needed and it is usually configured by linurxc as you can see in the example below:

> **Linuxrc Options:** `ifcfg=eth0=dhcp autoyast=http://192.1681.122.1/control-files/minimal.xml`

But it is not the only way to configure the network. 

In cases where the network is very complex, or just because we have it already defined in a profile we can configure it through AutoYaST. There is an special flag for configuring it before the registration takes place.

From https://documentation.suse.com/sles/15-SP1/html/SLES-all/configuration.html#CreateProfile-Register

>**Tip: Using the Installation Network Settings**
>
>In case you need to use the same network settings that were used for the installation, AutoYaST needs to run the network setup in stage 1 right before the registration is started:
>
> ```xml
> <networking>
>  <setup_before_proposal config:type="boolean">true</setup_before_proposal>
> </networking>
> ```

The problem is that this is only working with Full media and in case it is used with the Online media, then, only the linuxrc configuration will be available at that point producing a network error during registration.

> **Linuxrc options:** `autoyast=usb:///autoinst.xml`

![NetworkError](https://user-images.githubusercontent.com/7056681/82923078-5a66dc00-9f72-11ea-9bac-6c52f8ef6772.png)

- https://trello.com/c/mGrosoxT/1876-3-move-the-network-initialization-to-autoinit

## Solution

The configuration of the network has been moved just before the registration of an Online media takes place if it was specified to be written before the proposal and in case it is not an autupgrade.

## Tests

- Unit tests (in progress)
- Tested manually
  -  In the last build of SLE-15-SP2 and a dud with only the network changes (based on SP2 branch)
  - With last TW build