### PR TITLE
Remove language, keyboard and timezone sections

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 25 08:53:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- The language, timezone and keyboard sections are applied and
+  removed during the first stage.
+- 4.3.19
+
+-------------------------------------------------------------------
 Fri Jun 26 13:59:41 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow the user to ask for a reduced profile using the 'target'

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
-Thu Jun 25 08:53:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+Thu Jul 02 11:53:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - The language, timezone and keyboard sections are applied and
-  removed during the first stage.
+  removed during the first stage (bsc#1173624).
 - 4.3.19
 
 -------------------------------------------------------------------

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.18
+Version:        4.3.19
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -216,13 +216,17 @@ module Yast
 
       if Builtins.haskey(Profile.current, "timezone")
         Timezone.Import(Ops.get_map(Profile.current, "timezone", {}))
+        Profile.remove_sections("timezone")
       end
       # bnc#891808: infer keyboard from language if needed
       if Profile.current.key?("keyboard")
         Keyboard.Import(Profile.current["keyboard"] || {}, :keyboard)
+        Profile.remove_sections("keyboard")
       elsif Profile.current.key?("language")
         Keyboard.Import(Profile.current["language"] || {}, :language)
       end
+
+      Profile.remove_sections("language")
 
       # one can override the <confirm> option by the commandline parameter y2confirm
       @tmp = Convert.to_string(

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -52,12 +52,8 @@ module Yast
       Yast.import "AutoinstSoftware"
       Yast.import "Popup"
       Yast.import "Arch"
-      Yast.import "Timezone"
-      Yast.import "Keyboard"
       Yast.import "Call"
       Yast.import "ProductControl"
-      Yast.import "Language"
-      Yast.import "Console"
       Yast.import "ServicesManager"
       Yast.import "Y2ModuleConfig"
       Yast.import "AutoinstFunctions"
@@ -188,45 +184,13 @@ module Yast
         AutoinstGeneral.SetRebootAfterFirstStage
       end
 
-      @use_utf8 = true # utf8 is default
-
-      @displayinfo = UI.GetDisplayInfo
-      if !Ops.get_boolean(@displayinfo, "HasFullUtf8Support", true)
-        @use_utf8 = false # fallback to ascii
-      end
-
       #
       # Set it in the Language module.
       #
       Progress.NextStage
       Progress.Title(_("Configuring language..."))
-      Language.Import(Ops.get_map(Profile.current, "language", {}))
 
-      #
-      # Set Console font
-      #
-      Installation.encoding = Console.SelectFont(Language.language)
-
-      Installation.encoding = "UTF-8" if Ops.get_boolean(@displayinfo, "HasFullUtf8Support", true)
-
-      unless Language.SwitchToEnglishIfNeeded(true)
-        UI.SetLanguage(Language.language, Installation.encoding)
-        WFM.SetLanguage(Language.language, "UTF-8")
-      end
-
-      if Builtins.haskey(Profile.current, "timezone")
-        Timezone.Import(Ops.get_map(Profile.current, "timezone", {}))
-        Profile.remove_sections("timezone")
-      end
-      # bnc#891808: infer keyboard from language if needed
-      if Profile.current.key?("keyboard")
-        Keyboard.Import(Profile.current["keyboard"] || {}, :keyboard)
-        Profile.remove_sections("keyboard")
-      elsif Profile.current.key?("language")
-        Keyboard.Import(Profile.current["language"] || {}, :language)
-      end
-
-      Profile.remove_sections("language")
+      autosetup_country
 
       # one can override the <confirm> option by the commandline parameter y2confirm
       @tmp = Convert.to_string(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,11 +62,19 @@ module Yast
     def dummy
       true
     end
+
+    def Import(*_args)
+      true
+    end
   end
   Keyboard = KeyboardClass.new
 
   class TimezoneClass
     def dummy
+      true
+    end
+
+    def Import(*_args)
       true
     end
   end


### PR DESCRIPTION
## Problem

During an AutoYaST installation, the country settings (language, keyboard, timezone) are already applied during the 1st stage and also during the second stage when it is run. In order to not process the configuration a second time the related sections should be removed during the first stage once imported.

- https://trello.com/c/VPtx0SyN/1921-3-move-keyboard-language-timezone-to-1st-stage

## Solution

- Remove country related sections once imported during the 1st stage.

## Tests

- Unit test added
- Tested manually with last staging J build (including last yast2-country changes https://github.com/yast/yast-country/pull/254)