### PR TITLE
Fixed internal error crash when signature_handling contains no type definition

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug 26 08:17:59 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- bnc#1174133
+  - do not crash with internal error when the profile contains
+    corrupted signature_handling option
+- 4.3.39
+
+-------------------------------------------------------------------
 Tue Aug 25 14:17:31 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Add ability to use erb template as dynamic autoyast profile

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.38
+Version:        4.3.39
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -282,6 +282,8 @@ module Yast
           "string (map)")
       )
 
+      return if signature_handling.empty?
+
       if signature_handling.key?("accept_unsigned_file")
         Pkg.CallbackAcceptUnsignedFile(
           if signature_handling["accept_unsigned_file"]


### PR DESCRIPTION
## Problem

when no type is defined explicitly, then string is assumed

## Solution

For now this is expected to be a problem when signature_handling is empty and type definition is omitted completely. It for some reason has happened in bnc#1174133 when generating a profile, this fix should solve this issue. It intentionally do not handle incorrect explicit type definitions.

Profile export has also been checked with this version of autoyast and it correctly exports ```t="map"``` in signature_handling