### PR TITLE
Permit to use CDATA in the ntp_policy attribute

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 12 13:15:42 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Export ntp_policy as CDATA so that empty strings are preserved
+  during for the second_stage (bsc#1172026)
+- 4.1.17
+
+-------------------------------------------------------------------
 Wed May 20 22:00:01 UTC 2020 - David Díaz <dgonzalez@suse.com>
 
 - Revamp the storage client user interface, adapting it to the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.1.16
+Version:        4.1.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/xml.rb
+++ b/src/include/autoinstall/xml.rb
@@ -124,7 +124,8 @@ module Yast
           "location",
           "script_source",
           "media_url",
-          "subvolumes_prefix"
+          "subvolumes_prefix",
+          "ntp_policy"
         ]
       )
       #            doc["systemID"] = "/usr/share/autoinstall/dtd/profile.dtd";


### PR DESCRIPTION
## Problem

As a user I would like to disable the update of the ntp servers through netconfig. That is, I would like to set the netconfig NTP_POLICY as "" (disable) in the AutoYaST profile ntp section.

The problem is that the ntp_policy attribute is empty and it is omitted when serializing the profile at the end of the first stage.

- https://bugzilla.suse.com/show_bug.cgi?id=1172026

## Solution

Export ntp_policy via CDATA so that empty strings are preserved for the second stage.

Maybe we should do the same with other netconfig policy options.

## Test

- Tested manually

#### Without the fix the attribute is deleted from the YCP profile
![autoinstall.ycp](https://user-images.githubusercontent.com/7056681/84479314-a4e29b00-ac8a-11ea-8a72-f93250a6d68f.png)

#### With the fix the attribute contain an empty string in the YCP profile
![autoinstall.ycp](https://user-images.githubusercontent.com/7056681/84479319-a6ac5e80-ac8a-11ea-991f-3160da47bb57.png)

