### PR TITLE
Select patterns for installation

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 26 08:43:17 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Select patterns during auto installation even when not using the
+  confirm mode (related to jsc#SMO-20 and bsc#1182543).
+- 4.2.48
+
+-------------------------------------------------------------------
 Thu Jan 14 14:38:35 UTC 2021 - Stefan Schubert <schubi@suse.de>
 
 - Upgrade: Checking if a valid base product has been selected for

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.47
+Version:        4.2.48
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -916,6 +916,8 @@ module Yast
         end
       end
 
+      Packages.SelectSystemPatterns(false)
+
       #
       # Now remove all packages listed in remove-packages
       #


### PR DESCRIPTION
This PR tries to address a problem detected while implementing support for SELinux. When SELinux is enabled, (Auto)YaST should select the `selinux` pattern (defined in the control file) for installation. In AutoYaST it only works when the installation summary screen is shown. Why? Because the software proposal runs and the pattern gets selected.

However, if the summary is skipped, the software proposal does not run and the pattern is ignored.

If you are wondering why it works in other cases (like `yast2-bootloader`), it is because they use *packages* instead of *patterns*.

We need to review the general workflow, but this patch should fix the problem for MicroOS. However, I would like to ask @lslezak if he can foresee any potential problems. An alternative could be something like:

```ruby
patterns = Packages.GetAllResolvables(:pattern)
patterns.each do |name|
  Pkg.ResolvableInstall(name, :pattern)
end
```

**Caveat:** if the pattern is not found, the error message is displayed twice (if the summary is shown).


---

Related internal links:

* https://trello.com/c/g94xQBDM
* https://jira.suse.com/browse/SMO-20
* https://bugzilla.suse.com/show_bug.cgi?id=1182543