### PR TITLE
add helper for enumerate disks

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Sep  2 14:58:25 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Add to erb templates more helpers (bsc#1175735) 
+
+-------------------------------------------------------------------
 Tue Sep  1 11:32:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use <script> elements instead of <listentry> when exporting the

--- a/src/lib/autoinstall/y2erb.rb
+++ b/src/lib/autoinstall/y2erb.rb
@@ -85,6 +85,22 @@ module Y2Autoinstallation
         @network_cards
       end
 
+      # @return [Hash] list of info about OS release. Info contain:
+      #   `:name` human readable name of OS like `"openSUSE Tumbleweed"` or `"SLES"`
+      #   `:version` of release like `"20200727"` or `"12.5"`
+      #   `:id` id of OS like `"opensuse-tumbleweed"` or `"sles"`
+      def os_release
+        return @os_release if @os_release
+
+        Yast.import "OSRelease"
+        @os_release = {
+          name: Yast::OSRelease.ReleaseName,
+          version: Yast::OSRelease.ReleaseVersion,
+          id: Yast::OSRelease.id
+        }
+      end
+
+
       # allow to use env bindings
       def public_bindings
         binding

--- a/src/lib/autoinstall/y2erb.rb
+++ b/src/lib/autoinstall/y2erb.rb
@@ -6,7 +6,7 @@ module Y2Autoinstallation
     def self.render(path)
       env = TemplateEnvironment.new
       template = ERB.new(File.read(path))
-      template.result(env.send(:binding)) # intentional send as it is private method
+      template.result(env.public_bindings) # intentional send as it is private method
     end
 
     class TemplateEnvironment
@@ -16,23 +16,62 @@ module Y2Autoinstallation
         @hardware ||= Yast::SCR.Read(Yast::Path.new(".probe"))
       end
 
+      # @return [Array<Hash>] list of info about disks. Info contain:
+      #   `:vendor` of disk
+      #   `:device` kernel name of device
+      #   `:udev_names` list of udev names for given disk
+      #   `:model` model name from sysfs
+      #   `:serial` serial number of disk
+      #   `:size` disk size in bytes [Integer]
       def disks
         return @disks if @disks
 
         @disks = []
         hardware["disk"].each do |disk|
+          dev_name = ::File.pathname(disk["dev_name"])
           result = {
             vendor: disk["vendor"],
-            device: disk["dev_name"],
+            device: devn_name,
             udev_names: disk["dev_names"]
           }
-          dev_name = ::File.pathname(result[:device])
           result[:model] = sys_block_value(dev_name, "device/model") || "Unknown"
           result[:serial] = sys_block_value(dev_name, "device/serial") || "Unknown"
           result[:size] = (sys_block_value(dev_name, "device/size") || "-1").to_i
 
           @disks << result
         end
+      end
+
+      # @return [Array<Hash>] list of info about network cards. Info contain:
+      #   `:vendor` of card
+      #   `:device` name of device
+      #   `:mac` mac address of card
+      #   `:active` if card io is active [Boolean]
+      #   `:link_up` if card link is up [Boolean]
+      def network_cards
+        return @network_cards if @network_cards
+
+        @network_cards = []
+        hardware["netcard"].each do |card|
+          resource = card["resource"]
+          mac = resource["hwaddr"].first["addr"] rescue ""
+          active = resource["io"].first["active"] rescue false
+          link = resource["link"].first["state"] rescue false
+          result = {
+            vendor: card["vendor"],
+            device: card["dev_name"],
+            mac: mac,
+            active: active,
+            link: link
+          }
+
+          @network_cards << result
+        end
+      end
+
+      # allow to use env bindings
+      def public_bindings
+        binding
       end
 
     private

--- a/src/lib/autoinstall/y2erb.rb
+++ b/src/lib/autoinstall/y2erb.rb
@@ -94,12 +94,11 @@ module Y2Autoinstallation
 
         Yast.import "OSRelease"
         @os_release = {
-          name: Yast::OSRelease.ReleaseName,
+          name:    Yast::OSRelease.ReleaseName,
           version: Yast::OSRelease.ReleaseVersion,
-          id: Yast::OSRelease.id
+          id:      Yast::OSRelease.id
         }
       end
-
 
       # allow to use env bindings
       def public_bindings

--- a/src/lib/autoinstall/y2erb.rb
+++ b/src/lib/autoinstall/y2erb.rb
@@ -6,17 +6,43 @@ module Y2Autoinstallation
     def self.render(path)
       env = TemplateEnvironment.new
       template = ERB.new(File.read(path))
-      template.result(env.public_binding)
+      template.result(env.send(:binding)) # intentional send as it is private method
     end
 
     class TemplateEnvironment
+      include Yast::Logger
+
       def hardware
         @hardware ||= Yast::SCR.Read(Yast::Path.new(".probe"))
       end
 
-      # expose method bindings
-      def public_binding
-        binding
+      def disks
+        return @disks if @disks
+
+        @disks = []
+        hardware["disk"].each do |disk|
+          result = {
+            vendor: disk["vendor"],
+            device: disk["dev_name"],
+            udev_names: disk["dev_names"]
+          }
+          dev_name = ::File.pathname(result[:device])
+          result[:model] = sys_block_value(dev_name, "device/model") || "Unknown"
+          result[:serial] = sys_block_value(dev_name, "device/serial") || "Unknown"
+          result[:size] = (sys_block_value(dev_name, "device/size") || "-1").to_i
+
+          @disks << result
+        end
+      end
+
+    private
+
+      def  sys_block_value(device, path)
+        sys_path = "/sys/block/#{device}/"
+        ::File.read(sys_path + path).strip
+      rescue => e
+        log.warn "read of #{sys_path + path}  failed with #{e}"
+        return nil
       end
     end
   end

--- a/test/lib/y2erb_test.rb
+++ b/test/lib/y2erb_test.rb
@@ -82,7 +82,7 @@ def hardware_mock_data
           "link"    => [{ "state"=>false }],
           "mem"     =>
                        [{ "active" => true, "length" => 4096,
-                                                                         "start" => 4152377344 },
+                        "start" => 4152377344 },
                         { "active" => true, "length" => 16384,
                         "start" => 4152360960 }],
           "phwaddr" => [{ "addr"=>"a8:5e:45:c1:2f:eb" }]
@@ -225,6 +225,11 @@ describe Y2Autoinstallation::Y2ERB::TemplateEnvironment do
       expect(subject.disks).to be_a(Array)
       expect(subject.disks).to be_all(Hash)
     end
+  end
 
+  describe "#os_release" do
+    it "returns hash" do
+      expect(subject.os_release).to be_a(Hash)
+    end
   end
 end

--- a/test/lib/y2erb_test.rb
+++ b/test/lib/y2erb_test.rb
@@ -22,11 +22,179 @@ require_relative "../test_helper"
 require "tempfile"
 require "autoinstall/y2erb"
 
+# reduced probe agent output
+def hardware_mock_data
+  {
+    "disk"    => [{
+      "bios_id"           => "0x80",
+      "bus"               => "PCI",
+      "bus_hwcfg"         => "pci",
+      "class_id"          => 262,
+      "detail"            => { "channel" => 0, "host" => 0, "id" => 0, "lun" => 0 },
+      "dev_name"          => "/dev/nvme0n1",
+      "dev_names"         => ["/dev/nvme0n1"],
+      "dev_num"           => { "major" => 259, "minor" => 0, "range" => 0, "type" => "b" },
+      "device_id"         => 87056,
+      "driver"            => "nvme",
+      "driver_module"     => "nvme",
+      "model"             => "Micron Disk",
+      "old_unique_key"    => "m6To.U1c9LpxaqD7",
+      "parent_unique_key" => "svHJ.xTzyOFkYIiA",
+      "resource"          => {
+        "disk_log_geo" => [{ "cylinders" => 488386, "heads" => 64, "sectors" => 32 }],
+        "size"         => [{ "unit" => "sectors", "x" => 1000215216, "y" => 512 }]
+      },
+      "sub_class_id"      => 0,
+      "sub_device_id"     => 65792,
+      "sub_vendor"        => "Micron Technology Inc",
+      "sub_vendor_id"     => 70468,
+      "sysfs_bus_id"      => "nvme0",
+      "sysfs_id"          => "/class/block/nvme0n1",
+      "unique_key"        => "wLCS.U1c9LpxaqD7",
+      "vendor"            => "Micron Technology Inc",
+      "vendor_id"         => 70468
+    }],
+    "netcard" => [
+      {
+        "bus"               => "PCI",
+        "bus_hwcfg"         => "pci",
+        "bus_id"            => 2,
+        "class_id"          => 2,
+        "dev_name"          => "enp2s0",
+        "dev_names"         => ["enp2s0"],
+        "device"            => "RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller",
+        "device_id"         => 98664,
+        "driver"            => "r8169",
+        "driver_module"     => "r8169",
+        "drivers"           => [{ "active" => true, "modprobe" => true,
+        "modules" => [["r8169", ""]] }],
+        "modalias"          => "pci:v000010ECd00008168sv00001043sd0000208Fbc02sc00i00",
+        "model"             =>
+                               "Realtek RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller",
+        "old_unique_key"    => "bbxe.g1yJ3amPfwB",
+        "parent_unique_key" => "e6j0.CB0G3oMQsS4",
+        "resource"          => {
+          "hwaddr"  => [{ "addr"=>"a8:5e:45:c1:2f:eb" }],
+          "io"      => [{ "active" => true, "length" => 256,
+                                                            "mode" => "rw", "start" => 57344 }],
+          "irq"     => [{ "count" => 0, "enabled" => true,
+                                                            "irq" => 71 }],
+          "link"    => [{ "state"=>false }],
+          "mem"     =>
+                       [{ "active" => true, "length" => 4096,
+                                                                         "start" => 4152377344 },
+                        { "active" => true, "length" => 16384,
+                        "start" => 4152360960 }],
+          "phwaddr" => [{ "addr"=>"a8:5e:45:c1:2f:eb" }]
+        },
+        "rev"               => "21",
+        "sub_class_id"      => 0,
+        "sub_device_id"     => 73871,
+        "sub_vendor"        => "ASUSTeK Computer Inc.",
+        "sub_vendor_id"     => 69699,
+        "sysfs_bus_id"      => "0000:02:00.0",
+        "sysfs_id"          => "/devices/pci0000:00/0000:00:01.2/0000:02:00.0",
+        "unique_key"        => "c3qJ.g1yJ3amPfwB",
+        "vendor"            => "Realtek Semiconductor Co., Ltd.",
+        "vendor_id"         => 69868
+      },
+      {
+        "bus"               => "PCI",
+        "bus_hwcfg"         => "pci",
+        "bus_id"            => 4,
+        "class_id"          => 2,
+        "device"            => "RTL8821CE 802.11ac PCIe Wireless Network Adapter",
+        "device_id"         => 116769,
+        "modalias"          => "pci:v000010ECd0000C821sv00001A3Bsd00003041bc02sc80i00",
+        "model"             => "Realtek RTL8821CE 802.11ac PCIe Wireless Network Adapter",
+        "old_unique_key"    => "aher.1HJgn3FRa50",
+        "parent_unique_key" => "yk9C.CB0G3oMQsS4",
+        "resource"          =>
+                               { "io"  =>
+                                          [{ "active" => false, "length" => 256, "mode" => "rw",
+                                                             "start" => 53248 }],
+                                 "irq" =>
+                                          [{ "count" => 0, "enabled" => true, "irq" => 255 }],
+                                 "mem" =>
+                                          [{ "active" => false, "length" => 65536,
+                                                             "start" => 4150263808 }] },
+        "sub_class_id"      => 128,
+        "sub_device_id"     => 77889,
+        "sub_vendor"        => "AzureWave",
+        "sub_vendor_id"     => 72251,
+        "sysfs_bus_id"      => "0000:04:00.0",
+        "sysfs_id"          => "/devices/pci0000:00/0000:00:01.7/0000:04:00.0",
+        "unique_key"        => "YmUS.1HJgn3FRa50",
+        "vendor"            => "Realtek Semiconductor Co., Ltd.",
+        "vendor_id"         => 69868
+      },
+      {
+        "bus"               => "USB",
+        "bus_hwcfg"         => "usb",
+        "class_id"          => 2,
+        "dev_name"          => "wlp5s0f4u2",
+        "dev_names"         => ["wlp5s0f4u2"],
+        "device"            => "RTL8188EUS 802.11n Wireless Network Adapter",
+        "device_id"         => 229753,
+        "driver"            => "r8188eu",
+        "driver_module"     => "r8188eu",
+        "drivers"           =>
+                               [{ "active" => true, "modprobe" => true,
+                                             "modules" => [["r8188eu", ""]] }],
+        "hotplug"           => "usb",
+        "modalias"          => "usb:v0BDAp8179d0000dc00dsc00dp00icFFiscFFipFFin00",
+        "model"             => "Realtek RTL8188EUS 802.11n Wireless Network Adapter",
+        "old_unique_key"    => "mEws.W2OkjY9u_45",
+        "parent_unique_key" => "uIhY.Md0RKo+2xQF",
+        "resource"          =>
+                               { "baud"    => [{ "speed"=>480000000 }],
+                                 "hwaddr"  => [{ "addr"=>"50:3e:aa:d7:45:9f" }],
+                                 "link"    => [{ "state"=>true }],
+                                 "phwaddr" => [{ "addr"=>"50:3e:aa:d7:45:9f" }],
+                                 "wlan"    =>
+                                              [{ "auth_modes"  => [
+                                                "open", "wpa-psk", "wpa-eap"
+                                              ],
+                                                 "bitrates"    => [
+                                                   "1", "2", "5.5", "11"
+                                                 ],
+                                                 "channels"    => [
+                                                   "1", "2", "3", "4", "5", "6", "7",
+                                                   "8", "9", "10", "11", "12", "13"
+                                                 ],
+                                                 "enc_modes"   => ["TKIP", "CCMP"],
+                                                 "frequencies" =>
+                                                                  ["2.412",
+                                                                   "2.417",
+                                                                   "2.422",
+                                                                   "2.427",
+                                                                   "2.432",
+                                                                   "2.437",
+                                                                   "2.442",
+                                                                   "2.447",
+                                                                   "2.452",
+                                                                   "2.457",
+                                                                   "2.462",
+                                                                   "2.467",
+                                                                   "2.472"] }] },
+        "sub_class_id"      => 130,
+        "sysfs_bus_id"      => "3-2:1.0",
+        "sysfs_id"          =>
+                               "/devices/pci0000:00/0000:00:08.1/0000:05:00.4/usb3/3-2/3-2:1.0",
+        "unique_key"        => "mZxt.M1BlfozBLm7",
+        "vendor"            => "Realtek Semiconductor Corp.",
+        "vendor_id"         => 199642,
+        "wlan"              => true
+      }
+    ]
+  }
+end
+
 describe Y2Autoinstallation::Y2ERB do
   describe ".render" do
     it "returns string with rendered template" do
       # mock just for optimization
-      allow(Yast::SCR).to receive(:Read).and_return({})
+      allow(Yast::SCR).to receive(:Read).and_return(hardware_mock_data)
       file = Tempfile.new("test")
       path = file.path
       file.write("<test><%= hardware.inspect %></test>")
@@ -36,5 +204,27 @@ describe Y2Autoinstallation::Y2ERB do
 
       expect(result).to match(/<test>{.*}<\/test>/)
     end
+  end
+end
+
+describe Y2Autoinstallation::Y2ERB::TemplateEnvironment do
+  before do
+    allow(Yast::SCR).to receive(:Read).and_return(hardware_mock_data)
+  end
+
+  describe "#network_cards" do
+    it "returns list of map" do
+      expect(subject.network_cards).to be_a(Array)
+      expect(subject.network_cards).to be_all(Hash)
+    end
+  end
+
+  describe "#disks" do
+    it "returns list of map" do
+      allow(::File).to receive(:read).with(/\/sys\/block/).and_return("\n")
+      expect(subject.disks).to be_a(Array)
+      expect(subject.disks).to be_all(Hash)
+    end
+
   end
 end


### PR DESCRIPTION
trello: https://trello.com/c/zHOebVq5/2036-5-research-extend-dynamic-profile-helpers

new profile that works ( for old see https://github.com/yast/yast-autoinstallation/pull/667 ) :+1: 

```erb
<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
  <%# example how to dynamic force multipath. Here it use storage model and if
      it contain case insensitive word multipath %>
  <% if hardware["storage"].any? { |s| s["model"] =~ /multipath/i } %>
    <general>
      <storage>
        <start_multipath t="boolean">true</start_multipath>
      </storage>
    </general>
  <% end %>
  <software>
    <products config:type="list">
      <product>openSUSE</product>
    </products>
  </software>
  <%# first lets create list of disk names according to its size %>
  <% sorted_disks = disks.sort_by { |d| d[:size] }.map { |d| d[:device] }.reverse %>
  <partitioning t="list">
    <% sorted_disks[0..1].each do |name| %>
      <drive>
         <device>
           <%= name %>
         </device>
         <initialize t="boolean">
           true
         </initialize>
       </drive>
    <% end %>
  </partitioning>
  <%# situation: machine has two network catds. One leads to intranet and other to internet, so here we create udev
      rules to have internet one as eth0 and intranet as eth1. To distinguish in this example if use active flag for intranet %>
  <networking>
    <net-udev t="list">
      <rule>
        <name>eth0</name>
        <rule>ATTR{address}</rule>
        <value>
  	<%= network_cards.find { |c| c[:link] }[:mac] %>
        </value>
      </rule>
      <rule>
        <name>eth1</name>
        <rule>ATTR{address}</rule>
        <value>
  	<%= network_cards.find { |c| !c[:link] }[:mac] %>
        </value>
      </rule>
    </net-udev>
  </networking>
</profile>
```

diff of them:
```diff
--- dynamic.erb	2020-08-25 16:04:26.465592057 +0200
+++ dynamic.erb.1	2020-09-02 13:25:07.405540474 +0200
@@ -13,10 +13,10 @@
       <product>openSUSE</product>
     </products>
   </software>
-  <%# for details about values see libhd  TODO: better API? %>
-  <% disks = hardware["disk"].sort_by { |d| s = d["resource"]["size"].first; s["x"]*s["y"] }.map { |d| d["dev_name"] }.reverse %>
+  <%# first lets create list of disk names according to its size %>
+  <% sorted_disks = disks.sort_by { |d| d[:size] }.map { |d| d[:device] }.reverse %>
   <partitioning t="list">
-    <% disks[0..1].each do |name| %>
+    <% sorted_disks[0..1].each do |name| %>
       <drive>
          <device>
            <%= name %>
@@ -28,21 +28,21 @@
     <% end %>
   </partitioning>
   <%# situation: machine has two network catds. One leads to intranet and other to internet, so here we create udev
-      rules to have internet one as eth0 and intranet as eth1. To distinguish in this example intranet one is not active %>
+      rules to have internet one as eth0 and intranet as eth1. To distinguish in this example if use active flag for intranet %>
   <networking>
     <net-udev t="list">
       <rule>
         <name>eth0</name>
         <rule>ATTR{address}</rule>
         <value>
-  	<%= hardware["netcard"].find { |c| c["resource"]["link"].first["state"] }["resource"]["phwaddr"].first["addr"] %>
+  	<%= network_cards.find { |c| c[:link] }[:mac] %>
         </value>
       </rule>
       <rule>
         <name>eth1</name>
         <rule>ATTR{address}</rule>
         <value>
-  	<%= hardware["netcard"].find { |c| !c["resource"]["link"].first["state"] }["resource"]["phwaddr"].first["addr"] %>
+  	<%= network_cards.find { |c| !c[:link] }[:mac] %>
         </value>
       </rule>
     </net-udev>
```