### PR TITLE
[SP3] Add "final_reboot" and "final_halt" scripts only once (bsc#1188356)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 20 14:45:51 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed handling of the "final_reboot" and "final_halt" options,
+  add the custom scripts only once and avoid displaying
+  a warning popup during installation (bsc#1188356)
+- 4.3.88
+
+-------------------------------------------------------------------
 Fri Jul 16 15:27:30 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Copy the init-scripts to the right location during 1st stage

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.87
+Version:        4.3.88
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -131,11 +131,9 @@ module Yast
             Builtins.remove(Ops.get_map(@current, "general", {}), "clock")
           )
         end
-        if Ops.get_boolean(@current, ["general", "mode", "final_halt"], false)
-          script = {
-            "filename" => "zzz_halt",
-            "source"   => "shutdown -h now"
-          }
+        if Ops.get_boolean(@current, ["general", "mode", "final_halt"], false) &&
+            !Ops.get_list(@current, ["scripts", "init-scripts"], []).include?(HALT_SCRIPT)
+
           Ops.set(@current, "scripts", {}) if !Builtins.haskey(@current, "scripts")
           if !Builtins.haskey(
             Ops.get_map(@current, "scripts", {}),
@@ -148,15 +146,13 @@ module Yast
             ["scripts", "init-scripts"],
             Builtins.add(
               Ops.get_list(@current, ["scripts", "init-scripts"], []),
-              script
+              HALT_SCRIPTt
             )
           )
         end
-        if Ops.get_boolean(@current, ["general", "mode", "final_reboot"], false)
-          script = {
-            "filename" => "zzz_reboot",
-            "source"   => "shutdown -r now"
-          }
+        if Ops.get_boolean(@current, ["general", "mode", "final_reboot"], false) &&
+            !Ops.get_list(@current, ["scripts", "init-scripts"], []).include?(REBOOT_SCRIPT)
+
           Ops.set(@current, "scripts", {}) if !Builtins.haskey(@current, "scripts")
           if !Builtins.haskey(
             Ops.get_map(@current, "scripts", {}),
@@ -169,7 +165,7 @@ module Yast
             ["scripts", "init-scripts"],
             Builtins.add(
               Ops.get_list(@current, ["scripts", "init-scripts"], []),
-              script
+              REBOOT_SCRIPT
             )
           )
         end
@@ -657,6 +653,16 @@ module Yast
     publish function: :needed_second_stage_packages, type: "list <string> ()"
 
   private
+
+    REBOOT_SCRIPT = {
+      "filename" => "zzz_reboot",
+      "source"   => "shutdown -r now"
+    }.freeze
+
+    HALT_SCRIPT = {
+      "filename" => "zzz_halt",
+      "source"   => "shutdown -h now"
+    }.freeze
 
     def add_autoyast_packages
       @current["software"] ||= {}

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -146,7 +146,7 @@ module Yast
             ["scripts", "init-scripts"],
             Builtins.add(
               Ops.get_list(@current, ["scripts", "init-scripts"], []),
-              HALT_SCRIPTt
+              HALT_SCRIPT
             )
           )
         end

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -28,6 +28,12 @@ describe Yast::Profile do
     items_list("patterns")
   end
 
+  def reboot_scripts
+    Yast::Profile.current["scripts"]["init-scripts"].select do |s|
+      s["filename"] == "zzz_reboot"
+    end
+  end
+
   describe "#softwareCompat" do
     before do
       Yast::Profile.current = profile
@@ -116,6 +122,37 @@ describe Yast::Profile do
       it "adds 'base' pattern" do
         Yast::Profile.softwareCompat
         expect(patterns_list).to include("base")
+      end
+    end
+  end
+
+  describe "#generalCompat" do
+    before do
+      Yast::Profile.current = profile
+    end
+
+    context "when a custom reboot script is not present" do
+      let(:profile) { { "general" => { "mode" => { "final_reboot" => true } } } }
+
+      it "adds a reboot script for the 'final_reboot' flag" do
+        Yast::Profile.generalCompat
+        expect(reboot_scripts).to_not be_empty
+      end
+    end
+
+    # the first stage adds a custom script for the "final_reboot" flag,
+    # ensure the second stage does not add it again (bsc#1188356)
+    context "when a custom reboot script is present" do
+      let(:profile) do
+        { "general" => { "mode" => { "final_reboot" => true } },
+          "scripts" => { "init-scripts" => [
+            { "filename" => "zzz_reboot", "source" => "shutdown -r now" }
+          ] } }
+      end
+
+      it "does not duplicate the reboot script" do
+        Yast::Profile.generalCompat
+        expect(reboot_scripts.size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## The Problem

![script_conflict](https://user-images.githubusercontent.com/907998/126341964-5a2d66ed-132b-43f0-a37e-ee0c34283284.png)

- The problem happens when setting the `<final_reboot config:type="boolean">true</final_reboot>` option in the AutoYaST profile
- See https://bugzilla.suse.com/show_bug.cgi?id=1188356
- During debugging it turned out that the workflow is this:
  - The `Import()` method in the `Profile` module does some processing, in this case it adds a custom reboot script when `final_reboot` is set to actually do the reboot
  - The saved profile from the 1st stage to the 2nd stage contains both, the `final_reboot` flag and the custom script
  - The `Import()` method is called again the 2nd stage, it does the same processing again and adds the second custom reboot script accidentally
  - When AutoYaST runs the custom scripts later it complains that the same script is defined twice
- When inspecting the code the same problem was found also for the `final_halt` profile option

## The Fix

Simply check whether the custom reboot script is already present when processing the profile.

## Testing

- Tested manually - with the patch the warning popup is not displayed and the system is correctly rebooted at the 2nd stage when AutoYaST is finished
- Added an unit test to avoid regressions