### PR TITLE
Do not crash while importing the <scripts> section

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul  1 07:02:20 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash importing the <scripts> section (boo#1187898).
+  This bug does not affect the installation process.
+- 4.4.11
+
+-------------------------------------------------------------------
 Mon Jun 14 09:37:41 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the copy of the profile to the installed system as

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.10
+Version:        4.4.11
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/scripts_auto.rb
+++ b/src/lib/autoinstall/clients/scripts_auto.rb
@@ -20,6 +20,7 @@
 require "installation/auto_client"
 
 Yast.import "AutoinstScripts"
+Yast.import "Profile"
 
 module Y2Autoinstallation
   module Clients
@@ -33,7 +34,7 @@ module Y2Autoinstallation
       end
 
       def import(map)
-        Yast::AutoinstScripts.Import(map)
+        Yast::AutoinstScripts.Import(Yast::ProfileHash.new(map))
       end
 
       def summary
@@ -41,7 +42,7 @@ module Y2Autoinstallation
       end
 
       def reset
-        Yast::AutoinstScripts.Import({})
+        Yast::AutoinstScripts.Import(Yast::ProfileHash.new)
       end
 
       def modified?

--- a/test/lib/clients/scripts_auto_test.rb
+++ b/test/lib/clients/scripts_auto_test.rb
@@ -24,7 +24,7 @@ describe Y2Autoinstallation::Clients::ScriptsAuto do
   let(:mod) { Yast::AutoinstScripts }
   describe "#import" do
     it "imports its param" do
-      expect(mod).to receive(:Import).with({})
+      expect(mod).to receive(:Import).with(Yast::ProfileHash)
 
       subject.import({})
     end
@@ -40,7 +40,10 @@ describe Y2Autoinstallation::Clients::ScriptsAuto do
 
   describe "#reset" do
     it "repropose module" do
-      expect(mod).to receive(:Import).with({})
+      expect(mod).to receive(:Import) do |arg|
+        expect(arg).to be_a(Yast::ProfileHash)
+        expect(arg).to be_empty
+      end
 
       subject.reset
     end


### PR DESCRIPTION
[bsc#1187898](https://bugzilla.opensuse.org/show_bug.cgi?id=1187898)

Found by @joseivanlopez, the `scripts_auto` client crashes when it tries to import the list of scripts. To be clear, it does not affect the installation, because the import sequence is just different. This bug is another face of 
[bsc#1184508](https://bugzilla.opensuse.org/show_bug.cgi?id=1184508).