### PR TITLE
Fix storage reading

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 14 10:34:41 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the returned value form the AutoinstPartPlan's Read method
+  (boo#1176490).
+- 4.3.48
+
+-------------------------------------------------------------------
 Fri Sep 11 14:14:19 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Formally mark that fixes made for SP2 no longer affect SP3

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.47
+Version:        4.3.48
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstPartPlan.rb
+++ b/src/modules/AutoinstPartPlan.rb
@@ -121,6 +121,8 @@ module Yast
     end
 
     # Gets the probed partitioning from the storage manager
+    #
+    # @return [Boolean]
     def Read
       devicegraph = Y2Storage::StorageManager.instance.probed
       @plan = Y2Storage::AutoinstProfile::PartitioningSection.new_from_storage(devicegraph)

--- a/src/modules/AutoinstPartPlan.rb
+++ b/src/modules/AutoinstPartPlan.rb
@@ -65,12 +65,6 @@ module Yast
       @modified
     end
 
-    # Create a partition plan for the calling client
-    # @return [Array] partition plan
-    def ReadHelper
-      profile.to_hashes
-    end
-
     # PUBLIC INTERFACE
 
     # INTER FACE TO CONF TREE

--- a/src/modules/AutoinstPartPlan.rb
+++ b/src/modules/AutoinstPartPlan.rb
@@ -130,6 +130,7 @@ module Yast
     def Read
       devicegraph = Y2Storage::StorageManager.instance.probed
       @plan = Y2Storage::AutoinstProfile::PartitioningSection.new_from_storage(devicegraph)
+      true
     end
 
     # Dump the settings to a map, for autoinstallation use.

--- a/test/AutoinstPartPlan_test.rb
+++ b/test/AutoinstPartPlan_test.rb
@@ -72,6 +72,10 @@ describe "Yast::AutoinstPartPlan" do
       subject.Read
       expect(subject.Export).to eq(partitioning.to_hashes)
     end
+
+    it "returns true" do
+      expect(subject.Read).to eq(true)
+    end
   end
 
   describe "#Import" do


### PR DESCRIPTION
[boo#1176490](https://bugzilla.opensuse.org/show_bug.cgi?id=1176490). Basically, `AuitoinstPartPlan.Read` should return a ycp-compatible type.

Trello: https://trello.com/c/sSED0daZ/4281-drop-autoinstdrive-autoinstpartition-and-friends