### PR TITLE
Profile Validation During Installation

### DIFF
--- a/doc/validation.md
+++ b/doc/validation.md
@@ -1,6 +1,6 @@
 # Profile Validation
 
-Since version 4.3.14 AutoYaST validates all XML files (profiles,
+Since version 4.3.15 AutoYaST validates all XML files (profiles,
 rules, classes) before using them to avoid possible problems later.
 
 ## Validation Errors

--- a/doc/validation.md
+++ b/doc/validation.md
@@ -1,0 +1,41 @@
+# Profile Validation
+
+Since version 4.3.9 AutoYaST validates all XML files (profiles,
+rules, classes) before using them to avoid possible problems later.
+
+## Validation Errors
+
+If a XML document does not validate or is not well-formed (contains syntax
+errors) then AutoYaST displays an error popup with details.
+
+It is still possible to continue and use the XML file by clicking the
+`Continue` button. But that is on your risk, the installation might later
+fail or crash, the result will be different than expected or some data
+might be lost.
+
+If you are sure the XML file is correct and the problem is in the validation
+itself you can disable the error popup, see below.
+
+## Manual Validation
+
+Of course, it is much easier to validate the XML files *before* using them.
+The error popup contains some example commands for validating the failed file
+manually. See the [AutoYaST documentation](
+https://doc.opensuse.org/projects/autoyast/#CreateProfile-Manual) for more
+details.
+
+It is recommended to use `jing` for manual validation, it usually produces
+better error messages than `xmllint` (which is also internally used by AutoYaST).
+
+## Disabling Validation
+
+In some rare cases the XML files might work correctly but the validation
+reports errors because of an issue in the schema definition or in the validation
+process itself.
+
+In that case you can set the environment variable `YAST_SKIP_XML_VALIDATION=1`
+to skip the error popups. You can set that directly on the boot command line.
+
+Note: Internally the validation is still done, but the result is only logged
+into the `y2log` file, the error popup is not displayed. This should help with
+debugging AutoYaST problems.

--- a/doc/validation.md
+++ b/doc/validation.md
@@ -1,6 +1,6 @@
 # Profile Validation
 
-Since version 4.3.9 AutoYaST validates all XML files (profiles,
+Since version 4.3.14 AutoYaST validates all XML files (profiles,
 rules, classes) before using them to avoid possible problems later.
 
 ## Validation Errors

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 18 07:35:17 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Validate the XML files before using them (bsc#1173091)
+- Allow disabling the validation by setting
+  YAST_SKIP_XML_VALIDATION=1
+- 4.3.14
+
+-------------------------------------------------------------------
 Fri Jun 12 11:18:00 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoinstGeneral.SetRebootAfterFirstStage is not private

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -66,8 +66,8 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 
 Requires:       autoyast2-installation = %{version}
 Requires:       libxslt
-# AutoYaST issue handling
-Requires:       yast2 >= 4.3.2
+# XML.validate
+Requires:       yast2 >= 4.3.8
 Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
 # Moving security module to first installation stage

--- a/src/include/autoinstall/conftree.rb
+++ b/src/include/autoinstall/conftree.rb
@@ -684,7 +684,6 @@ module Yast
                 AutoinstConfig.currentFile
               )
             )
-            # Profile::checkProfile();
             Profile.changed = false
           else
             Popup.Warning(_("An error occurred while saving the file."))

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -48,7 +48,6 @@ module Y2Autoinstallation
     def readModified
       textdomain "autoinst"
       if Yast::SCR.Read(path(".target.size"), Yast::AutoinstConfig.modified_profile) <= 0
-        puts "NOT FOUND"
         return :not_found
       end
 

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -48,6 +48,7 @@ module Y2Autoinstallation
     def readModified
       textdomain "autoinst"
       if Yast::SCR.Read(path(".target.size"), Yast::AutoinstConfig.modified_profile) <= 0
+        puts "NOT FOUND"
         return :not_found
       end
 

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -19,6 +19,7 @@
 
 require "y2storage"
 require "autoinstall/activate_callbacks"
+require "autoinstall/xml_checks"
 
 Yast.import "Profile"
 
@@ -49,6 +50,8 @@ module Y2Autoinstallation
       if Yast::SCR.Read(path(".target.size"), Yast::AutoinstConfig.modified_profile) <= 0
         return :not_found
       end
+
+      return :abort unless Y2Autoinstallation::XmlChecks.valid_modified_profile?
 
       if !Yast::Profile.ReadXML(Yast::AutoinstConfig.modified_profile) ||
           Yast::Profile.current == {}

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -197,7 +197,7 @@ module Y2Autoinstallation
         Yast::Progress.NextStage
         Yast::Progress.Title(_("Parsing control file"))
 
-        # display an error when the profile is not valid and abort the installation
+        # validate the profile
         return :abort unless Y2Autoinstallation::XmlChecks.valid_profile?
 
         log.info "Parsing control file"

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -195,7 +195,6 @@ module Y2Autoinstallation
 
         Yast::Progress.NextStage
         Yast::Progress.Title(_("Parsing control file"))
-
         log.info "Parsing control file"
         if !Yast::Profile.ReadXML(Yast::AutoinstConfig.xml_tmpfile) || Yast::Profile.current.nil?
           Yast::Popup.Error(

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -1,5 +1,4 @@
 require "autoinstall/autosetup_helpers"
-require "autoinstall/xml_checks"
 require "y2packager/medium_type"
 
 Yast.import "AutoInstall"
@@ -196,9 +195,6 @@ module Y2Autoinstallation
 
         Yast::Progress.NextStage
         Yast::Progress.Title(_("Parsing control file"))
-
-        # validate the profile
-        return :abort unless Y2Autoinstallation::XmlChecks.valid_profile?
 
         log.info "Parsing control file"
         if !Yast::Profile.ReadXML(Yast::AutoinstConfig.xml_tmpfile) || Yast::Profile.current.nil?

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -1,4 +1,5 @@
 require "autoinstall/autosetup_helpers"
+require "autoinstall/xml_checks"
 require "y2packager/medium_type"
 
 Yast.import "AutoInstall"
@@ -195,6 +196,10 @@ module Y2Autoinstallation
 
         Yast::Progress.NextStage
         Yast::Progress.Title(_("Parsing control file"))
+
+        # display an error when the profile is not valid and abort the installation
+        return :abort unless Y2Autoinstallation::XmlChecks.valid_profile?
+
         log.info "Parsing control file"
         if !Yast::Profile.ReadXML(Yast::AutoinstConfig.xml_tmpfile) || Yast::Profile.current.nil?
           Yast::Popup.Error(

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -42,6 +42,12 @@ module Y2Autoinstallation
       check(Yast::AutoinstConfig.xml_tmpfile, PROFILE_SCHEMA, msg)
     end
 
+    def self.valid_modified_profile?
+      # TRANSLATORS: Error message
+      msg = _("The AutoYaST pre-script generated an invalid XML document.")
+      check(Yast::AutoinstConfig.modified_profile, PROFILE_SCHEMA, msg)
+    end
+
     def self.valid_rules?
       # TRANSLATORS: Error message
       msg = _("The AutoYaST rules file is not a valid XML document.")

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -36,10 +36,10 @@ module Y2Autoinstallation
     RULES_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/rules.rng".freeze
     CLASSES_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/classes-use.rng".freeze
 
-    def self.valid_profile?
+    def self.valid_profile?(file = Yast::AutoinstConfig.xml_tmpfile)
       # TRANSLATORS: Error message
       msg = _("The AutoYaST profile is not a valid XML document.")
-      check(Yast::AutoinstConfig.xml_tmpfile, PROFILE_SCHEMA, msg)
+      check(file, PROFILE_SCHEMA, msg)
     end
 
     def self.valid_modified_profile?

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -30,7 +30,6 @@ module Y2Autoinstallation
   # Validates an AutoYaST XML document and displays an error popup
   # for not well formed or invalid documents. It is possible to continue
   # anyway and ignore the found problems at your risk.
-  # 
   class XmlChecks
     extend Yast::Logger
     extend Yast::I18n

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -27,39 +27,59 @@ Yast.import "AutoinstConfig"
 Yast.import "Report"
 
 module Y2Autoinstallation
+  # Validates an AutoYaST XML document and displays an error popup
+  # for not well formed or invalid documents. It is possible to continue
+  # anyway and ignore the found problems at your risk.
+  # 
   class XmlChecks
     extend Yast::Logger
     extend Yast::I18n
     textdomain "autoinst"
 
+    # paths to the default AutoYaST schema files
     PROFILE_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/profile.rng".freeze
     RULES_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/rules.rng".freeze
     CLASSES_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/classes-use.rng".freeze
 
+    # Is the file a valid AutoYaST XML profile?
+    # @param file [String] pahth to the classes file
+    # @return [Boolean] true if valid, false otherwise
     def self.valid_profile?(file = Yast::AutoinstConfig.xml_tmpfile)
       # TRANSLATORS: Error message
       msg = _("The AutoYaST profile is not a valid XML document.")
       check(file, PROFILE_SCHEMA, msg)
     end
 
+    # Is the file a valid AutoYaST XML profile?
+    # @return [Boolean] true if valid, false otherwise
     def self.valid_modified_profile?
       # TRANSLATORS: Error message
       msg = _("The AutoYaST pre-script generated an invalid XML document.")
       check(Yast::AutoinstConfig.modified_profile, PROFILE_SCHEMA, msg)
     end
 
+    # Is the file a valid AutoYaST rules file?
+    # @return [Boolean] true if valid, false otherwise
     def self.valid_rules?
       # TRANSLATORS: Error message
       msg = _("The AutoYaST rules file is not a valid XML document.")
       check(Yast::AutoinstConfig.local_rules_file, RULES_SCHEMA, msg)
     end
 
+    # Is the file a valid AutoYaST class file?
+    # @param file [String] path to the classes file
+    # @return [Boolean] true if valid, false otherwise
     def self.valid_classes?(file)
       # TRANSLATORS: Error message
       msg = _("The AutoYaST class file is not a valid XML document.")
       check(file, RULES_SCHEMA, msg)
     end
 
+    # generic validation check
+    # @param file [String] path to the XML file
+    # @param schema [String] path to the RNG schema
+    # @param msg [String] title displayed in the popup when validation fails
+    # @return [Boolean] true if valid, false otherwise
     def self.check(file, schema, msg)
       validator = XmlValidator.new(file, schema)
       return true if validator.valid?
@@ -80,6 +100,11 @@ module Y2Autoinstallation
       ret
     end
 
+    # an internal helper for building the error message
+    # @param msg [String] title text
+    # @param errors [Array<String>] list of validation errors
+    # @param file [String] path to the XML file (only the base name is displayed)
+    # @param schema [String] path to the RNG schema
     def self.message(msg, errors, file, schema)
       xml_file = File.basename(file)
       jing_command = "jing #{schema} #{xml_file}"
@@ -92,7 +117,8 @@ module Y2Autoinstallation
         "</p><h4>" + _("Details") + "</h4>" + ERB::Util.html_escape(errors.join("<br>")) +
         "<h4>" + _("Note") + "</h4>" +
         # TRANSLATORS: A hints how to check a XML file, displayed as a part of the
-        # validation error message, %{jing} and %{xmllint} are replaced by shell commands
+        # validation error message, %{jing} and %{xmllint} are replaced by shell commands,
+        # use HTML tags and entities (non-breaking space) for formatting the message
         "<p>" + format(_("You can check the file manually with these commands:<br><br>" \
         "&nbsp;&nbsp;%{jing}<br>" \
         "&nbsp;&nbsp;%{xmllint}"), jing: jing_command, xmllint: xmllint_command) + "</p>"

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -72,9 +72,8 @@ module Y2Autoinstallation
       ret = Yast2::Popup.show(message(msg, validator.errors, file, schema),
         richtext: true,
         headline: :error,
-        buttons: :continue_cancel,
-        focus: :cancel
-      ) == :continue
+        buttons:  :continue_cancel,
+        focus:    :cancel) == :continue
 
       log.warn "Skipping invalid XML on user request!" if ret
 
@@ -87,16 +86,16 @@ module Y2Autoinstallation
       xmllint_command = "xmllint --noout --relaxng #{schema} #{xml_file}"
 
       "<h3>" + msg + "</h3>" + "<p>" +
-      # TRANSLATORS: Warn user about using invalid XML
-      _("Using an invalid XML document might result in an unexpected behavior, crash or even data loss!") +
-      "</p><h4>" + _("Details") + "</h4>" + ERB::Util.html_escape(errors.join("<br>")) +
-      "<h4>" + _("Note") + "</h4>" +
-      # TRANSLATORS: A hints how to check a XML file, displayed as a part of the
-      # validation error message, %{jing} and %{xmllint} are replaced by shell commands
-      "<p>" + _("You can check the file manually with these commands:<br><br>" \
+        # TRANSLATORS: Warn user about using invalid XML
+        _("Using an invalid XML document might result in an unexpected behavior, " \
+          "crash or even data loss!") +
+        "</p><h4>" + _("Details") + "</h4>" + ERB::Util.html_escape(errors.join("<br>")) +
+        "<h4>" + _("Note") + "</h4>" +
+        # TRANSLATORS: A hints how to check a XML file, displayed as a part of the
+        # validation error message, %{jing} and %{xmllint} are replaced by shell commands
+        "<p>" + format(_("You can check the file manually with these commands:<br><br>" \
         "&nbsp;&nbsp;%{jing}<br>" \
-        "&nbsp;&nbsp;%{xmllint}"
-      ) % {jing: jing_command, xmllint: xmllint_command} + "</p>"
+        "&nbsp;&nbsp;%{xmllint}"), jing: jing_command, xmllint: xmllint_command) + "</p>"
     end
 
     private_class_method :message

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -115,7 +115,7 @@ module Y2Autoinstallation
           "crash or even data loss!") +
         "</p><h4>" + _("Details") + "</h4>" + ERB::Util.html_escape(errors.join("<br>")) +
         "<h4>" + _("Note") + "</h4>" +
-        # TRANSLATORS: A hints how to check a XML file, displayed as a part of the
+        # TRANSLATORS: A hint how to check a XML file, displayed as a part of the
         # validation error message, %{jing} and %{xmllint} are replaced by shell commands,
         # use HTML tags and entities (non-breaking space) for formatting the message
         "<p>" + format(_("You can check the file manually with these commands:<br><br>" \

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -1,0 +1,82 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+require "autoinstall/xml_validator"
+require "yast2/popup"
+
+Yast.import "AutoinstConfig"
+
+module Y2Autoinstallation
+  class XmlChecks
+    extend Yast::Logger
+    extend Yast::I18n
+    textdomain "autoinst"
+
+    PROFILE_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/profile.rng".freeze
+    RULES_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/rules.rng".freeze
+    CLASSES_SCHEMA = "/usr/share/YaST2/schema/autoyast/rng/classes-use.rng".freeze
+
+    def self.valid_profile?
+      # TRANSLATORS: Error message
+      msg = _("The AutoYaST profile is not a valid XML document.")
+      check(Yast::AutoinstConfig.xml_tmpfile, PROFILE_SCHEMA, msg)
+    end
+
+    def self.valid_rules?
+      # TRANSLATORS: Error message
+      msg = _("The AutoYaST rules file is not a valid XML document.")
+      check(Yast::AutoinstConfig.local_rules_file, RULES_SCHEMA, msg)
+    end
+
+    def self.valid_classes?(file)
+      # TRANSLATORS: Error message
+      msg = _("The AutoYaST class file is not a valid XML document.")
+      check(file, RULES_SCHEMA, msg)
+    end
+
+    def self.check(file, schema, msg)
+      validator = XmlValidator.new(file, schema)
+      return true if validator.valid?
+
+      Yast2::Popup.show(error_message(msg, file, schema),
+        headline: :error, details: validator.errors.join("\n"),
+        buttons: { abort: Yast::Label.AbortButton })
+      false
+    end
+
+    private_class_method :check
+
+    def self.error_message(msg, file, schema)
+      xml_file = File.basename(file)
+      jing_command = "jing #{schema} #{xml_file}"
+      xmllint_command = "xmllint --noout --relaxng #{schema} #{xml_file}"
+
+      # TRANSLATORS: A hints how to check a XML file, displayed as a part of the
+      # validation error message, %{jing} and %{xmllint} are replaced by shell commands
+      msg += "\n\n" + _("You can check the file with these commands:\n\n" \
+        "  %{jing}\n" \
+        "  %{xmllint}"
+      ) % {jing: jing_command, xmllint: xmllint_command}
+    end
+
+    private_class_method :error_message
+  end
+end

--- a/src/lib/autoinstall/xml_validator.rb
+++ b/src/lib/autoinstall/xml_validator.rb
@@ -22,17 +22,25 @@ require "yast"
 Yast.import "XML"
 
 module Y2Autoinstallation
+  # Validates an XML document against a given RNG schema
   class XmlValidator
     include Yast::Logger
 
     attr_reader :xml, :schema
 
+    # Constructor
+    # @param xml [String] XML document or path to a XML file
+    # @param schema [String] path to the RNG schema
     def initialize(xml, schema)
       @xml = xml
       @schema = schema
       @errors = nil
     end
 
+    # runs the validation
+    # @return [Array<String>] Returns a list of errors, if the document is not
+    #  well formed it contains syntax errors, if it is not valid it contains
+    #  the validation errors, if it is valid it returns an empty list
     def errors
       return @errors if @errors
 
@@ -40,6 +48,9 @@ module Y2Autoinstallation
       @errors
     end
 
+    # runs the validation
+    # @return [Boolean] returns true if the document is well formed and valid,
+    #  false otherwise
     def valid?
       return @errors.empty? if @errors
 

--- a/src/lib/autoinstall/xml_validator.rb
+++ b/src/lib/autoinstall/xml_validator.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "pathname"
 
 Yast.import "XML"
 
@@ -29,7 +30,7 @@ module Y2Autoinstallation
     attr_reader :xml, :schema
 
     # Constructor
-    # @param xml [String] XML document or path to a XML file
+    # @param xml [String] path to a XML file
     # @param schema [String] path to the RNG schema
     def initialize(xml, schema)
       @xml = xml
@@ -58,10 +59,8 @@ module Y2Autoinstallation
   private
 
     def validate
-      # do not log whole document, only if it is a path
-      log_xml = xml.include?("\n") ? xml : "[XML document #{xml.bytesize} bytes]"
-      log.info "Validating #{log_xml} against #{schema}..."
-      @errors = Yast::XML.validate(xml, schema)
+      log.info "Validating #{xml} against #{schema}..."
+      @errors = Yast::XML.validate(Pathname.new(xml), Pathname.new(schema))
 
       if errors.empty?
         log.info "The XML is valid"

--- a/src/lib/autoinstall/xml_validator.rb
+++ b/src/lib/autoinstall/xml_validator.rb
@@ -35,17 +35,19 @@ module Y2Autoinstallation
 
     def errors
       return @errors if @errors
+
       validate
       @errors
     end
 
     def valid?
       return @errors.empty? if @errors
+
       validate
       @errors.empty?
     end
 
-    private
+  private
 
     def validate
       log.info "Validating #{xml} against #{schema}..."
@@ -58,7 +60,7 @@ module Y2Autoinstallation
       end
     rescue Yast::XMLDeserializationError => e
       log.error "Cannot parse XML: #{e.message}"
-      @errors = [ e.message ]
+      @errors = [e.message]
     end
   end
 end

--- a/src/lib/autoinstall/xml_validator.rb
+++ b/src/lib/autoinstall/xml_validator.rb
@@ -48,12 +48,6 @@ module Y2Autoinstallation
     private
 
     def validate
-      if ENV["YAST_SKIP_XML_VALIDATION"] == "1"
-        log.info "Skipping XML validation on user request"
-        @errors = []
-        return
-      end
-
       log.info "Validating #{xml} against #{schema}..."
       @errors = Yast::XML.validate(xml, schema)
 

--- a/src/lib/autoinstall/xml_validator.rb
+++ b/src/lib/autoinstall/xml_validator.rb
@@ -52,16 +52,15 @@ module Y2Autoinstallation
     # @return [Boolean] returns true if the document is well formed and valid,
     #  false otherwise
     def valid?
-      return @errors.empty? if @errors
-
-      validate
-      @errors.empty?
+      errors.empty?
     end
 
   private
 
     def validate
-      log.info "Validating #{xml} against #{schema}..."
+      # do not log whole document, only if it is a path
+      log_xml = xml.include?("\n") ? xml : "[XML document #{xml.bytesize} bytes]"
+      log.info "Validating #{log_xml} against #{schema}..."
       @errors = Yast::XML.validate(xml, schema)
 
       if errors.empty?

--- a/src/lib/autoinstall/xml_validator.rb
+++ b/src/lib/autoinstall/xml_validator.rb
@@ -1,0 +1,70 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+Yast.import "XML"
+
+module Y2Autoinstallation
+  class XmlValidator
+    include Yast::Logger
+
+    attr_reader :xml, :schema
+
+    def initialize(xml, schema)
+      @xml = xml
+      @schema = schema
+      @errors = nil
+    end
+
+    def errors
+      return @errors if @errors
+      validate
+      @errors
+    end
+
+    def valid?
+      return @errors.empty? if @errors
+      validate
+      @errors.empty?
+    end
+
+    private
+
+    def validate
+      if ENV["YAST_SKIP_XML_VALIDATION"] == "1"
+        log.info "Skipping XML validation on user request"
+        @errors = []
+        return
+      end
+
+      log.info "Validating #{xml} against #{schema}..."
+      @errors = Yast::XML.validate(xml, schema)
+
+      if errors.empty?
+        log.info "The XML is valid"
+      else
+        log.error "XML validation errors: #{errors.inspect}"
+      end
+    rescue Yast::XMLDeserializationError => e
+      log.error "Cannot parse XML: #{e.message}"
+      @errors = [ e.message ]
+    end
+  end
+end

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -897,6 +897,9 @@ module Yast
       @tomerge.each_with_index do |file, iter|
         log.info("Working on file: #{file}")
         current_profile = File.join(AutoinstConfig.local_rules_location, file)
+
+        error = true unless Y2Autoinstallation::XmlChecks.valid_profile?(current_profile)
+
         dest_profile = (iter == 0) ? base_profile : cleaned_profile
         if !XML_cleanup(current_profile, dest_profile)
           log.error("Error reading XML file")

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -5,6 +5,7 @@
 #
 # $Id$
 require "yast"
+require "autoinstall/xml_checks"
 require "yast2/popup"
 require "y2storage"
 
@@ -425,6 +426,8 @@ module Yast
     # Read rules file
     # @return [void]
     def Read
+      # display an error when the rules file is not valid
+      Y2Autoinstallation::XmlChecks.valid_rules?
       @UserRules = XML.XMLToYCPFile(AutoinstConfig.local_rules_file)
 
       if @UserRules.nil?

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -898,7 +898,10 @@ module Yast
         log.info("Working on file: #{file}")
         current_profile = File.join(AutoinstConfig.local_rules_location, file)
 
-        error = true unless Y2Autoinstallation::XmlChecks.valid_profile?(current_profile)
+        if !Y2Autoinstallation::XmlChecks.valid_profile?(current_profile)
+          error = true
+          next
+        end
 
         dest_profile = (iter == 0) ? base_profile : cleaned_profile
         if !XML_cleanup(current_profile, dest_profile)

--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -426,8 +426,6 @@ module Yast
     # Read rules file
     # @return [void]
     def Read
-      # display an error when the rules file is not valid
-      Y2Autoinstallation::XmlChecks.valid_rules?
       @UserRules = XML.XMLToYCPFile(AutoinstConfig.local_rules_file)
 
       if @UserRules.nil?

--- a/src/modules/AutoinstClass.rb
+++ b/src/modules/AutoinstClass.rb
@@ -51,9 +51,8 @@ module Yast
 
     # Reads classes
     def Read
-      if SCR.Read(path(".target.size"), @classPath) != -1
-        # display an error when the rules file is not valid
-        Y2Autoinstallation::XmlChecks.valid_classes?(@classPath)
+      if SCR.Read(path(".target.size"), @classPath) != -1 &&
+          Y2Autoinstallation::XmlChecks.valid_classes?(@classPath)
 
         # TODO: use XML module
         classes_map = Convert.to_map(SCR.Read(path(".xml"), @classPath))

--- a/src/modules/AutoinstClass.rb
+++ b/src/modules/AutoinstClass.rb
@@ -12,6 +12,7 @@
 #
 # $Id$
 require "yast"
+require "autoinstall/xml_checks"
 
 module Yast
   class AutoinstClassClass < Module
@@ -51,6 +52,9 @@ module Yast
     # Reads classes
     def Read
       if SCR.Read(path(".target.size"), @classPath) != -1
+        # display an error when the rules file is not valid
+        Y2Autoinstallation::XmlChecks.valid_classes?(@classPath)
+
         # TODO: use XML module
         classes_map = Convert.to_map(SCR.Read(path(".xml"), @classPath))
         @Classes = (classes_map && classes_map["classes"]) || []

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -737,6 +737,7 @@ module Yast
         "\n"
       valid = true
 
+      # TODO: Use Yast::XML.validate instead of external xmllint
       validators = [
         [
           _("Checking XML with RNG validation..."),

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -734,69 +734,10 @@ module Yast
       deep_copy(m)
     end
 
+    # @deprecated Unused, removed
     def checkProfile
-      file = Ops.add(Ops.add(AutoinstConfig.tmpDir, "/"), "valid.xml")
-      Save(file)
-      summary = "Some schema check failed!\n" \
-        "Please attach your logfile to bug id 211014\n" \
-        "\n"
-      valid = true
-
-      # TODO: Use Yast::XML.validate instead of external xmllint
-      validators = [
-        [
-          _("Checking XML with RNG validation..."),
-          Ops.add(
-            Ops.add("/usr/bin/xmllint --noout --relaxng ", Directory.schemadir),
-            "/autoyast/rng/profile.rng"
-          ),
-          ""
-        ]
-      ]
-      if !Stage.cont && PackageSystem.Installed("jing")
-        validators = Builtins.add(
-          validators,
-          [
-            _("Checking XML with RNC validation..."),
-            Ops.add(
-              Ops.add("/usr/bin/jing >&2 -c ", Directory.schemadir),
-              "/autoyast/rnc/profile.rnc"
-            ),
-            "jing_sucks"
-          ]
-        )
-      end
-
-      Builtins.foreach(validators) do |i|
-        header = Ops.get_string(i, 0, "")
-        cmd = Ops.add(Ops.add(Ops.get_string(i, 1, ""), " "), file)
-        summary = Ops.add(Ops.add(summary, header), "\n")
-        o = Convert.to_map(SCR.Execute(path(".target.bash_output"), cmd))
-        Builtins.y2debug("validation output: %1", o)
-        summary = Ops.add(Ops.add(summary, cmd), "\n")
-        summary = Ops.add(
-          Ops.add(summary, Ops.get_string(o, "stderr", "")),
-          "\n"
-        )
-        summary = Ops.add(summary, "\n")
-        if Ops.get_integer(o, "exit", 1) != 0 ||
-            Ops.get_string(i, 2, "") == "jing_sucks" &&
-                Ops.greater_than(
-                  Builtins.size(Ops.get_string(o, "stderr", "")),
-                  0
-                )
-          valid = false
-        end
-      end
-      if !valid
-        Popup.Error(summary)
-        Builtins.y2milestone(
-          "Profile check failed please attach the log to bug id 211014: %1",
-          summary
-        )
-      end
-
-      nil
+      log.warn("Profile.checkProfile() is obsolete, do not use it")
+      log.warn("Called from #{caller(1).first}")
     end
 
     # Removes the given sections from the profile

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -5,6 +5,8 @@
 #
 # $Id$
 require "yast"
+
+require "autoinstall/xml_checks"
 require "y2storage"
 
 module Yast
@@ -199,6 +201,9 @@ module Yast
       try_default_rules = false
       if AutoInstallRules.userrules
         Builtins.y2milestone("Reading Rules File")
+        # display an error when the rules file is not valid and return false
+        return false unless Y2Autoinstallation::XmlChecks.valid_rules?
+
         AutoInstallRules.Read
         # returns false if no rules have matched
         ret = AutoInstallRules.GetRules
@@ -224,6 +229,9 @@ module Yast
 
       if process_rules
         rulesret = AutoInstallRules.Process(AutoinstConfig.xml_tmpfile)
+        # validate the profile
+        return false if rulesret && !Y2Autoinstallation::XmlChecks.valid_profile?
+
         Builtins.y2milestone("rulesret=%1", rulesret)
         return rulesret
       end

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -176,6 +176,8 @@ module Yast
         )
       end
 
+      return false if !is_directory && !Y2Autoinstallation::XmlChecks.valid_profile?
+
       ret = if is_directory
         Get(
           AutoinstConfig.scheme,

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -6,7 +6,10 @@ Yast.import "AutoInstallRules"
 
 describe "Yast::AutoInstallRules" do
   subject { Yast::AutoInstallRules }
-  before { Y2Storage::StorageManager.create_test_instance }
+  before do
+    Y2Storage::StorageManager.create_test_instance
+    allow(Y2Autoinstallation::XmlChecks).to receive(:valid_profile?).and_return(true)
+  end
 
   let(:root_path) { File.expand_path("..", __dir__) }
 

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -6,6 +6,7 @@ Yast.import "AutoInstallRules"
 
 describe "Yast::AutoInstallRules" do
   subject { Yast::AutoInstallRules }
+
   before do
     Y2Storage::StorageManager.create_test_instance
     allow(Y2Autoinstallation::XmlChecks).to receive(:valid_profile?).and_return(true)

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -318,6 +318,15 @@ describe "Yast::AutoInstallRules" do
       end
     end
 
+    context "when a profile is not valid" do
+      it "returns false" do
+        subject.CreateFile("first.xml")
+        expect(Y2Autoinstallation::XmlChecks).to receive(:valid_profile?)
+          .and_return(false)
+        expect(subject.Merge(result_path)).to eq(false)
+      end
+    end
+
     context "when only one XML profile is given" do
       it "does read but not merge this XML profile" do
         subject.CreateFile("first.xml")

--- a/test/AutoinstClass_test.rb
+++ b/test/AutoinstClass_test.rb
@@ -16,6 +16,7 @@ describe "Yast::AutoinstClass" do
 
   before(:each) do
     subject.class_dir = CLASS_DIR
+    allow(Y2Autoinstallation::XmlChecks).to receive(:valid_classes?).and_return(true)
   end
 
   describe "#Read" do

--- a/test/AutoinstClass_test.rb
+++ b/test/AutoinstClass_test.rb
@@ -51,6 +51,7 @@ describe "Yast::AutoinstClass" do
       before(:each) do
         allow(Yast::SCR).to receive(:Read).and_call_original
         allow(Yast::SCR).to receive(:Read).with(Yast::Path.new(".xml"), CLASS_PATH).and_return(nil)
+        expect(Y2Autoinstallation::XmlChecks).to receive(:valid_classes?).and_return(false)
       end
 
       it "set Classes to []" do

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -210,6 +210,21 @@ describe Y2Autoinstallation::AutosetupHelpers do
           expect(client.readModified).to eq(:abort)
         end
       end
+
+      context "when the modified profile is not valid" do
+        before do
+          expect(Y2Autoinstallation::XmlChecks).to receive(:valid_modified_profile?).and_return(false)
+        end
+
+        it "returns :abort" do
+          expect(client.readModified).to eq(:abort)
+        end
+
+        it "sets modified_profile? to false" do
+          client.readModified
+          expect(client.modified_profile?).to eq(false)
+        end
+      end
     end
 
     context "when modified profile does not exist" do

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -33,6 +33,10 @@ describe Y2Autoinstallation::AutosetupHelpers do
   subject(:client) { DummyClient.new }
   let(:profile_dir_path) { File.join(TESTS_PATH, "tmp") }
 
+  before do
+    allow(Y2Autoinstallation::XmlChecks).to receive(:valid_modified_profile?).and_return(true)
+  end
+
   describe "#probe_storage" do
     let(:storage_manager) { double(Y2Storage::StorageManager) }
 

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -213,7 +213,8 @@ describe Y2Autoinstallation::AutosetupHelpers do
 
       context "when the modified profile is not valid" do
         before do
-          expect(Y2Autoinstallation::XmlChecks).to receive(:valid_modified_profile?).and_return(false)
+          expect(Y2Autoinstallation::XmlChecks).to receive(:valid_modified_profile?)
+            .and_return(false)
         end
 
         it "returns :abort" do

--- a/test/lib/xml_checks_test.rb
+++ b/test/lib/xml_checks_test.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "autoinstall/xml_checks"
+
+describe Y2Autoinstallation::XmlChecks do
+
+  before do
+    # mock the popup to avoid accidentally displaying a popup in tests
+    allow(Yast2::Popup).to receive(:show)
+  end
+
+  describe ".valid_profile?" do
+    before do
+      expect_any_instance_of(Y2Autoinstallation::XmlValidator).to receive(:valid?)
+        .and_return(valid)
+    end
+
+    context "valid profile" do
+      let(:valid) { true }
+    end
+
+    context "invalid profile" do
+      let(:valid) { false }
+
+    end
+  end
+end

--- a/test/lib/xml_validator_test.rb
+++ b/test/lib/xml_validator_test.rb
@@ -4,9 +4,11 @@ require_relative "../test_helper"
 require "autoinstall/xml_validator"
 
 describe Y2Autoinstallation::XmlValidator do
-  let(:xml) { "foo.xml" }
-  let(:schema) { "bar.rng" }
-  subject { Y2Autoinstallation::XmlValidator.new(xml, schema) }
+  let(:xml_name) { "foo.xml" }
+  let(:schema_name) { "bar.rng" }
+  let(:xml) { Pathname.new(xml_name) }
+  let(:schema) { Pathname.new(schema_name) }
+  subject { Y2Autoinstallation::XmlValidator.new(xml_name, schema_name) }
 
   describe "#valid?" do
     it "returns true if Yast::XML.validate returns no errors" do

--- a/test/lib/xml_validator_test.rb
+++ b/test/lib/xml_validator_test.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "autoinstall/xml_validator"
+
+describe Y2Autoinstallation::XmlValidator do
+  let(:xml) { "foo.xml" }
+  let(:schema) { "bar.rng" }
+  subject { Y2Autoinstallation::XmlValidator.new(xml, schema) }
+
+  describe "#valid?" do
+    it "returns true if Yast::XML.validate returns no errors" do
+      expect(Yast::XML).to receive(:validate).with(xml, schema).and_return([])
+      expect(subject.valid?).to be true
+    end
+
+    it "returns false if Yast::XML.validate returns some error" do
+      expect(Yast::XML).to receive(:validate).with(xml, schema).and_return(["ERROR"])
+      expect(subject.valid?).to be false
+    end
+
+    it "returns false if Yast::XML.validate fails with parse error" do
+      expect(Yast::XML).to receive(:validate).with(xml, schema)
+        .and_raise(Yast::XMLDeserializationError)
+      expect(subject.valid?).to be false
+    end
+  end
+
+  describe "#errors" do
+    it "returns empty list if Yast::XML.validate returns no errors" do
+      expect(Yast::XML).to receive(:validate).with(xml, schema).and_return([])
+      expect(subject.errors).to eq([])
+    end
+
+    it "returns errors from Yast::XML.validate" do
+      expect(Yast::XML).to receive(:validate).with(xml, schema).and_return(["ERROR"])
+      expect(subject.errors).to eq(["ERROR"])
+    end
+
+    it "returns the parse false if Yast::XML.validate fails with parse error" do
+      expect(Yast::XML).to receive(:validate).with(xml, schema)
+        .and_raise(Yast::XMLDeserializationError.new("error"))
+      expect(subject.errors).to eq(["error"])
+    end
+  end
+end


### PR DESCRIPTION
## The Problem

It would be nice to check whether the given profile is valid or not while running AutoYaST. Now that we have an API that allows for that, we should integrate it into the installer.

- [Trello card](https://trello.com/c/nNTAyFqA)
- [Bugzilla bug](https://bugzilla.suse.com/show_bug.cgi?id=1173091)

## Details

The XML YaST module now supports XML validation via the nokogiri backend.

To make the code better structured I created two helper classes: generic `XmlValidator` which validates a XML file against a schema (without UI) and `XmlChecks` which uses the validator and check the AutoYaST files against the AutoYaST schema (displays an error popup when validation fails).

### Skipping Validation

Because now the validation is mandatory and it already happened that we had a bug in the schema it should be possible to easily disable the validation check.

The code checks the `YAST_SKIP_XML_VALIDATION` environment variable and if it is set to `1` then the error popup is not displayed. But the validation is still done and the result is logged into the y2log. This should help when debugging AutoYaST issues.

## Screenshots

![validation_popup](https://user-images.githubusercontent.com/907998/84365371-a308d100-abd1-11ea-862f-5dc63aff6af5.png)

This error is displayed for invalid `software.xml` class file. The message is a bit different depending of the file type (profile/rules/classes). It also uses the real XML file name. (Using the full path is not possible as at the validation point we do not exactly know from where the file was downloaded. But that should be still a good hint for the user.)

The user can press "Continue" to ignore the validation error (but maybe something can go wrong later, it's the user responsibility) or press "Cancel" which report internally an error and YaST will ask for the profile in a popup. So the user has a chance to either fix the profile or use a completely different URL.

![validation_retry](https://user-images.githubusercontent.com/907998/84502461-a62abc80-acb8-11ea-8810-21a878a0a45c.png)


## Notes

- The `yast2-schema` package is already present in the inst-sys, in all SLE, Leap and TW. No change needed.

## Tests

Tested manually in these scenarios:

- Minimal profile
- Minimal profile with pre-script which modifies the XML profile
- With a simple rule
- With one AY class


## Memory Consumption

It seems that validation takes about 8MB of memory after it finishes. It does not matter much how big the profiles is. The question is how big is the peak *during* validation...

I wanted to test it in 512MB RAM installation, but the latest Tumbleweed ISO does not work with such a small memory, it hangs in linuxrc when loading the inst-sys images, even before starting YaST... :worried: 

<details>
 <summary>Click to see details</summary>

#### Minimal Profile

Size: ~500B

Before running validation:
```
VmData:    18668 kB
VmStk:      8188 kB
VmExe:         4 kB
VmLib:     40364 kB
VmPTE:       472 kB
VmPMD:        12 kB
VmSwap:        0 kB
```

After running validation:
```
VmData:    26484 kB
VmStk:      8188 kB
VmExe:         4 kB
VmLib:     40364 kB
VmPTE:       488 kB
VmPMD:        12 kB
VmSwap:        0 kB
```

#### Large Profile

Size: ~26kB

Before running validation:
```
VmData:    18620 kB
VmStk:      8188 kB
VmExe:         4 kB
VmLib:     40364 kB
VmPTE:       464 kB
VmPMD:        12 kB
VmSwap:        0 kB
```

After running validation:
```
VmData:    26924 kB
VmStk:      8188 kB
VmExe:         4 kB
VmLib:     40364 kB
VmPTE:       480 kB
VmPMD:        12 kB
VmSwap:        0 kB
```

</details>


## TODO

- [x] Measure memory impact
- [x] Unit tests
- [x] Documentation comments
- [x] Documentation
- [ ] Update the official AY documentation