### PR TITLE
Network start immediately

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar 15 20:20:41 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Move default networking section values to the network repository
+  in order to reduce the redundancy and to avoid an unexpected
+  behavior (bsc#1180535).
+- 4.3.73
+
+-------------------------------------------------------------------
 Mon Mar 15 13:13:20 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: allow semi-automatic_entry alias for module in

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.72
+Version:        4.3.73
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -72,7 +72,8 @@ Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
 # Moving security module to first installation stage
 Requires:       yast2-security >= 4.1.1
-Requires:       yast2-network >= 3.1.145
+# Modify start_immediately default value
+Requires:       yast2-network >= 4.3.59
 Requires:       yast2-schema >= 4.0.6
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -241,15 +241,6 @@ module Yast
         )
       end
 
-      # raise the network immediately after configuring it
-      if Builtins.haskey(@current, "networking") &&
-          !Builtins.haskey(
-            Ops.get_map(@current, "networking", {}),
-            "start_immediately"
-          )
-        Ops.set(@current, ["networking", "start_immediately"], true)
-        Builtins.y2milestone("start_immediately set to true")
-      end
       merge_resource_aliases!
       generalCompat # compatibility to new language,keyboard and timezone (SL10.1)
       softwareCompat


### PR DESCRIPTION
## Problem

The initialization of AY networking settings is scattered in different places and it is prone to errors or false expectations.

- https://trello.com/c/QV11z6q5/2332-p2-1180535-autoyastintel-udevadm-control-reload-failed

## Solution

- Remove the initialization of the start_immediately element in the networking_section from the Profile.

It depends on https://github.com/yast/yast-network/pull/1180 as the default for start_immediately in yast2-network was false.