### PR TITLE
[bsc#1172865] SetRebootAfterFirstStage is not private anymore

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 12 11:18:00 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoinstGeneral.SetRebootAfterFirstStage is not private
+  anymore (bsc#1172865).
+- 4.3.13
+
+-------------------------------------------------------------------
 Thu Jun 11 20:44:06 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not export Report section when cloning system as it is always

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.12
+Version:        4.3.13
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -457,6 +457,21 @@ module Yast
       nil
     end
 
+    # Set the "kexec_reboot" flag in the product
+    # description in order to force a reboot with
+    # kexec at the end of the first installation
+    # stage.
+    # @return [void]
+    def SetRebootAfterFirstStage
+      return unless mode.key?("forceboot")
+
+      ProductFeatures.SetBooleanFeature(
+        "globals",
+        "kexec_reboot",
+        !mode["forceboot"]
+      )
+    end
+
     publish variable: :second_stage, type: "boolean"
     publish variable: :mode, type: "map"
     publish variable: :signature_handling, type: "map"
@@ -476,21 +491,6 @@ module Yast
   private
 
     attr_reader :cio_ignore
-
-    # Set the "kexec_reboot" flag in the product
-    # description in order to force a reboot with
-    # kexec at the end of the first installation
-    # stage.
-    # @return [void]
-    def SetRebootAfterFirstStage
-      return unless mode.key?("forceboot")
-
-      ProductFeatures.SetBooleanFeature(
-        "globals",
-        "kexec_reboot",
-        !mode["forceboot"]
-      )
-    end
   end
 
   AutoinstGeneral = AutoinstGeneralClass.new


### PR DESCRIPTION
Accidentally, we set the SetRebootAfterFirstStage method as private, but it is used from outside AutoinstGeneral.

See [bsc#1172865](https://bugzilla.opensuse.org/show_bug.cgi?id=1172865).