### PR TITLE
Fix tests to use correct storage instance

### DIFF
--- a/test/autoinst_clone_test.rb
+++ b/test/autoinst_clone_test.rb
@@ -72,6 +72,7 @@ describe Yast::AutoinstClone do
   let(:multipaths) { [] }
 
   before do
+    Y2Storage::StorageManager.create_test_instance
     allow(Yast::Y2ModuleConfig).to receive(:ModuleMap).and_return(module_map)
     allow(Y2Storage::StorageManager.instance).to receive(:probed).and_return(probed_devicegraph)
     subject.additional = ["add-on"]


### PR DESCRIPTION
## Problem

The build of the package is failing in different architectures:

https://build.suse.de/package/live_build_log/Devel:YaST:SLE-15-SP2/autoyast2/SUSE_SLE-15-SP2_Update/aarch64

[   88s]      # Storage::LockException:
[   88s]      #   Storage::LockException
[   88s]      #   /usr/share/YaST2/lib/y2storage/storage_manager.rb:88:in `initialize'

Apparently we are not using the proper storage instance

## Soluction

Use a storage test instance for running the unit tests.