### PR TITLE
[SLE-15-SP2] Always import security settings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  2 17:05:03 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Execute the security client even when the given profile
+  does not have a security section (bsc#1182543).
+- 4.2.49
+
+-------------------------------------------------------------------
 Fri Feb 26 08:43:17 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Select patterns during auto installation even when not using the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.48
+Version:        4.2.49
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -454,13 +454,13 @@ module Yast
 
     # Import security settings from profile
     def autosetup_security
-      security_config = Profile.current["security"]
-      if security_config
-        # Do not start it in second installation stage again.
-        # Writing will be called in inst_finish.
-        Profile.remove_sections("security")
-        Call.Function("security_auto", ["Import", security_config])
-      end
+      security_config = Profile.current["security"] || {}
+
+      # Do not start it in second installation stage again.
+      # Writing will be called in inst_finish.
+      Profile.remove_sections("security")
+
+      Call.Function("security_auto", ["Import", security_config])
     end
 
     # Add YaST2 packages dependencies


### PR DESCRIPTION
## Problem

A bug report (https://bugzilla.suse.com/show_bug.cgi?id=1182543 ) got because of [SELinux proposal](https://github.com/yast/yast-security/pull/88) not working as expected during an auto-installation, revealed that security client was not being executed if the given profile does not contains a `security` section.

## Solution

To solve the issue, below changes are needed:
 
* Always call the client, giving an empty hash when security section is absent (this PR)
* Ensure defined SELinux patterns are set when needed, done at https://github.com/yast/yast-security/pull/101

## Tests

Tested manually via `yupdate` using `SUSE-MicroOS-5.0-DVD-x86_64-Build85.5` and also applying changes proposed at https://github.com/yast/yast-security/pull/101

<details>
<summary>Show/hide some excerpts from YaST logs</summary>

---


```
...
18821:2021-03-02 17:35:33 <1> install(3996) [Ruby] y2security/selinux.rb:301 Proposing `enforcing` SELinux mode.
18822-2021-03-02 17:35:33 <1> install(3996) [Ruby] y2security/selinux.rb:191 Modifying Bootlooader kernel params using {"security"=>"selinux", "selinux"=>"1", "enforcing"=>"1"}
18823:2021-03-02 17:35:33 <1> install(3996) [Ruby] y2security/selinux.rb:194 Saving SELinux config file to set enforcing mode
...
```

```
...
3556:2021-03-02 17:33:07 <1> install(3996) [Ruby] modules/PackagesProposal.rb:151 Setting resolvables ["microos-selinux"] of type pattern for selinux_patterns
...
...
5645-2021-03-02 17:33:11 <1> install(3996) [Pkg] y2packager/resolvable.rb:152 Pkg Builtin called: Resolvables
5646-2021-03-02 17:33:11 <1> install(3996) [Ruby] packager/product_patterns.rb:155 Found default patterns: []
5647-2021-03-02 17:33:11 <1> install(3996) [Ruby] packager/product_patterns.rb:63 Default patterns for the selected products: []
5648-2021-03-02 17:33:11 <1> install(3996) [Ruby] modules/Packages.rb:2416 Found default product patterns: []
5649:2021-03-02 17:33:11 <1> install(3996) [Ruby] modules/Packages.rb:1852 Selecting system patterns ["microos-selinux"]
5650-2021-03-02 17:33:11 <1> install(3996) [Pkg] y2packager/resolvable.rb:61 Pkg Builtin called: Resolvables
5651-2021-03-02 17:33:11 <1> install(3996) [Pkg] y2packager/resolvable.rb:152 Pkg Builtin called: Resolvables
5652-2021-03-02 17:33:11 <1> install(3996) [Pkg] y2packager/resolvable.rb:152 Pkg Builtin called: Resolvables
5653-2021-03-02 17:33:11 <1> install(3996) [Pkg] modules/Packages.rb:1861 Pkg Builtin called: ResolvableInstall
5654:2021-03-02 17:33:11 <1> install(3996) [Pkg] Resolvable_Install.cc(ResolvableUpdateInstallOrDelete):280 Installing pattern microos-selinux 
...
...
5830-2021-03-02 17:33:11 <1> install(3996) [Pkg] y2packager/resolvable.rb:152 Pkg Builtin called: Resolvables
5831:2021-03-02 17:33:11 <1> install(3996) [Ruby] clients/inst_prepare_image.rb:73 Currently selected patterns: ["microos-base", "basesystem", "microos-container_runtime", "microos-selinux"
...
...
17404:2021-03-02 17:35:17 <1> install(3996) [zypp] PathInfo.cc(copy):809 copy /var/adm/mount/AP_0xTiSzg7/x86_64/patterns-microos-selinux-5.0.0-15.3.x86_64.rpm -> /mnt/var/cache/zypp/packages/SUSE-Linux-Enterprise-Micro-5.0-1/x86_64/patterns-microos-selinux-5.0.0-15.3.x86_64.rpm 
17405:2021-03-02 17:35:17 <1> install(3996) [zypp++] MediaSetAccess.cc(releaseFile):88 Going to release file ./x86_64/patterns-microos-selinux-5.0.0-15.3.x86_64.rpm from media number 1
...
...
```

</details>