### PR TITLE
Do not export empty general settings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  5 08:30:18 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not export the general/storage section when it is empty
+  (related to bsc#1171356 and bsc#1187916).
+- 4.2.53
+
+-------------------------------------------------------------------
 Thu May 13 12:57:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Backport gh#651 by schubi@suse.de:

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.52
+Version:        4.2.53
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -220,7 +220,7 @@ module Yast
         end
       end
 
-      deep_copy(general)
+      general.reject { |_k, v| v.nil? || (v.respond_to?(:empty?) && v.empty?) }
     end
 
     # set the sigature handling

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -129,6 +129,19 @@ describe "Yast::AutoinstGeneral" do
       expect(subject.Export).to include("storage" => profile["storage"])
     end
 
+    context "when there are no storage settings" do
+      let(:profile) do
+        {
+          "storage" => {},
+          "mode" => { "confirm" => false }
+        }
+      end
+
+      it "does not export storage settings" do
+        expect(subject.Export.keys).to_not include("storage")
+      end
+    end
+
     it "exports mode settings" do
       expect(subject.Export).to include("mode" => profile["mode"])
     end
@@ -137,8 +150,28 @@ describe "Yast::AutoinstGeneral" do
       expect(subject.Export).to include("signature-handling" => profile["signature-handling"])
     end
 
+    context "when there are no signature-handling settings" do
+      let(:profile) do
+        { "signature-handling" => {} }
+      end
+
+      it "does not export the signature handling settings" do
+        expect(subject.Export.keys).to_not include("signature-handling")
+      end
+    end
+
     it "exports ask-list settings" do
       expect(subject.Export).to include("ask-list" => profile["ask-list"])
+    end
+
+    context "when there are no ask-list settings" do
+      let(:profile) do
+        { "ask-list" => [] }
+      end
+
+      it "does not export the ask-list settings" do
+        expect(subject.Export.keys).to_not include("ask-list")
+      end
     end
 
     it "exports proposals settings" do


### PR DESCRIPTION
Do not export the general/storage section when it is empty (related to [bsc#1171356](https://bugzilla.suse.com/show_bug.cgi?id=1171356) and [bsc#1187916](https://bugzilla.suse.com/show_bug.cgi?id=1187916)).