### PR TITLE
bsc#1183042: postpone importing security settings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  4 14:15:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Import the security settings after importing the bootloader
+  configuration (bsc#1183042).
+- 4.2.50
+
+-------------------------------------------------------------------
 Tue Mar  2 17:05:03 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Execute the security client even when the given profile

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.49
+Version:        4.2.50
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -69,9 +69,9 @@ module Yast
       @progress_stages = [
         _("Configure General Settings "),
         _("Set up language"),
-        _("Configure security settings"),
         _("Create partition plans"),
         _("Configure Bootloader"),
+        _("Configure security settings"),
         _("Registration"),
         _("Configure Software selections"),
         _("Configure Systemd Default Target"),
@@ -83,9 +83,9 @@ module Yast
       @progress_descriptions = [
         _("Configuring general settings..."),
         _("Setting up language..."),
-        _("Configuring security settings"),
         _("Creating partition plans..."),
         _("Configuring Bootloader..."),
+        _("Configuring security settings"),
         _("Registering the system..."),
         _("Configuring Software selections..."),
         _("Configuring Systemd Default Target..."),
@@ -251,10 +251,6 @@ module Yast
 
       Progress.NextStage
 
-      # Importing security settings
-      autosetup_security
-      return :abort if UI.PollInput == :abort && Popup.ConfirmAbort(:painless)
-
       #
       # Partitioning and Storage
       # //////////////////////////////////////////////////////////////////////
@@ -305,6 +301,10 @@ module Yast
         "bootloader_auto",
         ["Import", Ops.get_map(Profile.current, "bootloader", {})]
       )
+
+      # Importing security settings
+      autosetup_security
+      return :abort if UI.PollInput == :abort && Popup.ConfirmAbort(:painless)
 
       # Registration
       # FIXME: There is a lot of duplicate code with inst_autoupgrade.


### PR DESCRIPTION
Proposed fix for [bsc#1183042](https://bugzilla.suse.com/show_bug.cgi?id=1183042).