### PR TITLE
bsc#1176834: allow setting the config:type for upgrade/backup

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 13 10:06:05 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow setting the 't' (or 'config:type') attribute in the
+  'backup' and 'upgrade' elements (bsc#1176834 and bsc#1176848).
+- 4.3.61
+
+-------------------------------------------------------------------
 Thu Oct  8 15:31:12 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not show a warning the user when a script just did not run

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.60
+Version:        4.3.61
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/backup.rnc
+++ b/src/autoyast-rnc/backup.rnc
@@ -4,7 +4,10 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 backup =
   element backup {
-    element modified { BOOLEAN }? &
-    element remove_old { BOOLEAN }? &
-    element sysconfig { BOOLEAN }?
+    MAP,
+    (
+      element modified { BOOLEAN }? &
+      element remove_old { BOOLEAN }? &
+      element sysconfig { BOOLEAN }?
+    )
 }

--- a/src/autoyast-rnc/upgrade.rnc
+++ b/src/autoyast-rnc/upgrade.rnc
@@ -4,5 +4,8 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 upgrade =
   element upgrade {
-    element stop_on_solver_conflict { BOOLEAN }?
+    MAP,
+    (
+      element stop_on_solver_conflict { BOOLEAN }?
+    )
 }


### PR DESCRIPTION
Another fix for [bsc#1176834](https://bugzilla.suse.com/show_bug.cgi?id=1176834) and [bsc#1176848](https://bugzilla.suse.com/show_bug.cgi?id=1176848).

See https://github.com/yast/yast-schema/pull/92 for `yast2-schema` counterpart.