### PR TITLE
Import proxy settings at the first stage

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  8 09:38:45 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Import proxy settings during the 1st stage of the installation
+  (bsc#1185016)
+- 4.3.82
+
+-------------------------------------------------------------------
 Thu May 13 19:07:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Recommend icewm if graphical installation (bsc#1185095)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.81
+Version:        4.3.82
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -142,6 +142,10 @@ module Y2Autoinstallation
         Yast::WFM.CallFunction("host_auto", ["Import", Yast::Profile.current["host"]])
       end
 
+      if Yast::Profile.current["proxy"]
+        Yast::WFM.CallFunction("proxy_auto", ["Import", Yast::Profile.current["proxy"]])
+      end
+
       if semi_auto?("networking")
         log.info("Networking manual setup before proposal")
         Yast::WFM.CallFunction("inst_lan", ["enable_next" => true])
@@ -149,10 +153,11 @@ module Y2Autoinstallation
       end
 
       log.info("Networking setup before the proposal: #{network_before_proposal?}")
+      Yast::WFM.CallFunction("proxy_auto", ["Write"]) if network_before_proposal?
       Yast::WFM.CallFunction("lan_auto", ["Write"]) if network_before_proposal?
 
       # Clean-up the profile
-      Yast::Profile.remove_sections(["networking", "host"])
+      Yast::Profile.remove_sections(["networking", "host", "proxy"])
 
       @network_configured = true
     end

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -142,18 +142,18 @@ module Y2Autoinstallation
         Yast::WFM.CallFunction("host_auto", ["Import", Yast::Profile.current["host"]])
       end
 
-      if Yast::Profile.current["proxy"]
-        Yast::WFM.CallFunction("proxy_auto", ["Import", Yast::Profile.current["proxy"]])
-      end
-
       if semi_auto?("networking")
         log.info("Networking manual setup before proposal")
         Yast::WFM.CallFunction("inst_lan", ["enable_next" => true])
         @network_before_proposal = true
       end
 
+      if Yast::Profile.current["proxy"]
+        Yast::WFM.CallFunction("proxy_auto", ["Import", Yast::Profile.current["proxy"]])
+        Yast::WFM.CallFunction("proxy_auto", ["Write"]) if network_before_proposal?
+      end
+
       log.info("Networking setup before the proposal: #{network_before_proposal?}")
-      Yast::WFM.CallFunction("proxy_auto", ["Write"]) if network_before_proposal?
       Yast::WFM.CallFunction("lan_auto", ["Write"]) if network_before_proposal?
 
       # Clean-up the profile

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -401,7 +401,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
       end
 
       context "and the networking is configured to setup before the proposal" do
-        let(:profile) { networking_section.merge(proxy_section) }
+        let(:profile) { networking_section.merge("proxy" => proxy_section) }
 
         it "writes the proxy configuration to the ins-sys" do
           expect(Yast::WFM).to receive(:CallFunction).with("proxy_auto", ["Write"])

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -307,6 +307,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
       allow(Yast::WFM).to receive(:CallFunction).with("lan_auto", anything)
       allow(Yast::WFM).to receive(:CallFunction).with("inst_lan", anything)
       allow(Yast::WFM).to receive(:CallFunction).with("host_auto", anything)
+      allow(Yast::WFM).to receive(:CallFunction).with("proxy_auto", anything)
     end
 
     context "when a networking section is defined in the profile" do

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -383,6 +383,33 @@ describe Y2Autoinstallation::AutosetupHelpers do
         client.autosetup_network
       end
     end
+
+    context "when proxy configuration is given" do
+      let(:proxy_section) { { "enabled" => true, "http_proxy" => "http://proxy:3128" } }
+      let(:profile) { { "proxy" => proxy_section } }
+
+      it "imports the proxy configuration from the profile" do
+        expect(Yast::WFM).to receive(:CallFunction).with("proxy_auto", ["Import", proxy_section])
+
+        client.autosetup_network
+      end
+
+      it "removes the host section from the profile after imported" do
+        client.autosetup_network
+
+        expect(Yast::Profile.current.keys).to_not include("proxy")
+      end
+
+      context "and the networking is configured to setup before the proposal" do
+        let(:profile) { networking_section.merge(proxy_section) }
+
+        it "writes the proxy configuration to the ins-sys" do
+          expect(Yast::WFM).to receive(:CallFunction).with("proxy_auto", ["Write"])
+
+          client.autosetup_network
+        end
+      end
+    end
   end
 
   describe "#semi_auto?" do


### PR DESCRIPTION
## Problem

The proxy configuration is done during the second stage of the autoinstallation. As it could be very late and we have options for configuring the network before the proposal we probably could move it too.

- https://trello.com/c/s9gfK64m/2499-sles15-sp2-p2-1185016-l3-autoyast-does-not-set-proxy-properly-ref00d1iglod5001ixjkyhref
- https://bugzilla.suse.com/show_bug.cgi?id=1185016

## Solution

Move proxy configuration to the first stage.

## Test

- Tested manually and added unit test.
