### PR TITLE
Use ElementPath class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,9 @@ Metrics/AbcSize:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 500
+  # RSpec is known as DSL with big blocks
+  Exclude:
+    - test/**/*
 
 # Offense count: 64
 # Configuration parameters: CountBlocks.

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 26 10:31:54 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Unify profile element paths (bsc#1175680).
+- 4.3.40
+
+-------------------------------------------------------------------
 Wed Aug 26 08:17:59 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bnc#1174133

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.39
+Version:        4.3.40
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -41,8 +41,8 @@ BuildRequires:  libxml2-tools
 # xsltproc for AutoinstClass
 BuildRequires:  libxslt
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
-# AutoYaST issue handling
-BuildRequires:  yast2 >= 4.3.2
+# AutoYaST ElementPath class
+BuildRequires:  yast2 >= 4.3.20
 # FileSystems.read_default_subvol_from_target
 BuildRequires:  yast2-xml
 BuildRequires:  yast2-transfer
@@ -66,8 +66,8 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 
 Requires:       autoyast2-installation = %{version}
 Requires:       libxslt
-# XML.validate
-Requires:       yast2 >= 4.3.8
+# AutoYaST ElementPath class
+Requires:       yast2 >= 4.3.20
 Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
 # Moving security module to first installation stage

--- a/src/include/autoinstall/ask.rb
+++ b/src/include/autoinstall/ask.rb
@@ -20,19 +20,6 @@ module Yast
       Yast.import "UI"
     end
 
-    def path2pos(pa)
-      pos = []
-      Builtins.foreach(Builtins.splitstring(pa, ",")) do |p|
-        if Builtins.regexpmatch(p, "^[1,2,3,4,5,6,7,8,9,0]+$")
-          index = Builtins.tointeger(p)
-          pos = Builtins.add(pos, index)
-        else
-          pos = Builtins.add(pos, p)
-        end
-      end
-      deep_copy(pos)
-    end
-
     def createWidget(widget, _frametitle)
       widget = deep_copy(widget)
       ret = Left(widget)
@@ -423,20 +410,14 @@ module Yast
 
                 # Save the value in the profile (and also as default value)
                 Ops.set(ask, "default", val)
-                pos = path2pos(Ops.get_string(ask, "path", ""))
                 if Ops.get_string(ask, "path", "") != "" # Set value in the profile
-                  Profile.current = Profile.setElementByList(
-                    pos,
-                    val,
-                    Profile.current
+                  Profile.current = Profile.set_element_by_path(
+                    ask["path"], val, Profile.current
                   )
                 end
                 Builtins.foreach(Ops.get_list(ask, "pathlist", [])) do |p|
-                  pos2 = path2pos(p)
-                  Profile.current = Profile.setElementByList(
-                    pos2,
-                    val,
-                    Profile.current
+                  Profile.current = Profile.set_element_by_path(
+                    p, val, Profile.current
                   )
                 end
 

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -612,9 +612,10 @@ module Yast
 
     # Returns a profile merging the given value into the specified path
     #
-    # The path can be a proper a String or a proper {Installation::AutoinstProfile::ElementPath} object.
-    # Although the real work is performedby {SetElementByList}, it is usually preferred
-    # to use this method as it takes care of handling the path.
+    # The path can be a String or a {Installation::AutoinstProfile::ElementPath}
+    # object. Although the real work is performed by {SetElementByList}, it is
+    # usually preferred to use this method as it takes care of handling the
+    # path.
     #
     # @example Set a value using a XPath-like path
     #   path = "//a/b"

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -612,8 +612,8 @@ module Yast
 
     # Returns a profile merging the given value into the specified path
     #
-    # The path can be a String or a {Installation::AutoinstProfile::ElementPath}
-    # object. Although the real work is performed by {SetElementByList}, it is
+    # The path can be a String or a Installation::AutoinstProfile::ElementPath
+    # object. Although the real work is performed by {setElementByList}, it is
     # usually preferred to use this method as it takes care of handling the
     # path.
     #

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -603,4 +603,63 @@ describe Yast::Profile do
       expect(subject.SaveSingleSections("/tmp")).to eq({})
     end
   end
+
+  describe "#setElementByList" do
+    let(:profile) do
+      {
+        "users" => [
+          { "username" => "root" },
+          { "username" => "guest" }
+        ]
+      }
+    end
+    let(:path) { ["users", 1, "username"] }
+
+    context "when the element exists" do
+      it "replaces its value" do
+        new_profile = subject.setElementByList(path, "admin", profile)
+        expect(new_profile["users"][1]).to eq(
+          "username" => "admin"
+        )
+      end
+    end
+
+    context "when the element does not exist" do
+      let(:path) { ["users", 1, "realname"] }
+
+      it "adds the element in the given path" do
+        new_profile = subject.setElementByList(path, "Guest User", profile)
+        expect(new_profile["users"][1]).to eq(
+          "username" => "guest", "realname" => "Guest User"
+        )
+      end
+    end
+
+    context "when the element is supposed to be an array member but it does not exist" do
+      let(:path) { ["users", 3, "username"] }
+
+      it "adds an element to the array" do
+        new_profile = subject.setElementByList(path, "admin", profile)
+        expect(new_profile["users"][3]).to eq(
+          "username" => "admin"
+        )
+      end
+
+      it "fills any gap with nil" do
+        new_profile = subject.setElementByList(path, "admin", profile)
+        expect(new_profile["users"][2]).to be_nil
+      end
+    end
+
+    context "when parent elements are missing" do
+      let(:path) { ["groups", 0, "name"] }
+
+      it "adds all the full hierarchy up to the given path" do
+        new_profile = subject.setElementByList(path, "root", profile)
+        expect(new_profile["groups"]).to eq(
+          [{ "name" => "root" }]
+        )
+      end
+    end
+  end
 end

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -604,6 +604,33 @@ describe Yast::Profile do
     end
   end
 
+  describe "#set_element_by_path" do
+    let(:profile) { double("profile") }
+    let(:value) { double("value") }
+    let(:new_profile) { double("new_profile") }
+
+    context "when a string is given as path" do
+      it "sets the element by using the path's parts" do
+        expect(subject).to receive(:setElementByList).with(
+          ["users", 0, "username"], value, profile
+        ).and_return(new_profile)
+        result = subject.set_element_by_path("users,0,username", value, profile)
+        expect(result).to eq(new_profile)
+      end
+    end
+
+    context "when a profile path object is given as path" do
+      let(:path) { Installation::AutoinstProfile::ElementPath.from_string("groups,0,name") }
+      it "sets the element by using the path's parts" do
+        expect(subject).to receive(:setElementByList).with(
+          ["groups", 0, "name"], value, profile
+        ).and_return(new_profile)
+        result = subject.set_element_by_path(path, value, profile)
+        expect(result).to eq(new_profile)
+      end
+    end
+  end
+
   describe "#setElementByList" do
     let(:profile) do
       {


### PR DESCRIPTION
Use the ElementPath object, introduced in https://github.com/yast/yast-yast2/pull/1090:

* Replace `setElementByTest` with  `set_element_by_path` which accepts a proper `ElementPath` object instead of an array.
* Use `ElementPath#from_string` in order to parse the ask-list path.