### PR TITLE
bsc#1187962: properly register init-scripts to reboot after online update

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul  2 12:43:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Properly register the script to reboot after applying online
+  updates (bsc#1187962).
+- 4.3.84
+
+-------------------------------------------------------------------
 Fri Jun 11 09:46:05 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when the general/storage section is empty

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.83
+Version:        4.3.84
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -162,7 +162,7 @@ module Yast
           #  feedback_type, location, notification)
           # make sure to avoid conflicts with "zzz_reboot" script here
           # https://github.com/yast/yast-autoinstallation/blob/104c18f1a56d02ab50055cdf09653db964b97888/src/modules/Profile.rb#L157
-          AutoinstScripts.AddEditScript("zzzz_reboot", "shutdown -r now", "shell", "init",
+          AutoinstScripts.AddEditScript("zzzz_reboot", "shutdown -r now", "shell", "init-scripts",
             false, false, false, "", "", "") # wonderful API without defaults
         end
       end


### PR DESCRIPTION
This PR should fix [bsc#1187962](https://bugzilla.opensuse.org/show_bug.cgi?id=1187962). The type of the script is wrong, and it should be [`"init-scripts"`](https://github.com/yast/yast-autoinstallation/blob/master/src/lib/autoinstall/script.rb#L414-L416) instead of `"init"`.