### PR TITLE
bsc#1187962: properly register init-scripts to reboot after online update (master)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul  2 12:43:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Properly register the script to reboot after applying online
+  updates (bsc#1187962).
+- 4.4.12
+
+-------------------------------------------------------------------
 Thu Jul  1 07:02:20 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash importing the <scripts> section (boo#1187898).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autoconfigure.rb
+++ b/src/clients/inst_autoconfigure.rb
@@ -162,7 +162,7 @@ module Yast
           #  feedback_type, location, notification)
           # make sure to avoid conflicts with "zzz_reboot" script here
           # https://github.com/yast/yast-autoinstallation/blob/104c18f1a56d02ab50055cdf09653db964b97888/src/modules/Profile.rb#L157
-          AutoinstScripts.AddEditScript("zzzz_reboot", "shutdown -r now", "shell", "init",
+          AutoinstScripts.AddEditScript("zzzz_reboot", "shutdown -r now", "shell", "init-scripts",
             false, false, false, "", "", "") # wonderful API without defaults
         end
       end


### PR DESCRIPTION
This PR brings [bsc#1187962](https://github.com/yast/yast-autoinstallation/pull/774) into `master`.