### PR TITLE
[PoC] Run the unit tests in parallel

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,1 @@
+--format progress --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/src/modules/AutoInstall.rb
+++ b/src/modules/AutoInstall.rb
@@ -7,6 +7,7 @@
 require "yast"
 require "autoinstall/pkg_gpg_check_handler"
 require "installation/autoinst_issues"
+require "installation/autoinst_issues/issues_presenter"
 
 module Yast
   class AutoInstallClass < Module


### PR DESCRIPTION
## Problem

Running the unit tests takes quite long time, we should run the tests in parallel to speed it up. We already use that solution in the [yast2-storage-ng](https://github.com/yast/yast-storage-ng/pull/668) package.

## Todo

- [x] Fix the missing `require`
- [ ] Fix the `Storage::LockException` problem (according to @imobachgs we should run the storage related tests in one process, the other option would be to mock the storage calls)
- [ ] Adapt the `.spec` file (like [here](https://github.com/yast/yast-storage-ng/blob/master/package/yast2-storage-ng.spec#L43-L46))
- [ ] Fix code coverage reporting

*Note: the `Storage::LockException` happens only with more parallel processes (16), Travis uses just 2 CPUs so it does not happen there, the affected tests coincidentally run in the same process.*

## Results

- On my machine the test duration went down from 30s to 10s (3x faster) (using a 8C/16T CPU)
- At Travis the speed up is smaller (only 2 CPUs) and it highly depends how fast the worker machine is (it might actaully take the same time, see [parallel tests](https://travis-ci.org/github/yast/yast-autoinstallation/builds/720965762)  and the [standard tests](https://travis-ci.org/github/yast/yast-autoinstallation/builds/720957479)).
- The question is how faster it will be in OBS, but the builds usually use 4 or 8 CPUs so the speed up should be pretty good there.