### PR TITLE
Fix IBS build using Builtin.union instead of unsupported Array#union

### DIFF
--- a/src/modules/AutoInstallRules.rb
+++ b/src/modules/AutoInstallRules.rb
@@ -981,7 +981,7 @@ module Yast
         if profile_class.keys.include?("dont_merge")
           AutoinstConfig.dontmerge = [] if @dontmergeIsDefault
           not_mergeable = profile_class.fetch("dont_merge", [])
-          AutoinstConfig.dontmerge = (AutoinstConfig.dontmerge || []).union(not_mergeable)
+          AutoinstConfig.dontmerge = Builtins.union(AutoinstConfig.dontmerge || [], not_mergeable)
           @dontmergeIsDefault = false
           log.info("user defined dont_merge for class found. " \
                    "dontmerge is #{AutoinstConfig.dontmerge}")


### PR DESCRIPTION
It fixes the submit to IBS as the used method is not supported in ruby-2.5 see https://ci.suse.de/job/yast-yast-autoinstallation-master/69/console