### PR TITLE
Import initial configuration from the profile when modified by pre-scripts

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 18 11:22:49 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Reimport the initial configuration in case that the profile
+  is modified by pre-scripts (bsc#1175725)
+- 4.0.76
+
+-------------------------------------------------------------------
 Tue Sep  1 11:32:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use <script> elements instead of <listentry> when exporting the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.0.75
+Version:        4.0.76
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_autoinit.rb
+++ b/src/clients/inst_autoinit.rb
@@ -171,9 +171,17 @@ module Yast
         break if ret == :not_found
       end
 
-      # reimport scripts, for the case <ask> has changed them
-      AutoinstScripts.Import(Ops.get_map(Profile.current, "scripts", {}))
+      import_initial_config if modified_profile?
       :ok
+    end
+
+    # Imports the initial profile configuration (report, general and
+    # pre-scripts sections)
+    def import_initial_config
+      # reimport scripts, for the case <ask> has changed them
+      Yast::AutoinstScripts.Import(Yast::Profile.current.fetch("scripts", {}))
+      Yast::Report.Import(Yast::Profile.current.fetch("report", {}))
+      Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
     end
 
     # Checking profile for unsupported sections.
@@ -259,8 +267,7 @@ module Yast
       Progress.NextStage
       Progress.Title(_("Initial Configuration"))
       Builtins.y2milestone("Initial Configuration")
-      Report.Import(Profile.current.fetch("report",{}))
-      AutoinstGeneral.Import(Profile.current.fetch("general",{}))
+      import_initial_config
 
       #
       # Copy the control file for easy access by user to  a pre-defined


### PR DESCRIPTION
Fix from #698 backported to GA as we did when moved the pre-scripts ASAP (related to https://github.com/yast/yast-autoinstallation/pull/638)