### PR TITLE
Backport handling of <files> section in 1st stage

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 13 12:57:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Backport gh#651 by schubi@suse.de:
+  - Moving <files> section handling from second installation stage
+    to first installation stage. (bsc#1174194)
+- 4.2.52
+
+-------------------------------------------------------------------
 Fri May  7 10:24:22 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - During autoupgrade do not try to register the system if it is

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
@@ -263,6 +263,7 @@ done
 %{yast_clientdir}/autoinst_scripts2_finish.rb
 %{yast_clientdir}/ayast_probe.rb
 %{yast_clientdir}/inst_autosetup_upgrade.rb
+%{yast_clientdir}/autoinst_files_finish.rb
 %{yast_clientdir}/inst_store_upgrade_software.rb
 %{yast_clientdir}/clone_system.rb
 

--- a/src/clients/autoinst_files_finish.rb
+++ b/src/clients/autoinst_files_finish.rb
@@ -1,0 +1,3 @@
+require "autoinstall/clients/autoinst_files_finish"
+
+Y2Autoinstallation::Clients::AutoinstFilesFinish.run

--- a/src/clients/inst_autosetup.rb
+++ b/src/clients/inst_autosetup.rb
@@ -77,6 +77,7 @@ module Yast
         _("Configure Systemd Default Target"),
         _("Configure users and groups"),
         _("Import SSH keys/settings"),
+        _("Set up user defined configuration files"),
         _("Confirm License")
       ]
 
@@ -91,6 +92,7 @@ module Yast
         _("Configuring Systemd Default Target..."),
         _("Importing users and groups configuration..."),
         _("Importing SSH keys/settings..."),
+        _("Setting up user defined configuration files..."),
         _("Confirming License...")
       ]
 
@@ -415,6 +417,12 @@ module Yast
       end
 
       #
+      # Import profile settings for creating configuration files.
+      #
+      Progress.NextStage
+      autosetup_files
+
+      #
       # Checking Base Product licenses
       #
       Progress.NextStage
@@ -436,6 +444,17 @@ module Yast
       return :finish if @ret == :next
 
       @ret
+    end
+
+    # Import Files section from profile
+    def autosetup_files
+      files_config = Profile.current["files"] || []
+
+      # Do not start it in the second instalation stage again
+      # Writing will be called in inst_finish.
+      Profile.remove_sections("files")
+
+      Call.Function("files_auto", ["Import", files_config])
     end
 
     # Import Users configuration from profile

--- a/src/lib/autoinstall/clients/autoinst_files_finish.rb
+++ b/src/lib/autoinstall/clients/autoinst_files_finish.rb
@@ -1,0 +1,22 @@
+require "installation/finish_client"
+
+Yast.import "AutoinstFile"
+
+module Y2Autoinstallation
+  module Clients
+    class AutoinstFilesFinish < ::Installation::FinishClient
+      def title
+        textdomain "autoinst"
+        _("Writing configuration files ...")
+      end
+
+      def modes
+        [:autoinst]
+      end
+
+      def write
+        ::Yast::AutoinstFile.Write
+      end
+    end
+  end
+end

--- a/test/lib/clients/autoinst_files_finish_test.rb
+++ b/test/lib/clients/autoinst_files_finish_test.rb
@@ -1,0 +1,12 @@
+require_relative "../../test_helper"
+require "autoinstall/clients/autoinst_files_finish"
+
+describe Y2Autoinstallation::Clients::AutoinstFilesFinish do
+  describe "#write" do
+
+    it "writes additional configuration files" do
+      expect(Yast::AutoinstFile).to receive(:Write)
+      subject.write
+    end
+  end
+end


### PR DESCRIPTION
Backport #651 to fix [bsc#1174194](https://bugzilla.suse.com/show_bug.cgi?id=1174194).

* Moving <files> section handling to the first installation stage.
* See https://github.com/yast/yast-installation/pull/954
* Trello: https://trello.com/c/jgBnBQOU/