### PR TITLE
Fix the type used for 'partition' elements

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 14 12:05:44 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Fix 'partition' elements using the right type (bsc#1174071).
+- 4.3.24
+
+-------------------------------------------------------------------
 Mon Jul 13 09:26:52 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix exception when autoyast module does not report any package

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.23
+Version:        4.3.24
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -94,7 +94,10 @@ y2_partition =
   | bcache_caching_for
   | btrfs_name
 
-partition = element partition { y2_partition* }
+partition = element partition {
+  MAP,
+  y2_partition*
+}
 part_create =
   element create { BOOLEAN }
 part_crypt = element crypt { STRING }


### PR DESCRIPTION
## Problem

As reported in https://bugzilla.suse.com/show_bug.cgi?id=1174071, the AutoYaST profile validation started failing with `ERROR: Element profile failed to validate content`.


<details>
<summary>Click to show/hide an screenshot</summary>

<p>

![validation_failed](https://user-images.githubusercontent.com/1691872/87424468-e93bc080-c5d3-11ea-89bb-c38524324b89.png)

</p>
</details>

This happens because `partition` elements in the `autoinst.xml` profile have the `t="map"` attribute but it is currently missing in the schema.


## Solution

To update the `partitioning.rnc` file, setting the `MAP` type to the `partition` element.

## Tests

### During the installation, via driver update

* Build both packages, yast-autoinstallation and yast-schema using the `--keep-pkgs` and `--prefer-pkgs` osc options

  > **rake "osc:build[-p /tmp/pkgs -k /tmp/pkgs]"**

* Create a driver update
* Run the installation using the driver udpate and AutoYaST profile

The profile validations works fine and the auto installation could continue

<details>
<summary>Click to show/hide an screenshot</summary>

<p>

![Screenshot_openSUSE-Leap_2020-07-14_14:22:33](https://user-images.githubusercontent.com/1691872/87430689-7afbfb80-c5dd-11ea-8106-52d85dc87f31.png)

</p>
</details>

### Manually, runing the xmllint validation locally

I have tested this change manually, as described bellow

* Run the installation with the provided AutoYaST profile.
* Copy the `/tmp/YaST2-temporary-directory/autoinst.xml file to a local machine
* Execute the validation locally

  > $ xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng autoinst.xml
  >
  > Relax-NG validity error : Extra element partitioning in interleave
  > autoinst.xml:19: element partitioning: Relax-NG validity error : Element profile failed to validate content
  >  autoinst.xml fails to validate

* Apply suggested changes, build the package and re-install it using the new `rpm` file
* Re-build the yast2-schema manually

  > $ cd /path/to/yast2-schema-source-code
  > $ sudo zypper in trang
  > $ **make -f Makefile.cvs**
  > $ **make**
  > $ **sudo make install**

* Check that /usr/share/YaST2/schema/autoyast/rng/partitioning.rng has changed

  > ...
  >   \<define name="partition">
  >     \<element name="partition">
  >       \<**ref name="MAP"**/>
  > ...

* Execute the validation again 

  > $ xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng autoinst.xml
  > 
  > **autoinst.xml validates**

