### PR TITLE
Show the ask-list only once

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  6 06:33:32 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Show the <ask-list> only once during autoinstallation
+  (bsc#1184317).
+
+-------------------------------------------------------------------
 Thu Apr  1 10:27:56 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix crash during using autoyast UI (bsc#1184216)

--- a/src/include/autoinstall/ask.rb
+++ b/src/include/autoinstall/ask.rb
@@ -12,12 +12,11 @@ module Yast
     def initialize_autoinstall_ask(_include_target)
       textdomain "autoinst"
 
-      Yast.import "AutoinstGeneral"
-      Yast.import "Label"
-      Yast.import "Popup"
       Yast.import "Profile"
-      Yast.import "Stage"
       Yast.import "UI"
+      Yast.import "Label"
+      Yast.import "Stage"
+      Yast.import "Popup"
     end
 
     def createWidget(widget, _frametitle)
@@ -75,7 +74,9 @@ module Yast
       history = []
 
       Builtins.foreach(
-        Builtins.sort(AutoinstGeneral.askList) do |x, y|
+        Builtins.sort(
+          Ops.get_list(Profile.current, ["general", "ask-list"], [])
+        ) do |x, y|
           Ops.less_than(
             Ops.get_integer(x, "element", 0),
             Ops.get_integer(y, "element", 0)


### PR DESCRIPTION
This PR fixes [bsc#1184317](https://bugzilla.suse.com/show_bug.cgi?id=1184317). The problem is that the `AutoinstGeneral#askList` does not get updated when a script creates a modified version of the profile. Relying on the current profile (through `Yast::Profile.current`) fixes this problem.

Is `AutoinstGeneral#askList` useless then? No, it is used in the AutoYaST UI and when cloning the system.

Basically, this PR reverts 7cdb3ca.