### PR TITLE
Speed up finding the "autoyast()" supplements (bsc#1175317)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug 25 07:33:20 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Speed up finding the "autoyast()" supplements by filtering
+  packages directly on the lilbzypp level (bsc#1175317, related to
+  bsc#1146494)
+- 4.3.37
+
+-------------------------------------------------------------------
 Mon Aug 24 13:44:00 CEST 2020 - schubi@suse.de
 
 - Reporting an error if an corrupted AY configuration file has been

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.36
+Version:        4.3.37
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
@@ -130,8 +130,8 @@ Requires:       yast2-transfer >= 2.21.0
 # storage-ng based version
 Requires:       yast2-update >= 3.3.0
 Requires:       yast2-xml
-# "transact_by" key in PkgPropertiesAll()
-Requires:       yast2-pkg-bindings >= 4.0.7
+# RPM dependencies in Pkg.Resolvables
+Requires:       yast2-pkg-bindings >= 4.3.0
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Provides:       yast2-trans-autoinst

--- a/src/lib/autoinstall/package_searcher.rb
+++ b/src/lib/autoinstall/package_searcher.rb
@@ -38,7 +38,11 @@ module Y2Autoinstallation
       package_names = {}
       log.info "Evaluating needed packages for handling AY-sections via RPM Supplements"
       log.info "Sections: #{sections}"
-      packages = Y2Packager::Resolvable.find(kind: :package)
+      packages = Y2Packager::Resolvable.find(
+        kind:               :package,
+        # this is a POSIX extended regexp, not a Ruby regexp!
+        supplements_regexp: "^autoyast\\(.*\\)"
+      )
 
       sections.each do |section|
         # Evaluting which package has the supplement autoyast(<section>)

--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -51,6 +51,10 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
     allow(Yast::Pkg).to receive(:ResolvableInstall)
     allow(Yast::Pkg).to receive(:ResolvableRemove)
     allow(Yast::Pkg).to receive(:PkgSolve).and_return(true)
+    # do not change the current language, using translated messages
+    # would break test expectations
+    allow(Yast::WFM).to receive(:SetLanguage)
+    allow(Yast::UI).to receive(:SetLanguage)
   end
 
   describe "#main" do

--- a/test/lib/package_searcher_test.rb
+++ b/test/lib/package_searcher_test.rb
@@ -91,7 +91,8 @@ describe Y2Autoinstallation::PackagerSearcher do
 
     before do
       allow(Y2Packager::Resolvable).to receive(:find).with(
-        kind: :package
+        kind:               :package,
+        supplements_regexp: "^autoyast\\(.*\\)"
       ).and_return(packages)
     end
 


### PR DESCRIPTION
- Filter the packages directly on the lilbzypp level, that's much faster
- Related to https://github.com/yast/yast-pkg-bindings/pull/136
- Related to [bsc#1175317](https://bugzilla.suse.com/show_bug.cgi?id=1175317)
- Fixed unit test (do not change the current language), running the tests locally failed for me because of present translations
- 4.3.37