### PR TITLE
 Do not crash when the storage section is empty

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 11 09:46:05 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when the general/storage section is empty
+  (bsc#1187180).
+- 4.3.83
+
+-------------------------------------------------------------------
 Tue Jun  8 09:38:45 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Import proxy settings during the 1st stage of the installation

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.82
+Version:        4.3.83
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -74,7 +74,7 @@ module Yast
     #
     # @param settings [Hash] general/storage section settings
     def import_general_settings(settings)
-      return if settings.nil?
+      return unless settings.is_a?(Hash)
 
       self.general_settings = settings.clone
 

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -293,7 +293,7 @@ describe Yast::AutoinstStorage do
     end
 
     context "when settings are not a hash" do
-      let(:profile)  { "" }
+      let(:profile) { "" }
 
       it "does not import the settings" do
         subject.import_general_settings(profile)

--- a/test/autoinst_storage_test.rb
+++ b/test/autoinst_storage_test.rb
@@ -291,5 +291,14 @@ describe Yast::AutoinstStorage do
         subject.import_general_settings(profile)
       end
     end
+
+    context "when settings are not a hash" do
+      let(:profile)  { "" }
+
+      it "does not import the settings" do
+        subject.import_general_settings(profile)
+        expect(subject.general_settings).to be_a(Hash)
+      end
+    end
   end
 end


### PR DESCRIPTION
As described in [bsc#1187180](https://bugzilla.suse.com/show_bug.cgi?id=1187180), AutoYaST crashes with the following general section:

```xml
<general>
  <storage></storage>
</general>
```