### PR TITLE
fix autoyast profile parser (bsc#1184508)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr  8 16:13:44 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- fix autoyast profile parser (bsc#1184508)
+- 4.4.2
+
+-------------------------------------------------------------------
 Wed Apr  7 11:50:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash while sorting the list of modules to be processed

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -144,7 +144,7 @@ module Yast
 
       end
       # Initialize scripts stack
-      AutoinstScripts.Import(Profile.current.fetch("scripts", {}))
+      AutoinstScripts.Import(Profile.current.fetch_as_hash("scripts"))
 
       # online update
       if Ops.get_boolean(


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184508

AutoYaST profile processing may break in 2nd stage.

## Solution

Fix profile reader.

## Todo

This fixes the reported issue and makes AutoYaST installations possible again. There might be more places. The profile parsing code needs more refactoring time.