### PR TITLE
Resolve "zzz_reboot" script conflict (bsc#1177036)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct  6 07:20:14 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Resolve "zzz_reboot" script conflict (bsc#1177036)
+- 4.3.59
+
+-------------------------------------------------------------------
 Fri Oct  2 07:04:25 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix 'inst_autosetup' tests (bsc#1177227).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.58
+Version:        4.3.59
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -160,7 +160,9 @@ module Yast
         if @online_update_ret == :reboot
           # AddEditScript(scriptName, source, interpreter, type, chrooted, debug, feedback,
           #  feedback_type, location, notification)
-          AutoinstScripts.AddEditScript("zzz_reboot", "shutdown -r now", "shell", "init",
+          # make sure to avoid conflicts with "zzz_reboot" script here
+          # https://github.com/yast/yast-autoinstallation/blob/104c18f1a56d02ab50055cdf09653db964b97888/src/modules/Profile.rb#L157
+          AutoinstScripts.AddEditScript("zzzz_reboot", "shutdown -r now", "shell", "init",
             false, false, false, "", "", "") # wonderful API without defaults
         end
       end


### PR DESCRIPTION
- There was a conflict between `zzz_reboot` scripts [here](https://github.com/yast/yast-autoinstallation/blob/104c18f1a56d02ab50055cdf09653db964b97888/src/modules/Profile.rb#L157) and [here](https://github.com/yast/yast-autoinstallation/blob/39bc71d066b81ec6e3a6e73003f6bf45bc80b99f/src/clients/inst_autoconfigure.rb#L163)
- The AutoYaST reported an error [here](https://github.com/yast/yast-autoinstallation/blob/f71897c873392c0478312ef175495974dabbc8e6/src/modules/AutoinstScripts.rb#L147)
- 4.3.59