### PR TITLE
Reduce profile size on-demand

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 26 13:59:41 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow the user to ask for a reduced profile using the 'target'
+  argument in the command line (bsc#1171356).
+- 4.3.18
+
+-------------------------------------------------------------------
 Fri Jun 26 11:21:11 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Cloning does not depend on the SetModified API call(bsc#1172552)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.17
+Version:        4.3.18
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/clone_system.rb
+++ b/src/lib/autoinstall/clients/clone_system.rb
@@ -94,9 +94,11 @@ module Y2Autoinstallation
                 "help" => "filename=OUTPUT_FILE"
               },
               "target"   => {
-                "type" => "string",
-                "help" => _(
-                  "How much information to include in the profile ('default' or 'compact')"
+                "type"     => "enum",
+                "typespec" => ["default", "compact"],
+                "help"     => _(
+                  "How much information to include in the profile. When it is set to 'compact',\n" \
+                  "it omits some configuration details in order to reduce the size of the profile."
                 )
               }
             },

--- a/src/lib/autoinstall/clients/clone_system.rb
+++ b/src/lib/autoinstall/clients/clone_system.rb
@@ -92,9 +92,15 @@ module Y2Autoinstallation
               "filename" => {
                 "type" => "string",
                 "help" => "filename=OUTPUT_FILE"
+              },
+              "target"   => {
+                "type" => "string",
+                "help" => _(
+                  "How much information to include in the profile ('default' or 'compact')"
+                )
               }
             },
-            "mappings" => { "modules" => ["clone", "filename"] }
+            "mappings" => { "modules" => ["clone", "filename", "target"] }
           }
 
           Yast::CommandLine.Run(cmdline)
@@ -109,8 +115,12 @@ module Y2Autoinstallation
       # Clone the system
       #
       # @param options [Hash] Action options
+      # @option options [String] filename Path to write the profile to
+      # @option options [String] clone Comma separated list of sections to include
+      # @option options [String] target How much information to include in the profile
       def clone_system(options)
-        filename = options["filename"] || DEFAULT_FILENAME
+        filename = options.fetch("filename", DEFAULT_FILENAME)
+        target = options.fetch("target", :default).to_sym
 
         # Autoyast overwriting an already existing config file.
         # The warning is only needed while calling "yast clone_system". It is not
@@ -137,7 +147,7 @@ module Y2Autoinstallation
             # always clone general
             Yast::ProductControl.clone_modules + ["general"]
           end
-        Yast::AutoinstClone.Process
+        Yast::AutoinstClone.Process(target: target)
         Yast::XML.YCPToXMLFile(:profile, Yast::Profile.current, filename)
         Yast::Popup.ClearFeedback
         true

--- a/src/modules/AutoinstClone.rb
+++ b/src/modules/AutoinstClone.rb
@@ -60,7 +60,7 @@ module Yast
 
     # Builds the profile
     #
-    # @param target [Symbol] How much information to include in the profile
+    # @param target [Symbol] How much information to include in the profile (:default, :compact)
     # @return [void] returns void and sets profile in ProfileClass.current
     # @see ProfileClass.create
     # @see ProfileClass.current for result

--- a/src/modules/AutoinstClone.rb
+++ b/src/modules/AutoinstClone.rb
@@ -60,10 +60,12 @@ module Yast
 
     # Builds the profile
     #
+    # @param target [Symbol] How much information to include in the profile
     # @return [void] returns void and sets profile in ProfileClass.current
     # @see ProfileClass.create
     # @see ProfileClass.current for result
-    def Process
+    # @see ProfileClass.Prepare
+    def Process(target: :default)
       log.info "Additional resources: #{@additional}"
       Mode.SetMode("autoinst_config")
 
@@ -81,7 +83,7 @@ module Yast
 
       Call.Function("general_auto", ["Import", General()]) if @additional.include?("general")
 
-      Profile.create(@additional)
+      Profile.create(@additional, target: target)
       nil
     end
 

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -292,8 +292,10 @@ module Yast
     # Prepare Profile for saving and remove empty data structs
     # This is mainly for editing profile when there is some parts we do not write ourself
     # For creating new one from given set of modules see {#create}
+    #
+    # @param target [Symbol] How much information to include in the profile (:default, :compact)
     # @return [void]
-    def Prepare
+    def Prepare(target: :default)
       return if !@prepare
 
       Popup.ShowFeedback(
@@ -301,7 +303,7 @@ module Yast
         _("This may take a while")
       )
 
-      edit_profile
+      edit_profile(target: target)
 
       Popup.ClearFeedback
       @prepare = false
@@ -309,14 +311,15 @@ module Yast
     end
 
     # Sets Profile#current to exported values created from given set of modules
+    # @param target [Symbol] How much information to include in the profile (:default, :compact)
     # @return [Hash] value set to Profile#current
-    def create(modules)
+    def create(modules, target: :default)
       Popup.Feedback(
         _("Collecting configuration data..."),
         _("This may take a while")
       ) do
         @current = {}
-        edit_profile(modules)
+        edit_profile(modules, target: target)
       end
 
       @current
@@ -781,7 +784,7 @@ module Yast
     end
 
     # Edits profile for given modules. If nil is passed, it used GetModfied method.
-    def edit_profile(modules = nil)
+    def edit_profile(modules = nil, target: :default)
       @ModuleMap.each_pair do |name, module_map|
         #
         # Set resource name, if not using default value
@@ -797,7 +800,7 @@ module Yast
         end
         next unless export
 
-        resource_data = WFM.CallFunction(module_auto, ["Export"])
+        resource_data = WFM.CallFunction(module_auto, ["Export", "target" => target.to_s])
 
         if tomerge == ""
           s = (resource_data || {}).size

--- a/test/autoinst_clone_test.rb
+++ b/test/autoinst_clone_test.rb
@@ -129,7 +129,7 @@ describe Yast::AutoinstClone do
 
     it "creates profile with additional modules" do
       subject.additional = ["general"]
-      expect(Yast::Profile).to receive(:create).with(["general"])
+      expect(Yast::Profile).to receive(:create).with(["general"], target: :default)
       subject.Process
     end
 
@@ -155,6 +155,13 @@ describe Yast::AutoinstClone do
           expect(Yast::Call).to receive(:Function).with("storage_auto", ["Read"])
           subject.Process
         end
+      end
+    end
+
+    context "when a target is given" do
+      it "applies the target when creating the file" do
+        expect(Yast::Profile).to receive(:create).with(Array, target: :compact)
+        subject.Process(target: :compact)
       end
     end
   end

--- a/test/lib/clients/clone_system_test.rb
+++ b/test/lib/clients/clone_system_test.rb
@@ -139,6 +139,16 @@ describe Y2Autoinstallation::Clients::CloneSystem do
           client.main
         end
       end
+
+      context "when a target is given" do
+        let(:args) { ["modules", "target=compact"] }
+
+        it "sets the target when cloning the system" do
+          expect(Yast::AutoinstClone).to receive(:Process)
+            .with(target: :compact)
+          client.main
+        end
+      end
     end
   end
 end

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -294,7 +294,7 @@ describe Yast::Profile do
       allow(Yast::WFM).to receive(:CallFunction)
         .with("custom_auto", ["GetModified"]).and_return(true)
       allow(Yast::WFM).to receive(:CallFunction)
-        .with("custom_auto", ["Export"]).and_return(custom_export)
+        .with("custom_auto", ["Export", "target" => "default"]).and_return(custom_export)
       allow(Yast::AutoinstClone).to receive(:General)
         .and_return("mode" => { "confirm" => false })
 
@@ -306,6 +306,14 @@ describe Yast::Profile do
     it "exports modules data into the current profile" do
       subject.Prepare
       expect(subject.current["custom"]).to be_kind_of(Hash)
+    end
+
+    context "when a 'target' is given" do
+      it "exports the module data using the given 'target'" do
+        expect(Yast::WFM).to receive(:CallFunction)
+          .with("custom_auto", ["Export", "target" => "compact"])
+        subject.Prepare(target: :compact)
+      end
     end
 
     context "when preparation is not needed" do
@@ -404,7 +412,7 @@ describe Yast::Profile do
         .with(["all", "configure"]).and_return([module_map, {}])
       allow(Yast::WFM).to receive(:CallFunction).and_call_original
       allow(Yast::WFM).to receive(:CallFunction)
-        .with("custom_auto", ["Export"]).and_return(custom_export)
+        .with("custom_auto", ["Export", "target" => "default"]).and_return(custom_export)
 
       Yast::Y2ModuleConfig.main
     end


### PR DESCRIPTION
Allow the users to select how much information is exported by setting an additional `target` argument. For instance, the following command would instruct the modules to do not export *all* the information.

```
yast2 clone_system modules target=compact
```

Obviously, each module is responsible to select how much information it exports and it is expected that just a few modules implement support for this. Let's see some ideas:

* `yast2-users`: do not export non-system users (see https://github.com/yast/yast-users/pull/232).
* `yast2-network`: do not export `localhost` entries as part of the `<hosts>` section.
* `yast2-services-manager`: do not export services that have not changed.
* `yast2-firewall`: do not export empty zones.

https://github.com/yast/yast-yast2/pull/1067 implements support for the `target` option in `Installation::AutoClient` in a way that the derived classes do not need any modification.

## References

Trello: https://trello.com/c/By1ftlMo/1852-5-reduce-profile-ii-on-demand-mechanism

## Open questions

* Should be `compact` the default value and implement a `full` target?