### PR TITLE
fix missing product controls

### DIFF
--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -57,6 +57,7 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
     allow(Yast::UI).to receive(:SetLanguage)
     allow(Yast::AutoinstFunctions).to receive(:available_base_products).and_return([])
     allow(Yast::Product).to receive(:FindBaseProducts).and_return([])
+    allow(Yast::ProductControl).to receive(:RunFrom).and_return(:next)
   end
 
   describe "#main" do


### PR DESCRIPTION
follow up of https://github.com/yast/yast-autoinstallation/pull/731 which failed in jenkins, so no version/changes needed.