### PR TITLE
bsc#1171343: do not propose insecure signature handling settings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed May 27 08:26:35 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not propose insecure signature handling settings when
+  cloning (bsc#1171343).
+- Assign the correct callback when "accept_unknown_digest" is set.
+- Do not export storage settings in the general section
+  unless it is needed (related to bsc#1171356).
+- 4.3.5
+
+-------------------------------------------------------------------
 Fri May 22 09:58:24 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - The network configuration is applied during the first stage by

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.4
+Version:        4.3.5
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstClone.rb
+++ b/src/modules/AutoinstClone.rb
@@ -49,20 +49,7 @@ module Yast
       Mode.SetMode("normal")
 
       general = {}
-
       general["mode"] = { "confirm" => false }
-
-      # Signature handling is less restrictive in a cloned profile.
-      # https://bugzilla.suse.com/show_bug.cgi?id=248303
-      general["signature-handling"] = {
-        "accept_unsigned_file"         => true,
-        "accept_file_without_checksum" => true,
-        "accept_unknown_gpg_key"       => true,
-        "accept_verification_failed"   => false,
-        "import_gpg_key"               => true,
-        "accept_non_trusted_gpg_key"   => true
-      }
-
       general["storage"] = { "start_multipath" => true } if multipath_in_use?
 
       Mode.SetMode("autoinst_config")

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -403,7 +403,7 @@ module Yast
         )
       end
       if Builtins.haskey(@signature_handling, "accept_unknown_digest")
-        Pkg.CallbackAcceptWrongDigest(
+        Pkg.CallbackAcceptUnknownDigest(
           if Ops.get_boolean(@signature_handling, "accept_unknown_digest", false)
             fun_ref(
               AutoInstall.method(:callbackTrue_boolean_string_string_string),

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -490,7 +490,6 @@ module Yast
         if Ops.get_map(Profile.current, "general", {}) != {}
           Import(Ops.get_map(Profile.current, "general", {}))
         end
-        SetSignatureHandling()
       end
       nil
     end

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -34,13 +34,6 @@ module Yast
       # All shared data are in yast2.rpm to break cyclic dependencies
       Yast.import "AutoinstData"
 
-      #
-      # Show proposal and ask user for confirmation to go on with auto-installation
-      # Similar to interactive mode, without letting use change settings
-      # Interactive mode implies confirmation as well..
-      #
-      @Confirm = true
-
       # Running autoyast second_stage
       @second_stage = true
 
@@ -464,7 +457,6 @@ module Yast
       nil
     end
 
-    publish variable: :Confirm, type: "boolean"
     publish variable: :second_stage, type: "boolean"
     publish variable: :mode, type: "map"
     publish variable: :signature_handling, type: "map"

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -11,7 +11,7 @@ describe "Yast::AutoinstGeneral" do
   let(:profile) do
     {
       "storage"            => { "start_multipath" => true },
-      "mode"               => { "confirm" => false },
+      "mode"               => { "confirm" => true },
       "signature-handling" => { "import_gpg_key" => true },
       "ask-list"           => ["ask1"],
       "proposals"          => ["proposal1"]
@@ -23,9 +23,63 @@ describe "Yast::AutoinstGeneral" do
     allow(Yast).to receive(:import).with("FileSystems").and_return(nil)
   end
 
+  describe "#main" do
+    let(:second_stage) { false }
+    let(:imported_profile) { { "general" => general_settings } }
+    let(:general_settings) { { "mode" => true } }
+
+    before do
+      allow(Yast::Stage).to receive(:cont).and_return(second_stage)
+    end
+
+    context "on first stage" do
+      let(:second_stage) { false }
+
+      it "does not try to import the profile" do
+        expect(subject).to_not receive(:Import)
+        subject.main
+      end
+
+      it "does not set the signatures handling callbacks" do
+        expect(subject).to_not receive(:SetSignatureHandling)
+        subject.main
+      end
+    end
+
+    context "on second stage" do
+      let(:second_stage) { true }
+
+      before do
+        allow(Yast::Profile).to receive(:current).and_return(imported_profile)
+      end
+
+      context "and the profile contains a 'general' section" do
+        it "imports the profile" do
+          expect(subject).to receive(:Import).with(general_settings)
+          subject.main
+        end
+      end
+
+      context "and the profile does not contain a 'general' section" do
+        let(:general_settings) { {} }
+
+        it "does not try to import the profile" do
+          expect(subject).to_not receive(:Import)
+          subject.main
+        end
+      end
+
+      it "sets the signatures handling callbacks" do
+        expect(subject).to receive(:SetSignatureHandling)
+        subject.main
+      end
+    end
+  end
+
   describe "#Write" do
     before do
       allow(Yast::AutoinstStorage).to receive(:Write)
+      subject.Import(profile)
     end
 
     context "when a NTP server is set" do
@@ -34,25 +88,21 @@ describe "Yast::AutoinstGeneral" do
       end
 
       it "syncs hardware time" do
-        subject.Import(profile)
-
         expect(Yast::NtpClient).to receive(:sync_once).with("ntp.suse.de").and_return(0)
 
         expect(Yast::SCR).to receive(:Execute).with(path(".target.bash"), "/sbin/hwclock --systohc")
           .and_return(0)
 
-        subject.Write()
+        subject.Write
       end
 
       it "does not sync hardware time if ntp sync failed" do
-        subject.Import(profile)
-
         expect(Yast::NtpClient).to receive(:sync_once).with("ntp.suse.de").and_return(1)
 
         expect(Yast::SCR).to_not receive(:Execute)
           .with(path(".target.bash"), "/sbin/hwclock --systohc")
 
-        subject.Write()
+        subject.Write
       end
     end
 
@@ -63,7 +113,70 @@ describe "Yast::AutoinstGeneral" do
         subject.Import(profile)
         expect(Yast::SCR).not_to receive(:Execute)
           .with(path(".target.bash"), /hwclock/)
-        subject.Write()
+        subject.Write
+      end
+    end
+
+    context "mode options" do
+      context "when mode options are set" do
+        let(:profile) do
+          {
+            "mode" => {
+              "confirm" => true, "second_stage" => true, "halt" => true, "rebootmsg" => true
+            }
+          }
+        end
+
+        it "saves mode options" do
+          expect(Yast::AutoinstConfig).to receive(:second_stage=).with(true)
+          expect(Yast::AutoinstConfig).to receive(:Halt=).with(true)
+          expect(Yast::AutoinstConfig).to receive(:RebootMsg=).with(true)
+          subject.Write
+        end
+      end
+
+      context "when mode options are not set" do
+        let(:profile) { {} }
+
+        it "saves default values" do
+          expect(Yast::AutoinstConfig).to_not receive(:second_stage=)
+          expect(Yast::AutoinstConfig).to receive(:Halt=).with(false)
+          expect(Yast::AutoinstConfig).to receive(:RebootMsg=).with(false)
+          subject.Write
+        end
+      end
+
+      it "sets signature handling callbacks" do
+        expect(subject).to receive(:SetSignatureHandling)
+        subject.Write
+      end
+    end
+
+    context "when 'forceboot' is not set" do
+      it "does not set the kexec_reboot option in the product control" do
+        expect(Yast::ProductFeatures).to_not receive(:SetBooleanFeature)
+          .with("globals", "kexec_reboot", anything)
+        subject.Write
+      end
+    end
+
+    context "when 'forceboot' is set to 'false'" do
+      let(:profile) { { "mode" => { "forceboot" => false } } }
+
+      it "sets the kexec_reboot option in the product control to 'false'" do
+        expect(Yast::ProductFeatures).to_not receive(:SetBooleanFeature)
+          .with("globals", "kexec_reboot", false)
+        subject.Write
+      end
+    end
+
+    context "when 'forceboot' is set to 'true'" do
+      let(:profile) { { "mode" => { "forceboot" => true } } }
+
+      it "sets the kexec_reboot option in the product control to 'true'" do
+        expect(Yast::ProductFeatures).to_not receive(:SetBooleanFeature)
+          .with("globals", "kexec_reboot", true)
+        subject.Write
       end
     end
   end
@@ -234,6 +347,52 @@ describe "Yast::AutoinstGeneral" do
       summary = subject.Summary
       expect(summary).to include("Confirm installation?")
       expect(summary).to include("Signature Handling")
+    end
+
+    context "when signature handling checks are disabled" do
+      before do
+        subject.Import(
+          "signature-handling" => {
+            "accept_unsigned_file"         => true,
+            "accept_file_without_checksum" => true,
+            "accept_verification_failed"   => true,
+            "accept_unknown_gpg_key"       => true,
+            "import_gpg_key"               => true
+          }
+        )
+      end
+
+      it "includes signature settings values" do
+        summary = subject.Summary
+        expect(summary).to include("Accepting unsigned files")
+        expect(summary).to include("Accepting files without a checksum")
+        expect(summary).to include("Accepting failed verifications")
+        expect(summary).to include("Accepting unknown GPG keys")
+        expect(summary).to include("Importing new GPG keys")
+      end
+    end
+
+    context "when signature handling checks are not disabled" do
+      before do
+        subject.Import(
+          "signature-settings" => {
+            "accept_unsigned_file"         => false,
+            "accept_file_without_checksum" => false,
+            "accept_verification_failed"   => false,
+            "accept_unknown_gpg_key"       => false,
+            "import_gpg_key"               => false
+          }
+        )
+      end
+
+      it "includes signature settings values" do
+        summary = subject.Summary
+        expect(summary).to include("Not accepting unsigned files")
+        expect(summary).to include("Not accepting files without a checksum")
+        expect(summary).to include("Not accepting failed verifications")
+        expect(summary).to include("Not accepting unknown GPG Keys")
+        expect(summary).to include("Not importing new GPG Keys")
+      end
     end
   end
 end

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -145,4 +145,95 @@ describe "Yast::AutoinstGeneral" do
       expect(subject.Export).to include("proposals" => profile["proposals"])
     end
   end
+
+  RSpec.shared_examples "sets callback" do |option, cb_map = {}|
+    let(:signature_handling) { {} }
+
+    default_cb = option.split("_").map(&:capitalize).join # e.g., "AcceptUnsignedFile"
+    cb = "Callback#{default_cb}" # e.g., "CallbackAcceptUnsignedFile"
+
+    before do
+      subject.Import("signature-handling" => signature_handling)
+    end
+
+    context cb do
+      context "when '#{option}' is not set" do
+        it "sets '#{default_cb}' as the default handler" do
+          expect(Yast::Pkg).to receive(cb) do |ref|
+            expect(ref.remote_method)
+              .to eq(Yast::SignatureCheckCallbacks.method(default_cb))
+          end
+          subject.SetSignatureHandling
+        end
+      end
+
+      cb_map.each do |cb_name, value|
+        context "when '#{option}' is set to '#{value}'" do
+          let(:signature_handling) do
+            { option => value }
+          end
+
+          it "sets the '#{cb_name}' callback" do
+            expect(Yast::Pkg).to receive(cb).ordered.with(any_args)
+            expect(Yast::Pkg).to receive(cb).ordered do |ref|
+              expect(ref.remote_method).to eq(Yast::AutoInstall.method(cb_name))
+            end
+            subject.SetSignatureHandling
+          end
+        end
+      end
+    end
+  end
+
+  describe "#SetSignatureHandling" do
+    before do
+      subject.Import("signature-handling" => signature_handling)
+    end
+
+    include_examples "sets callback", "accept_unsigned_file",
+      callbackTrue_boolean_string_integer:  true,
+      callbackFalse_boolean_string_integer: false
+
+    include_examples "sets callback", "accept_file_without_checksum",
+      callbackTrue_boolean_string:  true,
+      callbackFalse_boolean_string: false
+
+    include_examples "sets callback", "accept_verification_failed",
+      callbackTrue_boolean_string_map_integer:  true,
+      callbackFalse_boolean_string_map_integer: false
+
+    include_examples "sets callback", "accept_verification_failed",
+      callbackTrue_boolean_string_map_integer:  true,
+      callbackFalse_boolean_string_map_integer: false
+
+    include_examples "sets callback", "accept_unknown_gpg_key",
+      callbackTrue_boolean_string_string_integer:  true,
+      callbackFalse_boolean_string_string_integer: false
+
+    include_examples "sets callback", "accept_wrong_digest",
+      callbackTrue_boolean_string_string_string:  true,
+      callbackFalse_boolean_string_string_string: false
+
+    include_examples "sets callback", "accept_unknown_digest",
+      callbackTrue_boolean_string_string_string:  true,
+      callbackFalse_boolean_string_string_string: false
+
+    include_examples "sets callback", "import_gpg_key",
+      callbackTrue_boolean_map_integer:  true,
+      callbackFalse_boolean_map_integer: false
+
+    include_examples "sets callback", "trusted_key_added",
+      callback_void_map: ["key"]
+
+    include_examples "sets callback", "trusted_key_removed",
+      callback_void_map: ["key"]
+  end
+
+  describe "#Summary" do
+    it "includes information about installation confirmation and signature handling" do
+      summary = subject.Summary
+      expect(summary).to include("Confirm installation?")
+      expect(summary).to include("Signature Handling")
+    end
+  end
 end

--- a/test/autoinst_clone_test.rb
+++ b/test/autoinst_clone_test.rb
@@ -178,7 +178,7 @@ describe Yast::AutoinstClone do
     end
 
     it "includes signature handling settings" do
-      expect(subject.General).to include("signature-handling" => Hash)
+      expect(subject.General).to_not include("signature-handling" => Hash)
     end
 
     context "when multipath is not enabled" do


### PR DESCRIPTION
Merges #618 into `master`. Additionally, it includes:

* Code clean-up for `AutoinstGeneral`.
* A minor fix to not call `SetSignatureHandling` twice.
* Drop the unused `@Confirm` variable.