### PR TITLE
bsc#1184316: crash when sorting the list of modules

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Apr  7 06:55:31 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash while sorting the list of modules to be processed
+  during the 2nd stage (bsc#1184316).
+- Prevent AutoYaST UI from crashing when trying to apply a module
+  changes (bsc#1184429).
+- 4.3.77
+
+-------------------------------------------------------------------
 Tue Apr  6 13:45:16 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use 'module' instead of 'listentry' when exporting pre-modules

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.76
+Version:        4.3.77
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/include/autoinstall/conftree.rb
+++ b/src/include/autoinstall/conftree.rb
@@ -505,7 +505,7 @@ module Yast
           modulename = getModule
           if modulename != ""
             registry = Y2Autoinstallation::Entries::Registry.instance
-            description = registry.descriptions.find { |d| d.resource_name == module_name }
+            description = registry.descriptions.find { |d| d.resource_name == modulename }
             if Popup.YesNo(
               Builtins.sformat(
                 _(


### PR DESCRIPTION
AutoYaST crashes when it is processing the list of modules to run during the 2nd stage if the *yast2-audit-laf* package is installed. The problem has two sides:

* The `org.opensuse.yast.AuditLAF.desktop` file contains an entry `AutoInstRequires` that points to an non-existing `audit` module.
* AutoYaST is unable to handle this situation and it just crashes.

This PR introduces these changes:

* If a required module is missing, AutoYaST just logs the error and continues,
* The list of modules is written to the log file, so it is easier to find out a potential problem.