### PR TITLE
Fix tests

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul  6 08:57:22 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Fix unit tests dependency (related to bsc#1187962).
+- 4.4.13
+
+-------------------------------------------------------------------
 Fri Jul  2 12:43:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Properly register the script to reboot after applying online

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.12
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/test/AutoinstScripts_test.rb
+++ b/test/AutoinstScripts_test.rb
@@ -13,6 +13,7 @@ describe "Yast::AutoinstScripts" do
     allow(Yast::SCR).to receive(:Write)
     # re-init
     subject.main
+    Yast::AutoinstConfig.main
   end
 
   describe "#GetModified" do


### PR DESCRIPTION
### Problem

There are some dependencies between unit tests because the singleton `YaST::AutoinstConfig` module. This is making the unit tests to fail when *test/ProfileLocation_test.rb* is executed before than *test/AutoinstScripts_test.rb*.

* https://ci.suse.de/job/yast-yast-autoinstallation-master/111/console (internal link)

See https://github.com/yast/yast-autoinstallation/pull/773.

### Solution

Reset `YaST::AutoinstConfig` module before running tests.
