### PR TITLE
Do not propose insecure signature handling settings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May 27 08:26:35 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not propose insecure signature handling settings when
+  cloning (bsc#1171343).
+- Do not export storage settings in the general section
+  unless it is needed (related to bsc#1171356).
+- 4.2.37
+
+-------------------------------------------------------------------
 Thu May 21 11:47:03 UTC 2020 - David Díaz <dgonzalez@suse.com>
 
 - Revamp the storage client user interface, adapting it to the

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -3,6 +3,7 @@ Wed May 27 08:26:35 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not propose insecure signature handling settings when
   cloning (bsc#1171343).
+- Assign the correct callback when "accept_unknown_digest" is set.
 - Do not export storage settings in the general section
   unless it is needed (related to bsc#1171356).
 - 4.2.37

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.36
+Version:        4.2.37
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstClone.rb
+++ b/src/modules/AutoinstClone.rb
@@ -67,9 +67,8 @@ module Yast
         "import_gpg_key"               => true,
         "accept_non_trusted_gpg_key"   => true
       }
-      general["storage"] = {
-        "start_multipath" => multipath_in_use?
-      }
+
+      general["storage"] = { "start_multipath" => true } if multipath_in_use?
 
       Mode.SetMode("autoinst_config")
       general

--- a/src/modules/AutoinstClone.rb
+++ b/src/modules/AutoinstClone.rb
@@ -58,20 +58,7 @@ module Yast
       Mode.SetMode("normal")
 
       general = {}
-
       general["mode"] = { "confirm" => false }
-
-      # Signature handling is less restrictive in a cloned profile.
-      # https://bugzilla.suse.com/show_bug.cgi?id=248303
-      general["signature-handling"] = {
-        "accept_unsigned_file"         => true,
-        "accept_file_without_checksum" => true,
-        "accept_unknown_gpg_key"       => true,
-        "accept_verification_failed"   => false,
-        "import_gpg_key"               => true,
-        "accept_non_trusted_gpg_key"   => true
-      }
-
       general["storage"] = { "start_multipath" => true } if multipath_in_use?
 
       Mode.SetMode("autoinst_config")

--- a/src/modules/AutoinstClone.rb
+++ b/src/modules/AutoinstClone.rb
@@ -17,6 +17,7 @@ require "yast"
 require "y2storage"
 
 module Yast
+  # This module drives the AutoYaST cloning process
   class AutoinstCloneClass < Module
     include Yast::Logger
 
@@ -50,6 +51,7 @@ module Yast
     end
 
     # General options
+    #
     # @return [Hash] general options
     def General
       Yast.import "Mode"
@@ -59,6 +61,8 @@ module Yast
 
       general["mode"] = { "confirm" => false }
 
+      # Signature handling is less restrictive in a cloned profile.
+      # https://bugzilla.suse.com/show_bug.cgi?id=248303
       general["signature-handling"] = {
         "accept_unsigned_file"         => true,
         "accept_file_without_checksum" => true,
@@ -75,6 +79,7 @@ module Yast
     end
 
     # Clone a Resource
+    #
     # @param _resource    [String] resource. Not used.
     # @param resourceMap [Hash] resources map
     # @return [Array]
@@ -97,7 +102,8 @@ module Yast
     end
 
     # Create a list of clonable resources
-    # @return [Array] list to be used in widgets
+    #
+    # @return [Array<Yast::Term>] list to be used in widgets
     def createClonableList
       items = []
       Builtins.foreach(Y2ModuleConfig.ModuleMap) do |def_resource, resourceMap|
@@ -157,7 +163,8 @@ module Yast
     end
 
     # Build the profile
-    # @return [void]
+    #
+    # @return [nil]
     def Process
       log.info "Base resources: #{@base} additional: #{@additional}"
       Profile.Reset

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -403,7 +403,7 @@ module Yast
         )
       end
       if Builtins.haskey(@signature_handling, "accept_unknown_digest")
-        Pkg.CallbackAcceptWrongDigest(
+        Pkg.CallbackAcceptUnknownDigest(
           if Ops.get_boolean(@signature_handling, "accept_unknown_digest", false)
             fun_ref(
               AutoInstall.method(:callbackTrue_boolean_string_string_string),

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -228,4 +228,12 @@ describe "Yast::AutoinstGeneral" do
     include_examples "sets callback", "trusted_key_removed",
       callback_void_map: ["key"]
   end
+
+  describe "#Summary" do
+    it "includes information about installation confirmation and signature handling" do
+      summary = subject.Summary
+      expect(summary).to include("Confirm installation?")
+      expect(summary).to include("Signature Handling")
+    end
+  end
 end

--- a/test/autoinst_clone_test.rb
+++ b/test/autoinst_clone_test.rb
@@ -175,7 +175,7 @@ describe Yast::AutoinstClone do
     end
 
     it "includes signature handling settings" do
-      expect(subject.General).to include("signature-handling" => Hash)
+      expect(subject.General).to_not include("signature-handling" => Hash)
     end
 
     context "when multipath is not enabled" do

--- a/test/autoinst_clone_test.rb
+++ b/test/autoinst_clone_test.rb
@@ -1,0 +1,202 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "AutoinstClone"
+
+describe Yast::AutoinstClone do
+  subject { Yast::AutoinstClone }
+
+  let(:module_map) do
+    {
+
+      "add-on"     => {
+        "Name"                         => "YaST Add-On Products",
+        "Icon"                         => "yast-addon",
+        "X-SuSE-YaST-AutoInst"         => "configure",
+        "X-SuSE-YaST-AutoInstResource" => "add-on",
+        "X-SuSE-YaST-Group"            => "Software",
+        "X-SuSE-YaST-AutoInstClonable" => "true",
+        "X-SuSE-DocTeamID"             => "ycc_org.opensuse.yast.AddOn",
+        "X-SuSE-YaST-AutoInstClient"   => "add-on_auto"
+      },
+      "general"    => {
+        "Name"                         => "General Options",
+        "Icon"                         => "yast-general",
+        "X-SuSE-YaST-AutoInst"         => "configure",
+        "X-SuSE-YaST-AutoInstResource" => "general",
+        "X-SuSE-YaST-Group"            => "System",
+        "X-SuSE-YaST-AutoInstClient"   => "general_auto"
+      },
+      "report"     => {
+        "Name"                         => "Report & Logging",
+        "Icon"                         => "yast-report",
+        "X-SuSE-YaST-AutoInst"         => "configure",
+        "X-SuSE-YaST-AutoInstResource" => "report",
+        "X-SuSE-YaST-Group"            => "System",
+        "X-SuSE-YaST-AutoInstClient"   => "report_auto"
+      },
+      "bootloader" => {
+        "Name"                         => "YaST Boot Loader",
+        "Icon"                         => "yast-bootloader",
+        "X-SuSE-YaST-AutoInst"         => "configure",
+        "X-SuSE-YaST-AutoInstResource" => "bootloader",
+        "X-SuSE-YaST-Group"            => "System",
+        "X-SuSE-DocTeamID"             => "ycc_org.opensuse.yast.Bootloader",
+        "X-SuSE-YaST-AutoInstClient"   => "bootloader_auto"
+      }
+    }
+  end
+
+  before do
+    allow(Yast::Y2ModuleConfig).to receive(:ModuleMap).and_return(module_map)
+    allow(subject).to receive(:multipath_in_use?).and_return(false)
+    subject.additional = ["add-on"]
+    Yast::Mode.SetMode("normal")
+  end
+
+  describe "#Process" do
+    before do
+      allow(subject).to receive(:CommonClone)
+      allow(Yast::Profile).to receive(:Prepare)
+    end
+
+    it "sets Mode to 'autoinst_config'" do
+      expect { subject.Process }.to change { Yast::Mode.mode }.from("normal").to("autoinst_config")
+    end
+
+    it "clones 'additional' modules" do
+      expect(subject).to receive(:CommonClone).with("add-on", module_map["add-on"])
+      subject.Process
+    end
+
+    it "imports 'general' and 'report' settings" do
+      expect(Yast::Call).to receive(:Function).with("general_auto", ["Import", Hash])
+      expect(Yast::Call).to receive(:Function).with("general_auto", ["SetModified"])
+      expect(Yast::Call).to receive(:Function).with("report_auto", ["Import", Hash])
+      expect(Yast::Call).to receive(:Function).with("report_auto", ["SetModified"])
+      subject.Process
+    end
+
+    it "asks the profile to 'prepare'" do
+      expect(Yast::Profile).to receive(:Reset)
+      expect(Yast::Profile).to receive(:prepare=).with(true)
+      expect(Yast::Profile).to receive(:Prepare)
+      subject.Process
+    end
+  end
+
+  describe "#CommonClone" do
+    let(:resource_map) { module_map["add-on"] }
+    let(:initial_stage) { false }
+
+    before do
+      allow(Yast::Call).to receive(:Function)
+      allow(Yast::Stage).to receive(:initial).and_return(initial_stage)
+    end
+
+    it "returns true" do
+      expect(subject.CommonClone("dummy", resource_map)).to eq(true)
+    end
+
+    it "reads the module settings" do
+      expect(Yast::Call).to receive(:Function).with("add-on_auto", ["Read"])
+      subject.CommonClone("dummy", resource_map)
+    end
+
+    it "sets the module as modified" do
+      expect(Yast::Call).to receive(:Function).with("add-on_auto", ["SetModified"])
+      subject.CommonClone("dummy", resource_map)
+    end
+
+    context "on 1st stage" do
+      let(:initial_stage) { true }
+
+      it "does not read the module settings" do
+        expect(Yast::Call).to_not receive(:Function).with(anything, ["Read"])
+        subject.CommonClone("dummy", resource_map)
+      end
+
+      it "sets the module as modified" do
+        expect(Yast::Call).to receive(:Function).with("add-on_auto", ["SetModified"])
+        subject.CommonClone("dummy", resource_map)
+      end
+
+      context "when cloning the software module" do
+        let(:resource_map) do
+          { "X-SuSE-YaST-AutoInstClient" => "software_auto" }
+        end
+
+        it "reads the module settings" do
+          expect(Yast::Call).to receive(:Function).with("software_auto", ["Read"])
+          subject.CommonClone("dummy", resource_map)
+        end
+      end
+
+      context "when cloning the storage module" do
+        let(:resource_map) do
+          { "X-SuSE-YaST-AutoInstClient" => "storage_auto" }
+        end
+
+        it "reads the module settings" do
+          expect(Yast::Call).to receive(:Function).with("storage_auto", ["Read"])
+          subject.CommonClone("dummy", resource_map)
+        end
+      end
+    end
+  end
+
+  describe "#General" do
+    it "includes installation mode configuration" do
+      expect(subject.General).to include("mode" => { "confirm" => false })
+    end
+
+    it "includes signature handling settings" do
+      expect(subject.General).to include("signature-handling" => Hash)
+    end
+
+    it "includes whether multipath is enabled or not" do
+      expect(subject.General).to include("storage" => { "start_multipath" => false })
+    end
+  end
+
+  describe "#createClonableList" do
+    before do
+      allow(Yast::Builtins)
+        .to receive(:dpgettext)
+        .with(
+          "desktop_translations",
+          "/usr/share/locale/",
+          "Name(org.opensuse.yast.AddOn.desktop): YaST Add-On Products"
+        ).and_return("Add-On (translated)")
+
+      allow(Yast::Builtins)
+        .to receive(:dpgettext)
+          .with("desktop_translations", "/usr/share/locale/", /Bootloader/) { |*a| a.last }
+    end
+
+    it "returns a list of modules to clone with translated names" do
+      modules = subject.createClonableList
+      items = modules.map(&:params)
+      names = items.map(&:last)
+      expect(names).to eq(["Add-On (translated)", "YaST Boot Loader"])
+    end
+  end
+end


### PR DESCRIPTION
The main point of this PR is to stop proposing insecure signature handling settings when cloning (see [bsc#1171343](https://bugzilla.suse.com/show_bug.cgi?id=1171343)). The problem does not affect the installation itself and I think it is a safe change to be included in SP2.

When I was about to add unit tests for this change, I realized that we already had some tests for the `AutoinstClone` module in `master`. So I decided to backport them and I included the fix to not export storage settings unless it is needed too (see [bsc#1171356](https://bugzilla.suse.com/show_bug.cgi?id=1171356)).

Finally, I have added a few tests to cover the import of the signature handling settings and then I realized that we were setting the wrong callback when importing `accept_unknown_digest`.

Trello: https://trello.com/c/iBY28SdE/