### PR TITLE
 Show the ask-list only once (alternative approach)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  6 12:45:29 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Show the <ask-list> only once during autoinstallation
+  (bsc#1184317).
+
+-------------------------------------------------------------------
 Mon Apr  5 08:41:25 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add the 'mkfs_options' element to the schema (bsc#1184268).

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -165,7 +165,10 @@ module Y2Autoinstallation
         return :abort if Yast::UI.PollInput == :abort && Yast::Popup.ConfirmAbort(:painless)
 
         loop do
+          # ask-list
+          Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
           askDialog
+
           # Pre-Scripts
           Yast::AutoinstScripts.Import(Yast::Profile.current["scripts"] || {})
           Yast::AutoinstScripts.Write("pre-scripts", false)


### PR DESCRIPTION
This PR is an alternative approach to https://github.com/yast/yast-autoinstallation/pull/748 in order to fix [bsc#1184317](https://bugzilla.suse.com/show_bug.cgi?id=1184317). Instead of reverting changes, it makes sure that the `ask-list` is up-to-date. Alternatively, we could call [import_initial_config](https://github.com/yast/yast-autoinstallation/blob/d857aeac4aa70d71b9fe99f083b7f7042163a2f5/src/lib/autoinstall/clients/inst_autoinit.rb#L186), but it does more than needed.