### PR TITLE
Autoupgrade: do not register the system if disabled explicitly in the profile

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  7 10:24:22 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- During autoupgrade do not try to register the system if it is
+  explicitly disabled in the profile (bsc#1176965)
+- 4.2.51
+
+-------------------------------------------------------------------
 Thu Mar  4 14:15:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Import the security settings after importing the bootloader

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.50
+Version:        4.2.51
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -82,8 +82,10 @@ module Y2Autoinstallation
       return true unless registration_module_available? # do nothing
 
       general_section = Yast::Profile.current["general"] || {}
+      register_section = Yast::Profile.current[REGISTER_SECTION]
+      disabled_registration = (register_section || {})["do_registration"] == false
       # autoupgrade detects itself if system is registered and if needed do migration via scc
-      if Yast::Profile.current[REGISTER_SECTION] || Yast::Mode.autoupgrade
+      if !disabled_registration && (register_section || Yast::Mode.autoupgrade)
         Yast::WFM.CallFunction(
           "scc_auto",
           ["Import", Yast::Profile.current[REGISTER_SECTION]]

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -84,6 +84,11 @@ module Y2Autoinstallation
       general_section = Yast::Profile.current["general"] || {}
       register_section = Yast::Profile.current[REGISTER_SECTION]
       disabled_registration = (register_section || {})["do_registration"] == false
+
+      # remove the registration section to not run it again in the 2nd when it is explicitly
+      # disabled (no autoupgrade detection is needed in this case)
+      Yast::Profile.remove_sections(REGISTER_SECTION) if disabled_registration
+
       # autoupgrade detects itself if system is registered and if needed do migration via scc
       if !disabled_registration && (register_section || Yast::Mode.autoupgrade)
         Yast::WFM.CallFunction(

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -81,45 +81,58 @@ describe Y2Autoinstallation::AutosetupHelpers do
       end
 
       context "suse_register tag is defined in AY file" do
-        let(:profile_content) { { "suse_register" => { "reg_code" => "12345" } } }
+        context "and the registration is disabled explicitly" do
+          let(:profile_content) { { "suse_register" => { "do_registration" => false } } }
 
-        before do
-          allow(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes")
-            .and_return(true)
-          allow(Yast::WFM).to receive(:CallFunction).with("scc_auto", anything).and_return(true)
-          Yast::Profile.Import(profile_content)
+          it "does not call any client and returns true." do
+            # no scc_auto call at all
+            expect(Yast::WFM).not_to receive(:CallFunction)
+            expect(client.suse_register).to eq(true)
+          end
         end
 
-        it "imports the registration settings from the profile" do
-          expect(Yast::WFM).to receive(:CallFunction).with("scc_auto",
-            ["Import", profile_content["suse_register"]]).and_return(true)
-          expect(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"])
-            .and_return(true)
-          client.suse_register
-        end
+        context "and the registration is not disabled explicitly" do
+          let(:profile_content) { { "suse_register" => { "reg_code" => "12345" } } }
 
-        it "downloads release notes" do
-          expect(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes")
-          client.suse_register
-        end
-
-        # bsc#1153293
-        it "removes the registration section to not run it again in the 2nd stage" do
-          expect(Yast::Profile).to receive(:remove_sections).with("suse_register")
-          client.suse_register
-        end
-
-        it "returns true" do
-          expect(client.suse_register).to eq(true)
-        end
-
-        context "when something goes wrong" do
           before do
-            allow(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"]).and_return(false)
+            allow(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes")
+              .and_return(true)
+            allow(Yast::WFM).to receive(:CallFunction).with("scc_auto", anything).and_return(true)
+            Yast::Profile.Import(profile_content)
           end
 
-          it "returns false" do
-            expect(client.suse_register).to eq(false)
+          it "imports the registration settings from the profile" do
+            expect(Yast::WFM).to receive(:CallFunction).with("scc_auto",
+              ["Import", profile_content["suse_register"]]).and_return(true)
+            expect(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"])
+              .and_return(true)
+            client.suse_register
+          end
+
+          it "downloads release notes" do
+            expect(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes")
+            client.suse_register
+          end
+
+          # bsc#1153293
+          it "removes the registration section to not run it again in the 2nd stage" do
+            expect(Yast::Profile).to receive(:remove_sections).with("suse_register")
+            client.suse_register
+          end
+
+          it "returns true" do
+            expect(client.suse_register).to eq(true)
+          end
+
+          context "when something goes wrong" do
+            before do
+              allow(Yast::WFM).to receive(:CallFunction).with("scc_auto", ["Write"])
+                .and_return(false)
+            end
+
+            it "returns false" do
+              expect(client.suse_register).to eq(false)
+            end
           end
         end
       end


### PR DESCRIPTION
## Problem

During an autoupgrade, it tries to register the system even when in the profile it is set to not do so.

- https://trello.com/c/DHlfQO4m/2437-3-sles15-sp2-p5-1176965-was-l3-proxy-autoupgrade-scccredentials-force-connection-to-scc-which-causes-installation-to-fail
- https://bugzilla.suse.com/show_bug.cgi?id=1176965

## Solution

Skip the registration in case it is explicitly disabled in the profile.