### PR TITLE
bsc#1188360: copy init-scripts to the target system

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 16 15:27:30 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Copy the init-scripts to the right location during 1st stage
+  (bsc#1188360).
+- 4.3.87
+
+-------------------------------------------------------------------
 Fri Jul 16 11:20:20 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Copy the files to the right location when a <file_location>

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.86
+Version:        4.3.87
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/script.rb
+++ b/src/lib/autoinstall/script.rb
@@ -406,6 +406,15 @@ module Y2Autoinstallation
     def script_path
       File.join(Yast::AutoinstConfig.initscripts_dir, script_name)
     end
+
+    # Returns the path to write th script
+    #
+    # The init-scripts always run in the target system.
+    #
+    # @return [String] Path to write the script
+    def localfile
+      File.join(Yast::AutoinstConfig.destdir, super)
+    end
   end
 
   # List of known script

--- a/test/lib/script_test.rb
+++ b/test/lib/script_test.rb
@@ -368,4 +368,14 @@ describe Y2Autoinstallation::InitScript do
       expect(subject.script_path).to eq "/var/adm/autoinstall/init.d/test.sh"
     end
   end
+
+  describe "#localfile" do
+    before do
+      allow(Yast::AutoinstConfig).to receive(:destdir).and_return("/mnt")
+    end
+
+    it "returns the path in the target system" do
+      expect(subject.localfile).to eq "/mnt/var/adm/autoinstall/init.d/test.sh"
+    end
+  end
 end


### PR DESCRIPTION
Fixes [bsc#1188360](https://bugzilla.suse.com/show_bug.cgi?id=1188360).

init-scripts are always copied to the target, similar to [chrooted scripts](https://github.com/yast/yast-autoinstallation/blob/master/src/lib/autoinstall/script.rb#L388).