### PR TITLE
[SLE-15-SP3] Select patterns fort installation

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 26 09:47:17 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Select patterns during auto installation even when not using the
+  confirm mode (related to jsc#SMO-20 and bsc#1182543).
+- 4.3.69
+
+-------------------------------------------------------------------
 Mon Feb 15 15:08:35 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.68
+Version:        4.3.69
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -416,6 +416,8 @@ module Yast
         end
       end
 
+      Packages.SelectSystemPatterns(false)
+
       #
       # Now remove all packages listed in remove-packages
       #

--- a/test/ProfileLocation_test.rb
+++ b/test/ProfileLocation_test.rb
@@ -27,7 +27,9 @@ describe "Yast::ProfileLocation" do
           "download.opensuse.org",
           "/distribution/leap/15.1/repo/oss/autoinst.xml",
           "/tmp/123").and_return(false)
-          # ^^^ Intentionally kill Process after get as rest of method is not tested and has too much side effects
+        # ^^^ Intentionally kill Process after get as rest of method is not tested and has too much
+        # side effects
+
         subject.Process
       end
     end


### PR DESCRIPTION
Sync to master changes done at https://github.com/yast/yast-autoinstallation/pull/734

> [...] address a problem detected while implementing support for SELinux. When SELinux is enabled, (Auto)YaST should select the selinux pattern (defined in the control file) for installation. In AutoYaST it only works when the installation summary screen is shown. Why? Because the software proposal runs and the pattern gets selected.
> 
> However, if the summary is skipped, the software proposal does not run and the pattern is ignored.
> [...]