### PR TITLE
Process PackagesProposal packages during autoupgrade

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 13 08:45:04 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Install packages in the PackagesProposal during autoupgrade
+  (see bsc#1184488).
+- 4.3.80
+
+-------------------------------------------------------------------
 Tue May 11 11:22:10 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Consider 'static_text' as a valid value for 'ask/type' elements

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.79
+Version:        4.3.80
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -18,6 +18,7 @@ Yast.import "Keyboard"
 Yast.import "Language"
 Yast.import "PackageCallbacks"
 Yast.import "Packages"
+Yast.import "PackagesProposal"
 Yast.import "Pkg"
 Yast.import "Popup"
 Yast.import "Product"
@@ -169,12 +170,6 @@ module Y2Autoinstallation
         Progress.NextStage
         return :abort unless suse_register
 
-        software_upgrade
-
-        return :abort if UI.PollInput == :abort && Popup.ConfirmAbort(:painless)
-
-        Progress.NextStage
-
         # Bootloader
         # FIXME: De-duplicate with inst_autosetup
         # Bootloader import / proposal is necessary to match changes done for manual
@@ -196,6 +191,12 @@ module Y2Autoinstallation
           "bootloader_auto",
           ["Import", Ops.get_map(Profile.current, "bootloader", {})]
         )
+
+        Progress.NextStage
+
+        return :abort if UI.PollInput == :abort && Popup.ConfirmAbort(:painless)
+
+        software_upgrade
 
         # SLES only, the only way to have kdump configured immediately after upgrade
         if Builtins.haskey(Profile.current, "kdump")
@@ -283,8 +284,8 @@ module Y2Autoinstallation
           _("Configure General Settings "),
           _("Set up language"),
           _("Registration"),
-          _("Configure Software selections"),
           _("Configure Bootloader"),
+          _("Configure Software selections"),
           _("Confirm License")
         ]
       end
@@ -294,8 +295,8 @@ module Y2Autoinstallation
           _("Configuring general settings..."),
           _("Setting up language..."),
           _("Registering the system..."),
-          _("Configuring Software selections..."),
           _("Configuring Bootloader..."),
+          _("Configuring Software selections..."),
           _("Confirming License...")
         ]
       end
@@ -367,8 +368,10 @@ module Y2Autoinstallation
         Builtins.foreach(sys_patterns) do |pat|
           Pkg.ResolvableInstall(pat, :pattern)
         end
+
         # this is new, (de)select stuff from the profile
         packages = Profile.current["software"]&.public_send(:[], "packages") || []
+        packages += Yast::PackagesProposal.GetAllResolvables(:package)
         patterns = Profile.current["software"]&.public_send(:[], "patterns") || []
         products = Profile.current["software"]&.public_send(:[], "products") || []
         remove_packages = Profile.current["software"]&.public_send(:[], "remove-packages") || []

--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -117,5 +117,18 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
 
       expect(Yast::AutoinstConfig.Confirm).to eq true
     end
+
+    context "when a package is proposed for installation" do
+      before do
+        allow(Yast::WFM).to receive(:CallFunction).with("bootloader_auto", any_args) do
+          Yast::PackagesProposal.AddResolvables("yast2-bootloader", :package, ["shim"])
+        end
+      end
+
+      it "install those packages" do
+        expect(Yast::Pkg).to receive(:ResolvableInstall).with("shim", :package)
+        subject.main
+      end
+    end
   end
 end


### PR DESCRIPTION
With this PR, AutoYaST will honor the packages registered in the `Yast::PackagesProposal` by the yast2-bootloader module.

Fixes [bsc#1184488](https://bugzilla.suse.com/show_bug.cgi?id=1184488).
Trello: https://trello.com/c/fZYFWGve/

Manually tested using QEMU.