### PR TITLE
Fix rules schema

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,8 +1,10 @@
 -------------------------------------------------------------------
 Fri Jul  9 13:46:05 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Recognize installed_product and installed_product_version as
-  legal elements of rules.xml files (boo#1176089).
+- Add missing elements to rules.xml schema:
+  - installed_product and installed_product_version (boo#1176089)
+  - dialog section (bsc#1188153)
+- 4.2.54
 
 -------------------------------------------------------------------
 Mon Jul  5 08:30:18 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  9 13:46:05 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Recognize installed_product and installed_product_version as
+  legal elements of rules.xml files (boo#1176089).
+
+-------------------------------------------------------------------
 Mon Jul  5 08:30:18 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not export the general/storage section when it is empty

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.53
+Version:        4.2.54
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -47,6 +47,8 @@ y2_match_to =
     | hostid
     | karch
     | linux
+    | installed_product
+    | installed_product_version
     | mac
     | memsize
     | network
@@ -71,6 +73,8 @@ hostaddress    = element hostaddress     { match_text & match_type? }
 hostid         = element hostid          { match_text & match_type? }
 karch          = element karch           { match_text & match_type? }
 linux          = element linux           { match_text & match_type? }
+installed_product         = element installed_product         { match_text & match_type? }
+installed_product_version = element installed_product_version { match_text & match_type? }
 mac            = element mac             { match_text & match_type? }
 memsize        = element memsize         { match_text & match_type? }
 network        = element network         { match_text & match_type? }

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -27,7 +27,8 @@ rule =
 element rule {
     y2_match_to+ &
     result &
-    operator?
+    operator? &
+    dialog?
 }
 
 y2_match_to =
@@ -94,6 +95,19 @@ element result {
         element element { text }*
     }? &
     continue?
+}
+
+dialog =
+element dialog {
+    element dialog_nr { INTEGER }? &
+    element element { INTEGER }? &
+    element title { text }? &
+    element question { text }? &
+    element timeout { INTEGER }? &
+    element conflicts {
+        LIST,
+        element (element | listentry) { INTEGER }*
+    }
 }
 
 profile =


### PR DESCRIPTION
Fixes [bsc#1188153](https://bugzilla.suse.com/show_bug.cgi?id=1188153). The problem was reported against `SLE-15-SP3`, but it applies to `SP2` too. Additionally, I found another problem with the `installed_product*` elements, so I backported that fix too.