### PR TITLE
Improving check-profile

### DIFF
--- a/src/lib/autoinstall/clients/autoyast.rb
+++ b/src/lib/autoinstall/clients/autoyast.rb
@@ -128,7 +128,7 @@ module Y2Autoinstallation
               "help"     => "Render the ERB profile. Be careful when running ERB profiles as " \
                             "root. Use only profiles that you trust. This option is" \
                             "\n\t\t\t\t     mandatory when running checks for an ERB profile as " \
-                            "root. By defautl true. Example: run-erb=true",
+                            "root. Example: run-erb=true",
               "typespec" => ["true", "false"]
             },
             "import-all"  => {

--- a/src/lib/autoinstall/clients/autoyast.rb
+++ b/src/lib/autoinstall/clients/autoyast.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2020] SUSE LLC
+# Copyright (c) [2020-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -172,7 +172,7 @@ module Y2Autoinstallation
         end
 
         checker = ProfileChecker.new(options["filename"],
-          import_all:  options["import_all"] != "false",
+          import_all:  options["import-all"] != "false",
           run_scripts: options["run-scripts"] == "true",
           target_file: options["output"] || "~/check_profile_result.xml")
         checker.check

--- a/src/lib/autoinstall/clients/autoyast.rb
+++ b/src/lib/autoinstall/clients/autoyast.rb
@@ -102,24 +102,45 @@ module Y2Autoinstallation
             }
           },
           "options"    => {
-            "filename"    => { "type" => "string", "help" => "Which profile to use. In " \
-              "check-profile case it supports also remote location like " \
-              "filename=ftp://test.com/example.xml" },
-            "modname"     => { "type" => "string", "help" => "modname=AYAST_MODULE" },
-            "output"      => { "type" => "string", "help" => "where evaluated profile will be " \
-              "written. Default is '~/check_profile_result.xml'. Example 'filename=~/test.xml'." },
-            "run-scripts" => { "type"     => "enum",
-                               "help"     => "run also scripts that are defined in profile. " \
-              "By default false. Example: run-scripts=true",
-                               "typespec" => ["true", "false"] },
-            "import-all"  => { "type"     => "enum",
-                               "help"     => "Do testing import of all sections in profile. " \
-              "Note that scripts are imported when run-scripts is set to true. By default true. " \
-              "Example: import-all=false",
-                               "typespec" => ["true", "false"] }
+            "filename"    => {
+              "type" => "string",
+              "help" => "Which profile to use. In check-profile case it supports also remote " \
+                        "location like filename=ftp://test.com/example.xml"
+            },
+            "modname"     => {
+              "type" => "string",
+              "help" => "modname=AYAST_MODULE"
+            },
+            "output"      => {
+              "type" => "string",
+              "help" => "Where evaluated profile will be written. Default is " \
+                        "'~/check_profile_result.xml'. Example 'filename=~/test.xml'."
+            },
+            "run-scripts" => {
+              "type"     => "enum",
+              "help"     => "Run also scripts that are defined in profile. Be careful when " \
+                            "running pre-installation scripts as root. Use only\n\t\t\t\t     " \
+                            "profiles that you trust. By default false. Example: run-scripts=true",
+              "typespec" => ["true", "false"]
+            },
+            "run-erb"     => {
+              "type"     => "enum",
+              "help"     => "Render the ERB profile. Be careful when running ERB profiles as " \
+                            "root. Use only profiles that you trust. This option is" \
+                            "\n\t\t\t\t     mandatory when running checks for an ERB profile as " \
+                            "root. By defautl true. Example: run-erb=true",
+              "typespec" => ["true", "false"]
+            },
+            "import-all"  => {
+              "type"     => "enum",
+              "help"     => "Do testing import of all sections in profile. Note that scripts are " \
+                            "imported when run-scripts is set to true.\n\t\t\t\t     By default " \
+                            "true. Example: import-all=false",
+              "typespec" => ["true", "false"]
+            }
           },
           "mappings"   => {
-            "check-profile" => ["filename", "run-scripts", "output", "import-all"],
+            "check-profile" => ["filename", "run-scripts", "run-erb", "output", "import-all"],
             "file"          => ["filename", "modname"],
             "module"        => ["filename", "modname"],
             "ui"            => ["filename", "modname"]
@@ -171,6 +192,8 @@ module Y2Autoinstallation
           return false
         end
 
+        return false unless erb_check(options["filename"], options["run-erb"])
+
         checker = ProfileChecker.new(options["filename"],
           import_all:  options["import-all"] != "false",
           run_scripts: options["run-scripts"] == "true",
@@ -199,6 +222,34 @@ module Y2Autoinstallation
         )
         Y2Autoinstallation::Importer.new(Profile.current).import_sections
         Yast::Popup.ClearFeedback
+      end
+
+      # Checks whether an ERB profile can be rendered according to the given options
+      #
+      # An ERB can be rendered if the check-profile command is run without root permissions. If it
+      # is run as root, then the option run-erb=true must be given.
+      #
+      # @param filename [String] filename of the AutoYaST profile
+      # @param run_erb_option [String] the given run-erb option
+      #
+      # @return [Boolean]
+      def erb_check(filename, run_erb_option)
+        return true unless filename.end_with?(".erb")
+
+        if !run_erb_option && Process.euid.zero?
+          Yast::CommandLine.Error(_("run-erb=true option is mandatory when checking an ERB " \
+            "profile as root."))
+
+          return false
+        end
+
+        if run_erb_option == "false"
+          Yast::CommandLine.Error(_("The ERB profile cannot be rendered with run-erb=false."))
+
+          return false
+        end
+
+        true
       end
 
       # AutoYaST UI sequence
@@ -264,7 +315,9 @@ module Y2Autoinstallation
       def check_profile_action_help
         _("Check if profile is valid. Also evaluate profile for dynamic profiles like " \
           "ERB or rules/classes. If run-scripts parameter is set to 'true' it can be used " \
-          "also to validate dynamic profiles generated by pre-scripts.")
+          "also to validate dynamic profiles generated by pre-scripts.\n\n    " \
+          "Be careful when running pre-installation scripts and ERB profiles as root. Use " \
+          "only profiles that you trust.")
       end
     end
   end

--- a/test/ProfileLocation_test.rb
+++ b/test/ProfileLocation_test.rb
@@ -1,5 +1,24 @@
 #!/usr/bin/env rspec
 
+# Copyright (c) [2019-2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require_relative "test_helper"
 
 Yast.import "ProfileLocation"
@@ -9,17 +28,18 @@ describe "Yast::ProfileLocation" do
   subject { Yast::ProfileLocation }
 
   describe "#Process" do
-
     before do
       Yast::AutoinstConfig.scheme = "relurl"
       Yast::AutoinstConfig.xml_tmpfile = "/tmp/123"
-      Yast::AutoinstConfig.filepath = "autoinst.xml"
+      Yast::AutoinstConfig.filepath = filepath
       allow(Yast::InstURL).to receive(:installInf2Url).and_return(
         "http://download.opensuse.org/distribution/leap/15.1/repo/oss/"
       )
       allow(Yast::SCR).to receive(:Read).and_return("test")
       allow(Yast::Report).to receive(:Error) # test is already quite weak and some errors are shown
     end
+
+    let(:filepath) { "autoinst.xml" }
 
     context "when scheme is \"relurl\"" do
       it "downloads AutoYaST configuration file with absolute path" do
@@ -48,6 +68,52 @@ describe "Yast::ProfileLocation" do
         expect_any_instance_of(String).to receive(:valid_encoding?).and_return(false)
         expect(Yast::Report).to receive(:Error).with(/has no valid encoding or is corrupted/)
         subject.Process
+      end
+    end
+
+    context "when the profile is an erb file" do
+      let(:filepath) { "autoinst.erb" }
+
+      before do
+        allow(Yast2::Popup).to receive(:show)
+
+        allow(subject).to receive(:Get).and_return("test")
+
+        allow(Yast::GPG).to receive(:encrypted_symmetric?).and_return(false)
+      end
+
+      context "and there is no error rendering the erb profile" do
+        before do
+          allow(Y2Autoinstallation::Y2ERB).to receive(:render)
+            .with(Yast::AutoinstConfig.xml_tmpfile).and_return("rendered content")
+
+          allow(Y2Autoinstallation::XmlChecks.instance).to receive(:valid_profile?).and_return(true)
+
+          allow(Yast::SCR).to receive(:Write)
+        end
+
+        it "does not show rendering errors" do
+          expect(Yast2::Popup).to_not receive(:show)
+
+          subject.Process
+        end
+      end
+
+      context "and there is some error rendering the erb profile" do
+        before do
+          allow(Y2Autoinstallation::Y2ERB).to receive(:render)
+            .with(Yast::AutoinstConfig.xml_tmpfile).and_raise StandardError
+        end
+
+        it "shows a rendering error" do
+          expect(Yast2::Popup).to receive(:show).with(/error while rendering/, anything)
+
+          subject.Process
+        end
+
+        it "returns false" do
+          expect(subject.Process).to eq(false)
+        end
       end
     end
   end


### PR DESCRIPTION
### Problem

A new [check-profile](https://github.com/yast/yast-autoinstallation/pull/696) command was recently added. This command is intended to check an AutoYaST profile without applying changes to the system. Generally, such a check could be done without root permissions, but there are some situations where root permissions are required:

* With option *run-scripts=true*, if the script code requires root permissions.
* With an *ERB* profile, if the *ERB* code requires root permissions.
* With option *import-all=true*, if any of the imported modules requires probing.

Running scripts/ERB code as root could lead to security problems, see:

* https://gist.github.com/lslezak/26b6ceb1e340c7216106bd43c5748b86.
* https://bugzilla.suse.com/show_bug.cgi?id=1177123

### Solution

It is difficult (or almost impossible) to know in advance if the command will require root access. The only way to ensure that the check will no fail because the permissions would be:

* By requiring root when *run-scripts=true* or *import-all=true* or the profile is an *ERB*. But this can be overkill in situations where the script/erb/probing does not require root.
* By executing YaST in a sandboxed environment (docker, namespaces) in order to avoid changes in the system. But it could have several implications and, at this moment, YaST is not well prepared for it.

It was agreed with security team to go with the following solution:

* Extend the command help with the implications of executing it as root.
* Add a new *run-erb* option in order to explicitly indicate that you want to execute the *ERB*. This option  is mandatory if the profile is an *ERB* file and the check is executed as root.  


### Testing

* Added unit tests
* Manually tested
