### PR TITLE
Correct schema

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,5 +1,16 @@
 -------------------------------------------------------------------
+Mon Jun  1 09:46:08 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- AutoYaST schema fixes:
+  - Work around Relax-NG parser error: "Found anyName attribute
+    without oneOrMore ancestor" (bsc#1172131)
+  - Rename 'option' to 'fs_option' to fix a duplicate definition
+    (bsc#1170886)
+- 4.3.8
+
+-------------------------------------------------------------------
 Wed May 27 15:03:50 UTC 2020 - schubi@suse.de
+
 - AutoYaST: Cleanup/improve issue handling (bsc#1171335).
 - 4.3.7
 

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/common.rnc
+++ b/src/autoyast-rnc/common.rnc
@@ -13,18 +13,28 @@ BOOLEAN |=
     ## Historically we used config:type
     ## but it is unnecessarily long to type and read.
     ## Shorter variants are allowed.
-    attribute ( t | type | config:type ) { "boolean" },
+    # This could be expressed also as
+    # 'attribute ( t | type | config:type ) { "boolean" }'
+    # but libxml2-2.9.7 xmllint considers it incorrect schema :-(
+    ( attribute t           { "boolean" } |
+      attribute type        { "boolean" } |
+      attribute config:type { "boolean" } ),
     ( "true" | "false" )
   )
 
 INTEGER |=
   (
-    attribute ( t | type | config:type ) { "integer" },
+    ( attribute t           { "integer" } |
+      attribute type        { "integer" } |
+      attribute config:type { "integer" } ),
     xsd:integer
   )
 
 # Usage: foo = element foo { STRING_ATTR, ( "bar" | "baz") }
-STRING_ATTR |= attribute ( t | type | config:type ) { "string" }?
+STRING_ATTR |=
+    ( attribute t           { "string" } |
+      attribute type        { "string" } |
+      attribute config:type { "string" } ) ?
 
 STRING |=
   (
@@ -34,15 +44,26 @@ STRING |=
 
 SYMBOL |=
   (
-    attribute ( t | type | config:type ) { "symbol" },
+    (
+      attribute t           { "symbol" } |
+      attribute type        { "symbol" } |
+      attribute config:type { "symbol" } ),
     text
   )
 
 LIST |=
-  attribute ( t | type | config:type ) { "list" }
+  (
+      attribute t           { "list" } |
+      attribute type        { "list" } |
+      attribute config:type { "list" }
+  )
 
 MAP |=
-  attribute ( t | type | config:type ) { "map" }?
+  (
+      attribute t           { "map" } |
+      attribute type        { "map" } |
+      attribute config:type { "map" }
+  ) ?
 
 # this is useful for testing
 Anything |=

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -125,21 +125,21 @@ part_fs_options =
     )
   }
 
-option = MAP, (option_str, option_value )
+fs_option = MAP, (option_str, option_value )
 blank_option = MAP, (option_blank, option_str, option_value )
-opt_block_size = element opt_block_size { option }
-opt_blocksize = element opt_blocksize { option }
+opt_block_size = element opt_block_size { fs_option }
+opt_blocksize = element opt_blocksize { fs_option }
 opt_bytes_per_inode =
-  element opt_bytes_per_inode { option }
+  element opt_bytes_per_inode { fs_option }
 opt_format =
   element opt_format { blank_option }
 opt_hash = element opt_hash { blank_option }
-opt_inode_align = element opt_inode_align { option }
+opt_inode_align = element opt_inode_align { fs_option }
 opt_max_inode_space =
-  element opt_max_inode_space { option }
-opt_raid = element opt_raid { option }
+  element opt_max_inode_space { fs_option }
+opt_raid = element opt_raid { fs_option }
 opt_reserved_blocks =
-  element opt_reserved_blocks { option }
+  element opt_reserved_blocks { fs_option }
 raid_name = element raid_name { STRING }
 
 raid_options = element raid_options { MAP, (persistent_superblock? & chunk_size? & parity_algorithm? & raid_type? & device_order? & raid_name?) }


### PR DESCRIPTION
- Work around Relax-NG parser error: "Found anyName attribute    without oneOrMore ancestor" ([bsc#1172131](https://bugzilla.opensuse.org/show_bug.cgi?id=1172131)) (companion to https://github.com/yast/yast-installation-control/pull/98)
- Rename 'option' to 'fs_option' to fix a duplicate definition    ([bsc#1170886](https://bugzilla.suse.com/show_bug.cgi?id=1170886))
