### PR TITLE
bsc#1183352: remove 'haspcmica' leftover

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 11 15:49:36 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove the 'haspcmica' element from the schema (related to
+  bsc#1183352).
+- 4.3.71
+
+-------------------------------------------------------------------
 Thu Mar  4 14:15:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Import the security settings after importing the bootloader

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.70
+Version:        4.3.71
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -45,7 +45,6 @@ y2_match_to =
     | custom5
     | disksize
     | domain
-    | haspcmica
     | hostaddress
     | hostid
     | karch


### PR DESCRIPTION
It removes a left-over from #683. Actually, it is `haspcmica` instead of `haspcmcia`.

See [bsc#1183352](https://bugzilla.suse.com/show_bug.cgi?id=1183352).