### PR TITLE
Add <mkfs_options> element to the <partition> section

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Apr  5 08:41:25 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the 'mkfs_options' element to the schema (bsc#1184268).
+
+-------------------------------------------------------------------
 Thu Apr  1 10:27:56 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix crash during using autoyast UI (bsc#1184216)

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -70,6 +70,7 @@ y2_partition =
   | part_loop_fs
   | part_lv_name
   | part_lvm_group
+  | part_mkfs_options
   | part_mount
   | part_mountby
   | part_filesystem_id
@@ -196,6 +197,7 @@ part_label = element label { STRING }
 part_uuid = element uuid { STRING }
 part_loop_fs =
   element loop_fs { BOOLEAN }
+part_mkfs_options = element mkfs_options { STRING }
 part_mount = element mount { STRING }
 part_mountby =
   element mountby { SYMBOL }


### PR DESCRIPTION
* [bsc#1184268](https://bugzilla.suse.com/show_bug.cgi?id=1184268): add the `<mkfs_options>` to the `<partition>` section.

The version number is not incremented because I would like to merge more fixes before releasing version 4.3.77.