### PR TITLE
Upgrade: Checking if a valid base product has been selected for upgra…

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 14 14:38:35 UTC 2021 - Stefan Schubert <schubi@suse.de>
+
+- Upgrade: Checking if a valid base product has been selected for
+  upgrade and if not asking the user to check the product entry
+  in the AY configuration file (bsc#1175876).
+- 4.2.47
+
+-------------------------------------------------------------------
 Tue Sep 29 09:52:11 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Drop the 'general/mouse' element from the schema. It has been

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.46
+Version:        4.2.47
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -132,8 +132,8 @@ module Y2Autoinstallation
            "in the AutoYaST configuration file. " \
            "Please check the <b>products</b> entry in the <b>software</b> section.<br><br>" \
            "Following base products are available:<br>")
-          Yast::AutoinstFunctions.available_base_products.each do |product|
-            msg += "#{product.name} (#{product.display_name})<br>"
+          Yast::AutoinstFunctions.available_base_products_hash.each do |product|
+            msg += "#{product[:name]} (#{product[:summary]})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the installation/upgrade.
           return :abort
@@ -420,10 +420,8 @@ module Y2Autoinstallation
               "Please check the <b>products</b> entry in the <b>software</b> section.<br><br>" \
               "Following base products are available:<br>")
           end
-          Yast::AutoinstFunctions.available_base_products.each do |bp|
-            # FIXME: here we abuse knowledge that base product is ProductLocation and not Product
-            # so we access that details which is not available in Product
-            msg += "#{bp.details.product} (#{bp.details.summary})<br>"
+          Yast::AutoinstFunctions.available_base_products_hash.each do |bp|
+            msg += "#{product[:name]} (#{product[:summary]})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the installation/upgrade.
           return :abort

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -420,7 +420,7 @@ module Y2Autoinstallation
               "Please check the <b>products</b> entry in the <b>software</b> section.<br><br>" \
               "Following base products are available:<br>")
           end
-          Yast::AutoinstFunctions.available_base_products_hash.each do |bp|
+          Yast::AutoinstFunctions.available_base_products_hash.each do |product|
             msg += "#{product[:name]} (#{product[:summary]})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the installation/upgrade.

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -227,6 +227,23 @@ module Y2Autoinstallation
         )
 
         #
+        # Checking if at least one base product has been selected/evaluated.
+        #
+        begin
+          Product.FindBaseProducts
+        rescue => e
+          msg = _("No new base product has been set.\n" \
+           "Please check the <b>software</b>/<b>products</b> entry in the " \
+           "AutoYaST configuration file.<br><br>" \
+           "Following base products are available:<br>")
+          Yast::AutoinstFunctions.available_base_products.each do |product|
+            msg += "#{product.details.product} (#{product.details.summary})<br>"
+          end
+          Yast::Popup.LongError(msg) # No timeout because we are stopping the upgrade.
+          return :abort
+        end
+
+        #
         # Checking Base Product licenses
         #
         Progress.NextStage

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -236,8 +236,8 @@ module Y2Autoinstallation
            "Please check the <b>software</b>/<b>products</b> entry in the " \
            "AutoYaST configuration file.<br><br>" \
            "Following base products are available:<br>")
-          Yast::AutoinstFunctions.available_base_products.each do |product|
-            msg += "#{product.details.product} (#{product.details.summary})<br>"
+          Yast::AutoinstFunctions.available_base_products_hash.each do |product|
+            msg += "#{product[:name]} (#{product[:summary]})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the upgrade.
           return :abort

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -234,7 +234,7 @@ module Y2Autoinstallation
           Product.FindBaseProducts
         rescue StandardError
           msg = _("No new base product has been set.\n" \
-           "Please check the <b>software</b>/<b>products</b> entry in the " \
+           "It can be specified in the <b>software</b>/<b>products</b> entry in the " \
            "AutoYaST configuration file.<br><br>" \
            "Following base products are available:<br>")
           Yast::AutoinstFunctions.available_base_products_hash.each do |product|

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -231,7 +231,7 @@ module Y2Autoinstallation
         #
         begin
           Product.FindBaseProducts
-        rescue => e
+        rescue StandardError
           msg = _("No new base product has been set.\n" \
            "Please check the <b>software</b>/<b>products</b> entry in the " \
            "AutoYaST configuration file.<br><br>" \

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -1,6 +1,7 @@
 require "autoinstall/autosetup_helpers"
 
 require "y2packager/product_upgrade"
+require "yast2/popup"
 
 Yast.import "AddOnProduct"
 Yast.import "Arch"
@@ -239,7 +240,7 @@ module Y2Autoinstallation
           Yast::AutoinstFunctions.available_base_products_hash.each do |product|
             msg += "#{product[:name]} (#{product[:summary]})<br>"
           end
-          Yast::Popup.LongError(msg) # No timeout because we are stopping the upgrade.
+          Yast2::Popup.show(msg, richtext: true) # No timeout because we are stopping the upgrade.
           return :abort
         end
 

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -138,7 +138,7 @@ module Yast
         if product.is_a?(Y2Packager::ProductLocation)
           {:name => product.details.product, :summary => product.details.summary}
         else
-          {:name => product.name, :summary => product.product.display_name}
+          {:name => product.name, :summary => product.display_name}
         end
       end
     end

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -135,7 +135,7 @@ module Yast
     # @return [Hash] an array of product hashes
     def available_base_products_hash
       available_base_products.map do |product|
-        if Y2Packager::MediumType.offline? && !@force_libzypp
+        if product.is_a?(Y2Packager::ProductLocation)
           {:name => product.details.product, :summary => product.details.summary}
         else
           {:name => product.name, :summary => product.product.display_name}

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -109,6 +109,13 @@ module Yast
       @selected_product
     end
 
+    #
+    # Evaluate all available base products and returns a list of product.
+    # CAUTION: The type of the return values depend of the kind of where
+    # the product information has been read (libzypp, product location).
+    # So the type could be ProductLocation or Product.
+    # available_base_products_hash could be an alternative for this call.
+    #
     def available_base_products
       @base_products ||= if Y2Packager::MediumType.offline? && !@force_libzypp
         url = InstURL.installInf2Url("")
@@ -118,6 +125,21 @@ module Yast
           .sort(&::Y2Packager::PRODUCT_SORTER)
       else
         Y2Packager::ProductReader.new.available_base_products(force_repos: @force_libzypp)
+      end
+    end
+
+    #
+    # Evaluate all available base products and returns a list of hashes which contains
+    # human readable strings only.
+    #
+    # @return [Hash] an array of product hashes
+    def available_base_products_hash
+      available_base_products.map do |product|
+        if Y2Packager::MediumType.offline? && !@force_libzypp
+          {:name => product.details.product, :summary => product.details.summary}
+        else
+          {:name => product.name, :summary => product.product.display_name}
+        end
       end
     end
 

--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -51,6 +51,7 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
     allow(Yast::Pkg).to receive(:ResolvableInstall)
     allow(Yast::Pkg).to receive(:ResolvableRemove)
     allow(Yast::Pkg).to receive(:PkgSolve).and_return(true)
+    allow(Yast::AutoinstFunctions).to receive(:available_base_products).and_return([])
   end
 
   describe "#main" do


### PR DESCRIPTION
…de and if not asking the user to check the product entry in the AY configuration file (bsc#1175876).

This also handles the error "no workflow has been defined for this installation/upgrade"