### PR TITLE
XML validation timeout

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 21 06:09:04 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST warnings timeout applies to the XML validation error
+  dialog (bsc#1176973).
+- 4.3.62
+
+-------------------------------------------------------------------
 Tue Oct 13 10:06:05 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow setting the 't' (or 'config:type') attribute in the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.61
+Version:        4.3.62
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/xml_checks.rb
+++ b/src/lib/autoinstall/xml_checks.rb
@@ -100,8 +100,9 @@ module Y2Autoinstallation
 
       ret = Yast2::Popup.show(message(msg, validator.errors, file, schema),
         richtext: true,
-        headline: :error,
+        headline: :warning,
         buttons:  :continue_cancel,
+        timeout:  Yast::Report.Export["warnings"]["timeout"],
         focus:    :cancel) == :continue
 
       if ret


### PR DESCRIPTION
We have received some complaints about the XML validation being annoying (e.g., see [bsc#1176973](https://bugzilla.suse.com/show_bug.cgi?id=1176973#c9)). We would like to keep it enabled by default, but we have decided to apply the same timeout that applies to any other AutoYaST warning (10 seconds by default).