### PR TITLE
[SLE-15-SP3] Ensure Closing Script Notification Pop-ups

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Sep  6 12:06:42 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Ensure closing notification pop-ups even if a user script
+  was not executed to prevent "No widget with ID ..." error pop-up
+  (bsc#1188930, bsc#1188716)
+- 4.3.89
+
+-------------------------------------------------------------------
 Tue Jul 20 14:45:51 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed handling of the "final_reboot" and "final_halt" options,

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.88
+Version:        4.3.89
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstScripts.rb
+++ b/src/modules/AutoinstScripts.rb
@@ -259,9 +259,9 @@ module Yast
         Popup.ShowFeedback("", script.notification) unless script.notification.empty?
 
         res = script.execute
-        next if res.nil? # the script was not executed
 
         Popup.ClearFeedback unless script.notification.empty?
+        next if res.nil? # the script was not executed
 
         feedback = if script.feedback.value == :no
           ""

--- a/test/AutoinstScripts_test.rb
+++ b/test/AutoinstScripts_test.rb
@@ -377,6 +377,20 @@ describe "Yast::AutoinstScripts" do
       subject.Write("pre-scripts", true)
     end
 
+    it "closes the notification popup even if the script was not executed" do
+      data = {
+        "pre-scripts" => [{ "location" => "http://test.com/script", "filename" => "script1",
+        "interpreter" => "shell", "rerun" => true, "notification" => "Script1!!!" }]
+      }
+
+      allow_any_instance_of(Y2Autoinstallation::PreScript).to receive(:execute).and_return(nil)
+      expect(Yast::Popup).to receive(:ShowFeedback).with("", "Script1!!!")
+      expect(Yast::Popup).to receive(:ClearFeedback)
+
+      subject.Import(data)
+      subject.Write("pre-scripts", true)
+    end
+
     it "shows a report if feedback parameter is set" do
       data = {
         "pre-scripts" => [{ "location" => "http://test.com/script", "filename" => "script1",


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1188930
https://bugzilla.suse.com/show_bug.cgi?id=1188716


## Problem

From SLE 15 SP3 on, AutoYaST user scripts that have a `<notification>` tag tend to cause a UI error pop-up _No widget with ID ..._. Removing the `<notification>` tag appears to fix the problem.


## Cause

The pop-up with the notification gets in the way when the progress report in the main window is updated: Since the pop-up with the notification is still open, the widget with the requested ID (containing the progress) cannot be found, causing this error.

**Side note:** This is only a fatal error for certain UI built-ins like `UI.ReplaceWidget()`, not for others like `UI.ChangeWidget()`, but the error can also be observed in the y2log for those other UI built-ins, so it appears to happen quite often after such a script notification was used.


## Fix

Now strictly _always_ closing the notification pop-up with `Popup::ClearFeedback()`. Previously it could remain open under certain conditions, like executing the script returned `nil`.


## Why Did Those Scripts Ever return _nil_?

This is something we don't know yet; it's probably a completely separate problem.


## Why in SLE 15 SP3 only and not in SLE 15 SP2?

There was major refactoring for SLE 15 SP3, modernizing a lot of old auto-translated ex-YCP code; it's now real Ruby. Some bugs seem to have sneaked in during that refactoring.