### PR TITLE
Erb template

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 25 14:17:31 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Add ability to use erb template as dynamic autoyast profile
+  (bsc#1175735)
+- 4.3.38
+
+-------------------------------------------------------------------
 Tue Aug 25 07:33:20 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Speed up finding the "autoyast()" supplements by filtering

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.37
+Version:        4.3.38
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/y2erb.rb
+++ b/src/lib/autoinstall/y2erb.rb
@@ -1,0 +1,23 @@
+require "yast"
+require "erb"
+
+module Y2Autoinstallation
+  class Y2ERB
+    def self.render(path)
+      env = TemplateEnvironment.new
+      template = ERB.new(File.read(path))
+      template.result(env.public_binding)
+    end
+
+    class TemplateEnvironment
+      def hardware
+        @hardware ||= Yast::SCR.Read(Yast::Path.new(".probe"))
+      end
+
+      # expose method bindings
+      def public_binding
+        binding
+      end
+    end
+  end
+end

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -189,6 +189,9 @@ module Yast
 
       return false if !is_directory && !profile_checker.valid_profile?
 
+      # no rules and classes support for erb templates
+      return true if AutoinstConfig.filepath.end_with?(".erb")
+
       ret = if is_directory
         Get(
           AutoinstConfig.scheme,

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -7,6 +7,7 @@
 require "yast"
 
 require "autoinstall/xml_checks"
+require "autoinstall/y2erb"
 require "y2storage"
 
 module Yast
@@ -158,6 +159,12 @@ module Yast
           )
           tmp = Convert.to_string(SCR.Read(path(".target.string"), localfile))
           l = Builtins.splitstring(tmp, "\n")
+        end
+
+        # render erb template
+        if AutoinstConfig.filepath.end_with?(".erb")
+          res = Y2Autoinstallation::Y2ERB.render(localfile)
+          SCR.Write(path(".target.string"), localfile, res)
         end
       else
         is_directory = true

--- a/test/lib/y2erb_test.rb
+++ b/test/lib/y2erb_test.rb
@@ -38,4 +38,3 @@ describe Y2Autoinstallation::Y2ERB do
     end
   end
 end
-

--- a/test/lib/y2erb_test.rb
+++ b/test/lib/y2erb_test.rb
@@ -1,0 +1,41 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "tempfile"
+require "autoinstall/y2erb"
+
+describe Y2Autoinstallation::Y2ERB do
+  describe ".render" do
+    it "returns string with rendered template" do
+      # mock just for optimization
+      allow(Yast::SCR).to receive(:Read).and_return({})
+      file = Tempfile.new("test")
+      path = file.path
+      file.write("<test><%= hardware.inspect %></test>")
+      file.close
+      result = described_class.render(path)
+      file.unlink
+
+      expect(result).to match(/<test>{.*}<\/test>/)
+    end
+  end
+end
+


### PR DESCRIPTION
trello: https://trello.com/c/gNgOHmh3/2016-5-dynamic-profiles-poc

how it works? Just pass erb file as autoyast parameter e.g. autoyast=ftp://neser-vr.suse.cz/dynamic.erb

and here is content of testing erb
```erb
<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
  <%# example how to dynamic force multipath. Here it use storage model and if
      it contain case insensitive word multipath %>
  <% if hardware["storage"].any? { |s| s["model"] =~ /multipath/i } %>
    <general>
      <storage>
        <start_multipath t="boolean">true</start_multipath>
      </storage>
    </general>
  <% end %>
  <software>
    <products config:type="list">
      <product>openSUSE</product>
    </products>
  </software>
  <%# for details about values see libhd  TODO: better API? %>
  <% disks = hardware["disk"].sort_by { |d| s = d["resource"]["size"].first; s["x"]*s["y"] }.map { |d| d["dev_name"] }.reverse %>
  <partitioning t="list">
    <% disks[0..1].each do |name| %>
      <drive>
         <device>
           <%= name %>
         </device>
         <initialize t="boolean">
           true
         </initialize>
       </drive>
    <% end %>
  </partitioning>
  <%# situation: machine has two network catds. One leads to intranet and other to internet, so here we create udev
      rules to have internet one as eth0 and intranet as eth1. To distinguish in this example intranet one is not active %>
  <networking>
    <net-udev t="list">
      <rule>
        <name>eth0</name>
        <rule>ATTR{address}</rule>
        <value>
  	<%= hardware["netcard"].find { |c| c["resource"]["link"].first["state"] }["resource"]["phwaddr"].first["addr"] %>
        </value>
      </rule>
      <rule>
        <name>eth1</name>
        <rule>ATTR{address}</rule>
        <value>
  	<%= hardware["netcard"].find { |c| !c["resource"]["link"].first["state"] }["resource"]["phwaddr"].first["addr"] %>
        </value>
      </rule>
    </net-udev>
  </networking>
</profile>
```

only helper so far is hardware which provives .probe agent hash output.