### PR TITLE
bsc#1177322: progress bar length

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  8 08:33:12 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the progress bar length during autoinstallation
+  initialization (bsc#1177322).
+
+-------------------------------------------------------------------
 Tue Oct  6 07:20:14 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Resolve "zzz_reboot" script conflict (bsc#1177036)

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -59,7 +59,7 @@ module Y2Autoinstallation
         Yast::Progress.New(
           _("Preparing System for Automatic Installation"),
           "", # progress_title
-          6, # progress bar length
+          7, # progress bar length
           progress_stages,
           [],
           help_text


### PR DESCRIPTION
Fixes [bsc#1177322](https://bugzilla.suse.com/show_bug.cgi?id=1177322).