### PR TITLE
Add missing MAP type to bcache_options element

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 17 09:30:44 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Fix 'bcache_options' element using the right type (bsc#1176595)
+- 4.3.49
+
+-------------------------------------------------------------------
 Mon Sep 14 10:34:41 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the returned value form the AutoinstPartPlan's Read method

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.48
+Version:        4.3.49
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -156,7 +156,7 @@ device_order = element device_order {
 }
 
 cache_mode = element cache_mode { STRING_ATTR, ("writethrough" | "writeback" | "writearound" | "none") }
-bcache_options = element bcache_options { cache_mode? }
+bcache_options = element bcache_options { MAP, (cache_mode?) }
 
 btrfs_name = element btrfs_name { STRING }
 


### PR DESCRIPTION
### Problem

The AutoYaST profile validation started failing because the missing `MAP` attribute in the schema for the `bcache_options` element.

* https://bugzilla.suse.com/show_bug.cgi?id=1176595

### Solution

To update the `partitioning.rnc` file, setting the `MAP` type to the `bcache_options` element. 

### Tests

Tested manually - runing the xmllint validation locally - following steps described in https://github.com/yast/yast-autoinstallation/pull/650
