### PR TITLE
Do not remove interfaces configuration when network section is absent

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul  7 13:20:24 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not remove interfaces configuration by default when there is
+  not networking section defined in the profile (bsc#1173793)
+- 4.2.39
+
+-------------------------------------------------------------------
 Fri Jun 12 13:15:42 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Export ntp_policy as CDATA so that empty strings are preserved

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.38
+Version:        4.2.39
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -128,21 +128,6 @@ module Yast
         Ops.get_string(d, "res", "")
       end)
 
-      # keep network on AutoYaST ugprade
-      if !Mode.autoupgrade
-        if !Builtins.haskey(Profile.current, "networking")
-          removeNetwork([]) # no networking section -> no network
-        elsif Ops.get_boolean(
-          Profile.current,
-          ["networking", "keep_install_network"],
-          true
-        ) == false
-          removeNetwork(
-            Ops.get_list(Profile.current, ["networking", "interfaces"], [])
-          ) # networking section without keeping the install network
-        end
-      end
-
       Builtins.foreach(@deps) do |r|
         p = Ops.get_string(r, "res", "")
         d = Ops.get_map(r, "data", {})
@@ -415,54 +400,6 @@ module Yast
       end
       Builtins.y2milestone("MatchInterface id:%1 ret:%2", id, ret)
       ret
-    end
-
-    def removeNetwork(ilist)
-      ilist = deep_copy(ilist)
-      Yast.import "NetworkInterfaces"
-      Builtins.y2milestone("removeNetwork ifaces:%1", ilist)
-      ilist = Builtins.maplist(ilist) do |i|
-        if Builtins.substring(Ops.get_string(i, "device", ""), 0, 7) == "eth-id-"
-          Ops.set(i, "device", MatchInterface(Ops.get_string(i, "device", "")))
-        end
-        deep_copy(i)
-      end
-      Builtins.y2milestone("removeNetwork ifaces:%1", ilist)
-      l = SCR.Read(path(".target.dir"), ["/etc/sysconfig/network", []])
-      netlist = []
-      Builtins.y2milestone("removeNetwork list:%1", l)
-      Builtins.foreach(
-        Convert.convert(l, from: "any", to: "list <string>")
-      ) do |s|
-        if Builtins.issubstring(s, "ifcfg-") &&
-            !Builtins.issubstring(s, "ifcfg-lo")
-          if Builtins.substring(s, 0, 6) == "ifcfg-" && s != "ifcfg-lo"
-            net = Builtins.substring(s, 6)
-            tmp = Builtins.filter(ilist) do |l2|
-              Ops.get_string(l2, "device", "") == net
-            end
-            if Builtins.isempty(tmp)
-              Builtins.y2milestone("removeNetwork net:%1", net)
-              NetworkInterfaces.Delete(net)
-              netlist = Builtins.add(netlist, net)
-              Builtins.y2milestone(
-                "removing installation network: /etc/sysconfig/network/%1",
-                s
-              )
-              SCR.Execute(
-                path(".target.remove"),
-                Builtins.sformat("/etc/sysconfig/network/%1", s)
-              )
-            end
-          end
-        end
-      end
-      Builtins.y2milestone("removeNetwork netlist:%1", netlist)
-      if !Builtins.isempty(netlist)
-        NetworkInterfaces.Commit
-        # NetworkInterfaces::Write( ".*" );
-      end
-      nil
     end
 
     def processWait(resource, stage)


### PR DESCRIPTION
## Problem

Since https://bugzilla.suse.com/show_bug.cgi?id=1170821, the networking section is not added by default to the profile, in order to not call the auto client when not specifically needed.

The problem is that we remove the interfaces configuration when it is not defined in the profile.

- https://bugzilla.suse.com/show_bug.cgi?id=1173793

## Solution

- The network interfaces configuration will not be removed by inst_autoconfigure anymore (backported partially from master see https://github.com/yast/yast-autoinstallation/pull/606/files#diff-b2063d649bd3696f9fefc54a84912ff7L131)

## Todo

Decide if we would like to allow a way to delete existing network interfaces configuration and related files (routes, aliases entries etc)