### PR TITLE
bsc#1175714: export postpartitioning-scripts section properly

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  1 11:32:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use <script> elements instead of <listentry> when exporting the
+  <postpartitioning-scripts> section (related to bsc#1175714).
+- 3.2.46
+
+-------------------------------------------------------------------
 Fri Apr  3 09:27:04 CEST 2020 - schubi@suse.de
 
 - Clone system: Reverting wrong fix for adding not used devices to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           autoyast2
-Version:        3.2.45
+Version:        3.2.46
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/autoinstall/xml.rb
+++ b/src/include/autoinstall/xml.rb
@@ -55,6 +55,7 @@ module Yast
           "post-scripts"             => "script",
           "chroot-scripts"           => "script",
           "init-scripts"             => "script",
+          "postpartitioning-scripts" => "script",
           "local_domains"            => "domains",
           "masquerade_other_domains" => "domain",
           "masquerade_users"         => "masquerade_user",


### PR DESCRIPTION
Backport of https://github.com/yast/yast-autoinstallation/pull/676. It will not trigger the same error, but it can affect any user that uses the AutoYaST UI to generate a `postpartitioning-scripts` section.