### PR TITLE
bsc#1175714: export postpartitioning-scripts section properly

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  1 11:13:05 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use <script> elements instead of <listentry> when exporting the
+  <postpartitioning-scripts> section (bsc#1175714).
+- 4.3.42
+
+-------------------------------------------------------------------
 Thu Aug 27 13:20:00 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the AutoYaST storage UI (related to bsc#1175680).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.41
+Version:        4.3.42
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/include/autoinstall/xml.rb
+++ b/src/include/autoinstall/xml.rb
@@ -51,6 +51,7 @@ module Yast
         "post-scripts"             => "script",
         "chroot-scripts"           => "script",
         "init-scripts"             => "script",
+        "postpartitioning-scripts" => "script",
         "local_domains"            => "domains",
         "masquerade_other_domains" => "domain",
         "masquerade_users"         => "masquerade_user",


### PR DESCRIPTION
When processing the profile, AutoYaST exports/imports it again in order [to clean-up the profile](https://github.com/yast/yast-autoinstallation/blob/94cd6e43391b66bcd57394156c5b0b2791082cfe/src/include/autoinstall/classes.rb#L19). The problem is that the `<postpartitioning-scripts>` is not exported properly: it uses `<listentry>` elements instead of `<script>`.