### PR TITLE
Stop when importing users fails

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun  7 13:06:43 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Abort the installation importing the users sections from
+  the profile fails (related to jsc#PM-2620).
+- 4.4.7
+
+-------------------------------------------------------------------
 Thu May 13 19:07:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Recommend icewm if graphical installation (bsc#1185095)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -135,7 +135,7 @@ module Yast
         result = importer.import_entry(description)
         log.info "Imported #{result.inspect}"
 
-        Call.Function(description.client_name, ["Write"]) unless result.empty?
+        Call.Function(description.client_name, ["Write"]) unless result.sections.empty?
 
         processWait(description.module_name, "post-modules")
 

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -343,7 +343,7 @@ module Y2Autoinstallation
         # Import users configuration from the profile
         #
         Progress.NextStage
-        autosetup_users
+        return :abort unless autosetup_users
 
         #
         # Import profile settings for copying SSH keys from a
@@ -363,7 +363,7 @@ module Y2Autoinstallation
         # Import profile settings for creating configuration files.
         #
         Progress.NextStage
-        autosetup_files
+        return :abort unless autosetup_files
 
         #
         # Checking Base Product licenses
@@ -396,24 +396,30 @@ module Y2Autoinstallation
       end
 
       # Import Files section from profile
+      #
+      # @return [Boolean] Determine whether the import was successful
       def autosetup_files
-        importer.import_entry("files").each do |e|
-          Profile.remove_sections(e)
-        end
+        result = importer.import_entry("files")
+        result.sections.each { |e| Profile.remove_sections(e) }
+        result.success?
       end
 
       # Import Users configuration from profile
+      #
+      # @return [Boolean] Determine whether the import was successful
       def autosetup_users
-        importer.import_entry("users").each do |e|
-          Profile.remove_sections(e)
-        end
+        result = importer.import_entry("users")
+        result.sections.each { |e| Profile.remove_sections(e) }
+        result.success?
       end
 
       # Import security settings from profile
+      #
+      # @return [Boolean] Determine whether the import was successful
       def autosetup_security
-        importer.import_entry("security").each do |e|
-          Profile.remove_sections(e)
-        end
+        result = importer.import_entry("security")
+        result.sections.each { |e| Profile.remove_sections(e) }
+        result.success?
       end
 
       # Add YaST2 packages dependencies

--- a/test/lib/importer_test.rb
+++ b/test/lib/importer_test.rb
@@ -121,8 +121,10 @@ describe Y2Autoinstallation::Importer do
       }
     end
 
+    let(:success?) { true }
+
     before do
-      allow(Yast::WFM).to receive(:CallFunction)
+      allow(Yast::WFM).to receive(:CallFunction).and_return(success?)
     end
 
     it "accepts string or Description parameter" do
@@ -154,8 +156,34 @@ describe Y2Autoinstallation::Importer do
       subject.import_entry("users")
     end
 
-    it "returns all imported keys" do
-      expect(subject.import_entry("users")).to match_array(["users", "groups"])
+    it "returns a result containing all imported keys" do
+      result = subject.import_entry("users")
+      expect(result.sections).to match_array(["users", "groups"])
+    end
+
+    context "when the call to the auto client works" do
+      it "returns a successful result" do
+        result = subject.import_entry("bootloader")
+        expect(result).to be_success
+      end
+    end
+
+    context "when the call to the auto client returns nothing" do
+      let(:success?) { nil }
+
+      it "returns a successful result" do
+        result = subject.import_entry("bootloader")
+        expect(result).to be_success
+      end
+    end
+
+    context "when the call to the auto client fails" do
+      let(:success?)  { false }
+
+      it "the contains a failing result" do
+        result = subject.import_entry("bootloader")
+        expect(result).to_not be_success
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is the counterpart of https://github.com/yast/yast-users/pull/296. Basically, it stops the autoinstallation when importing user settings fails.