### PR TITLE
Improve libxml2 validation errors presentation

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 29 13:55:29 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve validation errors presentation (related to bsc#1176973).
+- 4.3.56
+
+-------------------------------------------------------------------
 Tue Sep 29 09:52:11 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Drop the 'general/mouse' element from the schema. It has been

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.55
+Version:        4.3.56
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -168,7 +168,8 @@ module Y2Autoinstallation
         # TRANSLATORS: Warn user about using invalid XML
         _("Using an invalid XML document might result in an unexpected behavior, " \
           "crash or even data loss!") +
-        "</p><h4>" + _("Details") + "</h4>" + ERB::Util.html_escape(errors.join("<br>")) +
+        "</p><h4>" + _("Details") + "</h4>" \
+        "<p>" + ERB::Util.html_escape(errors.join("<br>")) + "</p>" \
         "<h4>" + _("Note") + "</h4>" +
         # TRANSLATORS: A hint how to check a XML file, displayed as a part of the
         # validation error message, %{jing} and %{xmllint} are replaced by shell commands,


### PR DESCRIPTION
Improve validation errors presentation. In Qt, the errors were looking good. However, the "details" header does not look good in textmode.

## Before

![validation-error-ko](https://user-images.githubusercontent.com/15836/94574847-7e616380-026b-11eb-8763-5620fcf38e2c.png)

# After

![validation-error-ok](https://user-images.githubusercontent.com/15836/94574861-80c3bd80-026b-11eb-8d9c-ed853da53f59.png)

