### PR TITLE
Do not export useless sections

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 18 11:53:05 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not export sections with no content (related to bsc#1172749).
+- 4.3.14
+
+-------------------------------------------------------------------
 Fri Jun 12 11:18:00 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoinstGeneral.SetRebootAfterFirstStage is not private

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -337,11 +337,16 @@ module Yast
                   from: "any",
                   to:   "map <string, any>"
                 )
-                if Ops.get_string(_MergeTypes, i, "map") == "map"
-                  Ops.set(@current, res, Ops.get_map(rd, res, {}))
-                else
-                  Ops.set(@current, res, Ops.get_list(rd, res, []))
-                end
+
+                value =
+                  if !rd.key?(res)
+                    nil
+                  elsif Ops.get_string(_MergeTypes, i, "map") == "map"
+                    Ops.get_map(rd, res, {})
+                  else
+                    Ops.get_list(rd, res, [])
+                  end
+                Ops.set(@current, res, value) if value
                 i = Ops.add(i, 1)
               end
             else

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -339,6 +339,12 @@ describe Yast::Profile do
     end
 
     context "when a module has elements to merge" do
+      let(:custom_export) do
+        {
+          "users"    => [{ "username" => "root" }],
+          "defaults" => { "key1" => "val1" }
+        }
+      end
       let(:custom_module) do
         CUSTOM_MODULE.merge(
           "X-SuSE-YaST-AutoInstClient"     => "custom_auto",
@@ -349,8 +355,19 @@ describe Yast::Profile do
 
       it "adds each element into the current profile" do
         subject.Prepare
-        expect(subject.current["users"]).to be_kind_of(Array)
-        expect(subject.current["defaults"]).to be_kind_of(Hash)
+        expect(subject.current["users"]).to eq(custom_export["users"])
+        expect(subject.current["defaults"]).to eq(custom_export["defaults"])
+      end
+
+      context "but there is no content for some of the elements" do
+        let(:custom_export) do
+          { "defaults" => { "key1" => "val1" } }
+        end
+
+        it "does not include the element with no content" do
+          subject.Prepare
+          expect(subject.current).to_not have_key("users")
+        end
       end
     end
 


### PR DESCRIPTION
Some AutoYaST modules are responsible for generating different parts of the profile. For instance, `yast2-users` generates the content of `<users>`, `<groups>`, `<login_settings>` and `<user_defaults>` sections. A side effect of the merging process is that, even if some of the exported sections is nil, it will appear in the final profile.

So, for instance, you will always have a `<login_settings>` section, even if it is empty. This PR fixes this issue.
