### PR TITLE
Reimport general and report sections in case of pre-script modified profile

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 17 20:03:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Import general and report sections in case that some pre-script
+  modified the profile (bsc#1175725)
+- 4.2.45
+
+-------------------------------------------------------------------
 Mon Sep  7 07:58:56 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - When 'NetworkManager' is selected in the profile as the network

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.44
+Version:        4.2.45
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -174,8 +174,13 @@ module Y2Autoinstallation
           break if ret == :not_found
         end
 
-        # reimport scripts, for the case <ask> has changed them
-        Yast::AutoinstScripts.Import(Yast::Profile.current["scripts"] || {})
+        if modified_profile?
+          # reimport scripts, for the case <ask> has changed them
+          Yast::AutoinstScripts.Import(Yast::Profile.current["scripts"] || {})
+          Yast::Report.Import(Yast::Profile.current.fetch("report", {}))
+          Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
+        end
+
         :ok
       end
 

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -150,7 +150,8 @@ module Y2Autoinstallation
       # an ask-list is declared redoing the import and write of the pre-scripts as
       # many times as needed.
       def autoinit_scripts
-        # pre-scripts should be already imported
+        # Pre-Scripts
+        Yast::AutoinstScripts.Import(Yast::Profile.current["scripts"] || {})
         Yast::AutoinstScripts.Write("pre-scripts", false)
 
         # Reread Profile in case it was modified in pre-script
@@ -173,6 +174,7 @@ module Y2Autoinstallation
           break if ret == :not_found
         end
 
+        # reimport scripts, for the case <ask> has changed them
         import_initial_config if modified_profile?
         :ok
       end
@@ -180,10 +182,9 @@ module Y2Autoinstallation
       # Imports the initial profile configuration (report, general and
       # pre-scripts sections)
       def import_initial_config
-        # reimport scripts, for the case <ask> has changed them
-        Yast::AutoinstScripts.Import(Yast::Profile.current.fetch("scripts", {}))
         Yast::Report.Import(Yast::Profile.current.fetch("report", {}))
         Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
+        Yast::AutoinstScripts.Import(Yast::Profile.current.fetch("scripts", {}))
       end
 
       # Checking profile for unsupported sections.

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -150,8 +150,7 @@ module Y2Autoinstallation
       # an ask-list is declared redoing the import and write of the pre-scripts as
       # many times as needed.
       def autoinit_scripts
-        # Pre-Scripts
-        Yast::AutoinstScripts.Import(Yast::Profile.current["scripts"] || {})
+        # pre-scripts should be already imported
         Yast::AutoinstScripts.Write("pre-scripts", false)
 
         # Reread Profile in case it was modified in pre-script
@@ -174,14 +173,17 @@ module Y2Autoinstallation
           break if ret == :not_found
         end
 
-        if modified_profile?
-          # reimport scripts, for the case <ask> has changed them
-          Yast::AutoinstScripts.Import(Yast::Profile.current["scripts"] || {})
-          Yast::Report.Import(Yast::Profile.current.fetch("report", {}))
-          Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
-        end
-
+        import_initial_config if modified_profile?
         :ok
+      end
+
+      # Imports the initial profile configuration (report, general and
+      # pre-scripts sections)
+      def import_initial_config
+        # reimport scripts, for the case <ask> has changed them
+        Yast::AutoinstScripts.Import(Yast::Profile.current.fetch("scripts", {}))
+        Yast::Report.Import(Yast::Profile.current.fetch("report", {}))
+        Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
       end
 
       # Checking profile for unsupported sections.
@@ -265,8 +267,7 @@ module Y2Autoinstallation
         Yast::Progress.NextStage
         Yast::Progress.Title(_("Initial Configuration"))
         log.info "Initial Configuration"
-        Yast::Report.Import(Yast::Profile.current.fetch("report", {}))
-        Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
+        import_initial_config
 
         #
         # Copy the control file for easy access by user to  a pre-defined


### PR DESCRIPTION
## Problem

The import of the general and report configuration happens before the `pre-scripts` handling. Thus, the signature handling and report default configuration is not imported correctly if not defined in the `pre-script` xml.

In the bug in particular, it complains when a repository is added and it is not digitally signed.

- https://trello.com/c/zkB79isR/2057-3-sles15-sp2-p5-1175725-even-when-setting-insecure1-there-is-an-error-that-the-repomdxml-is-not-digitally-signed

## Solution

Import both configurations ('report' and 'general') if the profile is modified by pre-scripts.

## Tests

- Tested manually with a pre-script without signature handling section which fetches the complete profile:

