### PR TITLE
Add NetworkManager package when missing in software but needed

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -3,7 +3,7 @@ Mon Sep  7 07:58:56 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - When 'NetworkManager' is selected in the profile as the network
   backend to be used, the 'NetworkManager' package is added to the
-  list of packages to be installed in case of missing.
+  list of packages to be installed in case of missing (bsc#1172817)
 - 4.2.44
 
 -------------------------------------------------------------------

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Sep  7 07:58:56 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- When 'NetworkManager' is selected in the profile as the network
+  backend to be used, the 'NetworkManager' package is added to the
+  list of packages to be installed in case of missing.
+- 4.2.44
+
+-------------------------------------------------------------------
 Tue Sep  1 11:32:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use <script> elements instead of <listentry> when exporting the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.43
+Version:        4.2.44
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -187,6 +187,17 @@ module Yast
       true
     end
 
+    # Add the given list of packages to the one to be installed
+    #
+    # @param pkglist [Array<String>] list of additional packages to be installed
+    def add_additional_packages(pkglist)
+      pkglist.each do |p|
+        if !PackageAI.toinstall.include?(p) && @packagesAvailable.include?(p)
+          PackageAI.toinstall.push(p)
+        end
+      end
+    end
+
     def AddYdepsFromProfile(entries)
       Builtins.y2milestone("AddYdepsFromProfile entries %1", entries)
       pkglist = []
@@ -232,11 +243,7 @@ module Yast
       end
       pkglist.uniq!
       Builtins.y2milestone("AddYdepsFromProfile pkglist %1", pkglist)
-      pkglist.each do |p|
-        if !PackageAI.toinstall.include?(p) && @packagesAvailable.include?(p)
-          PackageAI.toinstall.push(p)
-        end
-      end
+      add_additional_packages(pkglist)
     end
 
     # Constructer

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -28,6 +28,31 @@ describe Yast::AutoinstSoftware do
     end
   end
 
+  describe "#add_additional_packages" do
+    let(:pkgs) { ["NetworkManager"] }
+    let(:available_packages) { ["a1", "a2", "a3", "NetworkManager"] }
+
+    before do
+      allow(Yast::Pkg).to receive(:GetPackages)
+        .with(:available, true).and_return(available_packages)
+      subject.Import(Yast::Profile.current["software"])
+    end
+
+    it "appends the given list to the one to be installed" do
+      Yast::AutoinstSoftware.add_additional_packages(pkgs)
+      expect(Yast::PackageAI.toinstall).to include("NetworkManager")
+    end
+
+    context "when the packages given are not available" do
+      let(:available_packages) { ["a1", "a2", "a3"] }
+
+      it "the packages are not added" do
+        Yast::AutoinstSoftware.add_additional_packages(pkgs)
+        expect(Yast::PackageAI.toinstall).to_not include("NetworkManager")
+      end
+    end
+  end
+
   describe "#Export" do
     it "puts product definition into the exported profile" do
       expect(Yast::Product)


### PR DESCRIPTION
## Problem

If the NetworkManager package is not added explicitly into the software section then it is not enabled correctly during the first_stage switching to wicked as the network service.

In the second stage, it does not try to switch between backends and the check of needed packages is based in the current service which is wrong according to the profile.

- https://trello.com/c/yeV9lOmS/2025-3-sled15-sp2-p3-1172817-networkmanager-not-getting-installed-via-autoyast-sled-15-sp2-rc3

## Solution

Add the package to the list of packages to be installed when 'NetworkManager' is selected as the network backend to be used.