### PR TITLE
fix handling of empty signature-handling element in autoyast profile (bsc#1180968)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 18 09:25:15 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- fix handling of empty signature-handling element in autoyast
+  profile (bsc#1180968)
+- 4.3.75
+
+-------------------------------------------------------------------
 Wed Mar 17 11:50:06 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Export properly "ask" section "selection"  (bsc#1183624)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.74
+Version:        4.3.75
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/pkg_gpg_check_handler.rb
+++ b/src/lib/autoinstall/pkg_gpg_check_handler.rb
@@ -149,8 +149,9 @@ module Yast
     def get_addon_config(profile, url)
       addon_config = addons_config(profile).find { |c| c["media_url"] == url } || {}
       general_config = profile.fetch("general", {})
-      general_config.fetch("signature-handling", {})
-        .merge(addon_config.fetch("signature-handling", {}))
+      signature_handling = general_config.fetch("signature-handling", {})
+      signature_handling = {} unless signature_handling.is_a?(Hash)
+      signature_handling.merge(addon_config.fetch("signature-handling", {}))
     end
 
     # Get add-ons configuration


### PR DESCRIPTION
## Problem

- https://trello.com/c/YHXqyvAd
- https://bugzilla.suse.com/show_bug.cgi?id=1180968

An empty `<signature-handling>` element in an AutoYaST profile will crash YaST.

## Solution

Empty elements in AutoYaST profiles are in some cases (not all) a problem due to the way XML is handled in YaST.

This pull request just fixes the reported issue. For a full analysis and a more general fix see https://github.com/yast/yast-autoinstallation/pull/730