### PR TITLE
AutoYaST UI: fix field fstopt in partitioning (bsc#1181577)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     # just for easier debugging...
     - name: Inspect Installed Packages
@@ -38,7 +38,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Rubocop
       run: rake check:rubocop
@@ -50,7 +50,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Package Build
       run: yast-ci-ruby -o package
@@ -62,7 +62,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Yardoc
       run: rake check:doc
@@ -76,7 +76,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Perl Syntax
       run: yast-ci-ruby -o perl_syntax

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb  1 09:09:15 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST UI: fixed field Mount Options (fstopt) in the
+  partitioning section (bsc#1181577).
+- 4.3.67
+
+-------------------------------------------------------------------
 Thu Jan 28 16:54:47 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST UI: added drive types CT_NFS and CT_TMPFS to the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.66
+Version:        4.3.67
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/presenters/partition.rb
+++ b/src/lib/autoinstall/presenters/partition.rb
@@ -84,6 +84,17 @@ module Y2Autoinstallation
         drive_presenter.type
       end
 
+      # String representation of #fstab_options
+      #
+      # The field is actually called fstopt in the AutoYaST xml and treated like a plain string,
+      # so this method provides a more direct communication between the profile and the current
+      # UI (which also uses a plain InputField).
+      #
+      # @return [String]
+      def fstopt
+        fstab_options&.join(",")
+      end
+
       # Whether the section is an LVM Logical Volume
       #
       # @return [Boolean] true when belongs to an LVM drive; false otherwise
@@ -231,6 +242,20 @@ module Y2Autoinstallation
         return :drive if drive.master_partition == section
 
         :none
+      end
+
+      # @see Section#clean_section
+      def clean_section(attrs)
+        # "fstopt" is the right key to use as part of the hash received by
+        # Y2Storage::AutoinstProfile::PartitionSection.init_from_hashes,
+        # but the corresponding attribute in that class is called #fstab_options
+        new_attrs =
+          if attrs.include?("fstopt")
+            attrs - ["fstopt"] + ["fstab_options"]
+          else
+            attrs
+          end
+        super(new_attrs)
       end
     end
   end

--- a/src/lib/autoinstall/presenters/partition.rb
+++ b/src/lib/autoinstall/presenters/partition.rb
@@ -90,7 +90,8 @@ module Y2Autoinstallation
       # so this method provides a more direct communication between the profile and the current
       # UI (which also uses a plain InputField).
       #
-      # @return [String]
+      # @return [String, nil] nil if there are no fstab_options (which is consistent with the
+      #   behavior of all other attributes of Y2Storage::AutoinstProfile::PartitionSection)
       def fstopt
         fstab_options&.join(",")
       end

--- a/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
+++ b/src/lib/autoinstall/widgets/storage/filesystem_attrs.rb
@@ -70,7 +70,7 @@ module Y2Autoinstallation
           label_widget.value             = section.label
           mount_point_widget.value       = section.mount
           mountby_widget.value           = section.mountby
-          fstab_options_widget.value     = section.fstab_options
+          fstab_options_widget.value     = section.fstopt
           mkfs_options_widget.value      = section.mkfs_options
           create_subvolumes_widget.value = section.create_subvolumes
 
@@ -86,7 +86,7 @@ module Y2Autoinstallation
             "label"             => label_widget.value,
             "mount"             => mount_point_widget.value,
             "mountby"           => mountby_widget.value,
-            "fstab_options"     => fstab_options_widget.value,
+            "fstopt"            => fstab_options_widget.value,
             "mkfs_options"      => mkfs_options_widget.value,
             "create_subvolumes" => btrfs? ? create_subvolumes_widget.value : nil
           }

--- a/test/lib/widgets/storage/filesystem_attrs_test.rb
+++ b/test/lib/widgets/storage/filesystem_attrs_test.rb
@@ -144,7 +144,8 @@ describe Y2Autoinstallation::Widgets::Storage::FilesystemAttrs do
     end
 
     it "includes fstab options" do
-      expect(widget.values).to include("fstab_options" => "ro,noatime,user")
+      # See bsc#1181577, the correct name in this hash is fstopt (not fstab_options)
+      expect(widget.values).to include("fstopt" => "ro,noatime,user")
     end
   end
 end

--- a/test/lib/widgets/storage/partition_usage_tab_test.rb
+++ b/test/lib/widgets/storage/partition_usage_tab_test.rb
@@ -145,13 +145,14 @@ describe Y2Autoinstallation::Widgets::Storage::PartitionUsageTab do
 
   describe "#store" do
     it "sets section attributes related to its usage" do
+      # See bsc#1181577, the correct name in this hash is fstopt (not fstab_options)
       expect(partition).to receive(:update).with(
         hash_including(
           "filesystem",
           "label",
           "mount",
           "mountby",
-          "fstab_options",
+          "fstopt",
           "mkfs_options",
           "raid_name",
           "lvm_group",


### PR DESCRIPTION
## Problem

See [bsc#1181577](https://bugzilla.suse.com/show_bug.cgi?id=1181577).

In the partitioning section of the UI offered by YaST to customize an AutoYaST profile, the field "Mount Options" of the partition section was completely broken. It didn't show the value read from the system (or from the AutoYaST profile used as input) and it did not transfer the value written by the user to the resulting AutoYaST profile.

The root of the problem was using the attribute `Y2Storage::AutoinstProfile::PartitionSection#fstab_options` that operates with arrays of strings instead of a plain string with the attributes concatenated (separated by comma).

## Solution

Since we work with the final concatenated string in the UI, do the following:

  - When exporting to XML, use directly the field `fstopt`
  - When initializing the widget value, calculate the plain string

## Testing

- Carefully tested manually
- Updated unit tests