### PR TITLE
Update rules.xml schema (bsc#1190696)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Sep 21 11:13:59 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Update the rules.xml schema:
+  - add the "hostname" element (bsc#1190696).
+  - remove the 'haspcmica' element (related to bsc#1183352).
+- 4.2.56
+
+-------------------------------------------------------------------
 Fri Jul 16 11:20:20 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Copy the files to the right location when a <file_location>

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.2.55
+Version:        4.2.56
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -42,7 +42,6 @@ y2_match_to =
     | custom5
     | disksize
     | domain
-    | haspcmica
     | hostaddress
     | hostid
     | karch
@@ -68,7 +67,6 @@ custom4        = element custom4         { match_text & match_type? & script }
 custom5        = element custom5         { match_text & match_type? & script }
 disksize       = element disksize        { match_text & match_type? }
 domain         = element domain          { match_text & match_type? }
-haspcmica      = element haspcmica       { match_text & match_type? }
 hostaddress    = element hostaddress     { match_text & match_type? }
 hostid         = element hostid          { match_text & match_type? }
 karch          = element karch           { match_text & match_type? }

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -42,6 +42,7 @@ y2_match_to =
     | custom5
     | disksize
     | domain
+    | hostname
     | hostaddress
     | hostid
     | karch
@@ -67,6 +68,7 @@ custom4        = element custom4         { match_text & match_type? & script }
 custom5        = element custom5         { match_text & match_type? & script }
 disksize       = element disksize        { match_text & match_type? }
 domain         = element domain          { match_text & match_type? }
+hostname       = element hostname        { match_text & match_type? }
 hostaddress    = element hostaddress     { match_text & match_type? }
 hostid         = element hostid          { match_text & match_type? }
 karch          = element karch           { match_text & match_type? }


### PR DESCRIPTION
* According to [bsc#1190696](https://bugzilla.suse.com/show_bug.cgi?id=1190696) this element is not validated properly.
* BTW, backport the fix to remove the `haspcmica` element ([bsc#1183352](https://bugzilla.suse.com/show_bug.cgi?id=1183352)).

Related to https://github.com/yast/yast-schema/pull/113.