### PR TITLE
Fix client default name

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 20 14:51:49 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix fallback for autoyast client name (bsc#1174119)
+- 4.3.28
+
+-------------------------------------------------------------------
 Mon Jul 20 12:12:39 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not crash when wait section is not initialized (related to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.27
+Version:        4.3.28
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/entries/description.rb
+++ b/src/lib/autoinstall/entries/description.rb
@@ -93,7 +93,7 @@ module Y2Autoinstallation
       end
 
       def client_name
-        values["X-SuSE-YaST-AutoInstClient"] || (resource_name + "_auto")
+        values["X-SuSE-YaST-AutoInstClient"] || (module_name + "_auto")
       end
 
       def hidden?

--- a/test/lib/entries/description_test.rb
+++ b/test/lib/entries/description_test.rb
@@ -102,7 +102,7 @@ describe Y2Autoinstallation::Entries::Description do
     end
 
     context "X-SuSE-YaST-AutoInstClient is not defined" do
-      let(:values) { {} }
+      let(:values) { { "X-SuSE-YaST-AutoInstResource" => "fancy" } }
 
       it "returns #module_name with _auto suffix" do
         expect(subject.client_name).to eq "moduleA_auto"


### PR DESCRIPTION
trello: https://trello.com/c/bev3V41K/1966-2-tw-1174119-network-section-will-not-be-created-while-calling-yast-clonesystem