### PR TITLE
bsc#1188357: copy files to the right location when `file_location` is given

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 16 11:20:20 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Copy the files to the right location when a <file_location>
+  is given (bsc#1188357).
+- 4.2.55
+
+-------------------------------------------------------------------
 Fri Jul  9 13:46:05 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add missing elements to rules.xml schema:

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.54
+Version:        4.2.55
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstFile.rb
+++ b/src/modules/AutoinstFile.rb
@@ -12,6 +12,7 @@ module Yast
       textdomain "autoinst"
 
       Yast.import "AutoinstConfig"
+      Yast.import "Installation"
       Yast.import "Summary"
 
       Yast.include self, "autoinstall/io.rb"
@@ -149,14 +150,15 @@ module Yast
             Ops.set(file, "file_location", newloc)
             Builtins.y2milestone("changed relurl to %1 for file", newloc)
           end
+          file_location = File.join(Installation.destdir, file["file_path"] || alternate_location)
           Builtins.y2milestone(
             "trying to get file from %1 storing in %2",
             Ops.get_string(file, "file_location", ""),
-            Ops.get_string(file, "file_path", alternate_location)
+            file_location
           )
           if !GetURL(
             Ops.get_string(file, "file_location", ""),
-            Ops.get_string(file, "file_path", alternate_location)
+            file_location
           )
             Builtins.y2error("file could not be retrieved")
           else

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -133,7 +133,7 @@ describe "Yast::AutoinstGeneral" do
       let(:profile) do
         {
           "storage" => {},
-          "mode" => { "confirm" => false }
+          "mode"    => { "confirm" => false }
         }
       end
 

--- a/test/autoinst_file_test.rb
+++ b/test/autoinst_file_test.rb
@@ -1,0 +1,108 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# !/usr/bin/env rspec
+
+require_relative "test_helper"
+require "tmpdir"
+
+Yast.import "AutoinstFile"
+
+describe Yast::AutoinstFile do
+  subject { Yast::AutoinstFile }
+
+  describe "#Write" do
+    let(:scr_root_dir) { Dir.mktmpdir("YaST-") }
+
+    before do
+      allow(Yast::Installation).to receive(:destdir).and_return(scr_root_dir)
+      allow(Yast::SCR).to receive(:Execute).and_call_original
+      subject.Import(profile)
+    end
+
+    around do |example|
+      change_scr_root(scr_root_dir, &example)
+      FileUtils.remove_entry(scr_root_dir) if Dir.exist?(scr_root_dir)
+    end
+
+    context "when the file path ends with a slash" do
+      let(:profile) do
+        [{ "file_path" => "/etc/", "file_permissions" => "750", "file_owner" => "root" }]
+      end
+
+      it "considers the file to be a directory" do
+        expect(Yast::SCR)
+          .to receive(:Execute).with(Yast::Path.new(".target.bash"), "chmod 750 /etc/")
+        expect(Yast::SCR)
+          .to receive(:Execute).with(Yast::Path.new(".target.bash"), "chown root /etc/")
+
+        subject.Write
+
+        expect(Dir).to exist(File.join(scr_root_dir, "etc"))
+      end
+    end
+
+    context "when file contents are given" do
+      let(:profile) do
+        [
+          { "file_path" => "/etc/" },
+          {
+            "file_contents" => "hello!", "file_path" => "/etc/motd",
+            "file_permissions" => "644", "file_owner" => "root"
+          }
+        ]
+      end
+
+      it "writes the contents to the destdir" do
+        expect(Yast::SCR)
+          .to receive(:Execute).with(Yast::Path.new(".target.bash"), "chmod 644 /etc/motd")
+        expect(Yast::SCR)
+          .to receive(:Execute).with(Yast::Path.new(".target.bash"), "chown root /etc/motd")
+
+        subject.Write
+
+        content = File.read(File.join(scr_root_dir, "etc", "motd"))
+        expect(content).to eq("hello!")
+      end
+    end
+
+    context "when a file location is given" do
+      let(:profile) do
+        [
+          {
+            "file_location" => "http://example.net/test", "file_path" => "/test.txt",
+            "file_permissions" => "644", "file_owner" => "root"
+          }
+        ]
+      end
+
+      it "copies the file to the destdir" do
+        expect(Yast::SCR)
+          .to receive(:Execute).with(Yast::Path.new(".target.bash"), "chmod 644 /test.txt")
+        expect(Yast::SCR)
+          .to receive(:Execute).with(Yast::Path.new(".target.bash"), "chown root /test.txt")
+        expect(subject)
+          .to receive(:GetURL).with("http://example.net/test", File.join(scr_root_dir, "test.txt"))
+
+        subject.Write
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Fixes [bsc#1188357](https://bugzilla.suse.com/show_bug.cgi?id=1188357)

This problem might affect SLE 15 SP2 once [this change](https://github.com/yast/yast-autoinstallation/blob/SLE-15-SP2/package/autoyast2.changes#L19-L21) reaches the installer update channel.

When using `file_location`, the file is copied to the inst-sys instead of the final system. The real issue is that `GetURL` is not aware of SCR changed root. However, as it is used in several places, I have decided to fix the problem in the caller, having the `Installation.destdir` into account. Additionally, I took the chance to add a few unit tests.

For this change to work, we need and up-to-date `yast2-installation` package (version `4.2.52` at least).