### PR TITLE
[bsc#1174118] Do not crash when the networking section is missing

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 21 19:24:34 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when the networking section is missing
+  (bsc#1174118).
+- 4.3.29
+
+-------------------------------------------------------------------
 Mon Jul 20 14:51:49 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix fallback for autoyast client name (bsc#1174119)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.28
+Version:        4.3.29
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -126,23 +126,13 @@ module Y2Autoinstallation
       # Prevent to be called twice in case of already configured
       return if @network_configured
 
-      if Yast::Profile.current["networking"]
-        if network_before_proposal?
-          log.info("Networking setup before the proposal")
-        else
-          log.info("Networking setup at the end of first installation stage")
-        end
+      networking_section = Yast::Profile.current.fetch("networking", {})
+      Yast::WFM.CallFunction("lan_auto", ["Import", networking_section])
 
-        log.info("Importing Network settings from configuration file")
-        Yast::WFM.CallFunction("lan_auto", ["Import", Yast::Profile.current["networking"]])
-        Yast::Profile.remove_sections("networking")
-
-        # Import also the host section in order to resolve hosts only available
-        # with the network configuration and the host entry
-        if Yast::Profile.current["host"] && network_before_proposal?
-          Yast::WFM.CallFunction("host_auto", ["Import", Yast::Profile.current["host"]])
-          Yast::Profile.remove_sections("host")
-        end
+      # Import also the host section in order to resolve hosts only available
+      # with the network configuration and the host entry
+      if Yast::Profile.current["host"] && network_before_proposal?
+        Yast::WFM.CallFunction("host_auto", ["Import", Yast::Profile.current["host"]])
       end
 
       if semi_auto?("networking")
@@ -151,7 +141,12 @@ module Y2Autoinstallation
         @network_before_proposal = true
       end
 
+      log.info("Networking setup before the proposal: #{network_before_proposal?}")
       Yast::WFM.CallFunction("lan_auto", ["Write"]) if network_before_proposal?
+
+      # Clean-up the profile
+      Yast::Profile.remove_sections(["networking", "host"])
+
       @network_configured = true
     end
 

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -131,7 +131,7 @@ module Y2Autoinstallation
 
       # Import also the host section in order to resolve hosts only available
       # with the network configuration and the host entry
-      if Yast::Profile.current["host"] && network_before_proposal?
+      if Yast::Profile.current["host"]
         Yast::WFM.CallFunction("host_auto", ["Import", Yast::Profile.current["host"]])
       end
 


### PR DESCRIPTION
It fixes [bsc#1174118](https://bugzilla.suse.com/show_bug.cgi?id=1174118), which was a side effect of moving all the network configuration to the 1st stage. Additionally, it tries to simplify the `autosetup_network` method a bit.