### PR TITLE
Recommend icewm if libyui-qt is installed

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 13 19:07:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Recommend icewm if graphical installation (bsc#1185095)
+- 4.3.81
+
+-------------------------------------------------------------------
 Thu May 13 08:45:04 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Install packages in the PackagesProposal during autoupgrade

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -134,6 +134,8 @@ Requires:       yast2-xml
 # RPM dependencies in Pkg.Resolvables
 Requires:       yast2-pkg-bindings >= 4.3.0
 Requires:       yast2-ruby-bindings >= 1.0.0
+# bsc#1185095
+Recommends:     (icewm if libyui-qt)
 
 Provides:       yast2-trans-autoinst
 Obsoletes:      yast2-trans-autoinst

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.80
+Version:        4.3.81
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

The **icewm** package was moved to the **basic_desktop** pattern (requested by https://jira.suse.com/browse/SLE-5558)

If the package and the pattern are not specified in the profile we could end with a graphical installation without a display manager which could be painful (see https://bugzilla.suse.com/show_bug.cgi?id=1185095).

A [similar bug](https://bugzilla.suse.com/show_bug.cgi?id=1165646) was already reported for **firstboot** and it was decided to recommend the **icewm** package in case that **libyui-qt** is installed as you can see here (https://github.com/yast/yast-firstboot/pull/96)

The pull request also contains a description of the problem and the solution applied so it could be just be applied for this PBI

## Solution

- As the AutoYaST Second Stage is similar to Firstboot it has been decided to follow the same approach.

**Alternative:** As we are in an autoinstallation we could also check if the **Textmode** and the **Second Stage** is needed is used in order to determine if the icewm package should be recommended or not. This need some logic to be added but as we already check if we require the autoyast2 package we could also add this checks there (see https://github.com/yast/yast-autoinstallation/blob/77b3f6563e1ac8d27d75ed95fea4df4a3c0943d3/src/lib/autoinstall/clients/inst_autosetup.rb#L298)