### PR TITLE
AutoYaST schema: Make the report section elements optional

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul  2 15:18:39 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Make the report section elements optional as AutoYaST proposes
+  default values when missing (bsc#1173312)
+- 4.3.20
+
+-------------------------------------------------------------------
 Thu Jul 02 11:53:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - The language, timezone and keyboard sections are applied and

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.19
+Version:        4.3.20
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/reporting.rnc
+++ b/src/autoyast-rnc/reporting.rnc
@@ -6,11 +6,11 @@ namespace config = "http://www.suse.com/1.0/configns"
 
 include "common.rnc"
 
-report = element report { MAP, (errors & messages & warnings & yesno_messages?) }
-errors = element errors { MAP, (log & show & timeout) }
-yesno_messages = element yesno_messages { MAP, (log & show & timeout) }
-messages = element messages { MAP, (log & show & timeout) }
-warnings = element warnings { MAP, (log & show & timeout) }
+report = element report { MAP, (errors? & messages? & warnings? & yesno_messages?) }
+errors = element errors { MAP, (log? & show? & timeout?) }
+yesno_messages = element yesno_messages { MAP, (log? & show? & timeout?) }
+messages = element messages { MAP, (log? & show? & timeout?) }
+warnings = element warnings { MAP, (log? & show? & timeout?) }
 # <!ELEMENT location (#PCDATA)>
 log =
   element log { BOOLEAN }


### PR DESCRIPTION
## Problem

When the report section is defined it expects all the schema elements to be given although AutoYaST already proposes default values when missing. Thus, the installation validation schema (https://github.com/yast/yast-autoinstallation/pull/624) reports an error which seems too strict.

https://trello.com/c/m3hv8ihn/1923-ostumbleweed-p2-1173312-schema-validation-seems-overly-strict

## Solution

- Make the report section elements and theirs descendants optional.
