### PR TITLE
Fix popup

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 15:08:35 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.68
+
+-------------------------------------------------------------------
 Mon Feb  1 09:09:15 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST UI: fixed field Mount Options (fstopt) in the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.67
+Version:        4.3.68
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -14,6 +14,8 @@ describe "Yast::AutoInstallRules" do
   before do
     Y2Storage::StorageManager.create_test_instance
     allow(profile_checker).to receive(:valid_profile?).and_return(true)
+    # do not crash on reporting errors
+    allow(Yast::Report).to receive(:Error)
   end
 
   let(:root_path) { File.expand_path("..", __dir__) }

--- a/test/AutoinstConfig_test.rb
+++ b/test/AutoinstConfig_test.rb
@@ -17,6 +17,7 @@ describe "Yast::AutoinstConfig" do
       let(:slp_server_reply) { [] }
 
       it "returns nil" do
+        expect(Yast::Report).to receive(:Error)
         expect(subject.find_slp_autoyast).to eq(nil)
       end
     end
@@ -91,7 +92,7 @@ describe "Yast::AutoinstConfig" do
     context "when the profile url is invalid" do
       let(:autoyast_profile_url) { "//file:8080/path/auto-installation.xml" }
       it "reports an error and returns false" do
-        expect(Yast::Report).to receive(:Error).with(/Invalid.*/).and_call_original
+        expect(Yast::Report).to receive(:Error).with(/Invalid.*/)
         expect(subject.ParseCmdLine(autoyast_profile_url)).to eq(false)
       end
     end

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -102,6 +102,8 @@ describe "Yast::AutoinstGeneral" do
         expect(Yast::SCR).to_not receive(:Execute)
           .with(path(".target.bash"), "/sbin/hwclock --systohc")
 
+        expect(Yast::Report).to receive(:Error)
+
         subject.Write
       end
     end

--- a/test/ProfileLocation_test.rb
+++ b/test/ProfileLocation_test.rb
@@ -17,6 +17,8 @@ describe "Yast::ProfileLocation" do
       allow(Yast::InstURL).to receive(:installInf2Url).and_return(
         "http://download.opensuse.org/distribution/leap/15.1/repo/oss/"
       )
+      allow(Yast::SCR).to receive(:Read).and_return("test")
+      allow(Yast::Report).to receive(:Error) # test is already quite weak and some errors are shown
     end
 
     context "when scheme is \"relurl\"" do
@@ -24,7 +26,8 @@ describe "Yast::ProfileLocation" do
         expect(subject).to receive(:Get).with("http",
           "download.opensuse.org",
           "/distribution/leap/15.1/repo/oss/autoinst.xml",
-          "/tmp/123")
+          "/tmp/123").and_return(false)
+          # ^^^ Intentionally kill Process after get as rest of method is not tested and has too much side effects
         subject.Process
       end
     end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.