### PR TITLE
Fix inst_autosetup client tests

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct  2 07:04:25 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix 'inst_autosetup' tests (bsc#1177227).
+- 4.3.58
+
+-------------------------------------------------------------------
 Thu Oct  1 05:58:50 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add validation of 'activate_systemd_default_target' and

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.57
+Version:        4.3.58
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -42,7 +42,7 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       allow(Yast::Progress).to receive(:Title)
       allow(Yast::AutoinstStorage).to receive(:Import).and_return(true)
       allow(Yast::AutoinstStorage).to receive(:Write).and_return(true)
-      allow(Yast::Profile).to receive(:current).and_return(profile)
+
       allow(Yast::WFM).to receive(:CallFunction).with(/_auto/, Array).and_return(true)
       allow(Yast::Popup).to receive(:ConfirmAbort).and_return(true)
 
@@ -59,6 +59,7 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       allow(subject).to receive(:probe_storage)
       allow(Yast::AutoinstSoftware).to receive(:Write).and_return(true)
       allow(Yast::ServicesManager).to receive(:import)
+      Yast::Profile.current = profile
     end
 
     it "sets up the network" do
@@ -174,7 +175,7 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
     end
 
     it "sets up the software" do
-      expect(Yast::AutoinstSoftware).to receive(:Import).with(profile["software"])
+      expect(Yast::AutoinstSoftware).to receive(:Import).with(a_hash_including(profile["software"]))
       expect(Yast::AutoinstSoftware).to receive(:Write).and_return(true)
       subject.main
     end


### PR DESCRIPTION
Fix [bsc#1177227](https://bugzilla.suse.com/show_bug.cgi?id=1177227).