### PR TITLE
Adapt to the ProductSpec API

### DIFF
--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -1,6 +1,7 @@
 require "autoinstall/autosetup_helpers"
 require "autoinstall/importer"
 require "y2packager/medium_type"
+require "y2packager/product_spec"
 require "autoinstall/ask/runner"
 require "autoinstall/ask/stage"
 
@@ -134,8 +135,8 @@ module Y2Autoinstallation
            "in the AutoYaST configuration file. " \
            "Please check the <b>products</b> entry in the <b>software</b> section.<br><br>" \
            "Following base products are available:<br>")
-          Yast::AutoinstFunctions.available_base_products_hash.each do |product|
-            msg += "#{product[:name]} (#{product[:summary]})<br>"
+          Y2Packager::ProductSpec.base_products.each do |product|
+            msg += "#{product.name} (#{product.display_name})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the installation/upgrade.
           return :abort
@@ -428,8 +429,8 @@ module Y2Autoinstallation
               "Please check the <b>products</b> entry in the <b>software</b> section.<br><br>" \
               "Following base products are available:<br>")
           end
-          Yast::AutoinstFunctions.available_base_products_hash.each do |p|
-            msg += "#{p[:name]} (#{p[:summary]})<br>"
+          Y2Packager::ProductSpec.base_products.each do |product|
+            msg += "#{product.name} (#{product.display_name})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the installation/upgrade.
           return :abort

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -429,8 +429,8 @@ module Y2Autoinstallation
               "Please check the <b>products</b> entry in the <b>software</b> section.<br><br>" \
               "Following base products are available:<br>")
           end
-          Y2Packager::ProductSpec.base_products.each do |product|
-            msg += "#{product.name} (#{product.display_name})<br>"
+          Y2Packager::ProductSpec.base_products.each do |prod|
+            msg += "#{prod.name} (#{prod.display_name})<br>"
           end
           Yast::Popup.LongError(msg) # No timeout because we are stopping the installation/upgrade.
           return :abort

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -408,7 +408,7 @@ module Y2Autoinstallation
           log_url = Yast::URL.HidePassword(base_url)
           Yast::Packages.Initialize_StageInitial(show_popup, base_url, log_url, product.dir)
           # select the product to install
-          Yast::Pkg.ResolvableInstall(product.details.product, :product, "")
+          Yast::Pkg.ResolvableInstall(product.name, :product, "")
           # initialize addons and the workflow manager
           Yast::AddOnProduct.SetBaseProductURL(base_url)
           Yast::WorkflowManager.SetBaseWorkflow(false)

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -1,5 +1,6 @@
 require "autoinstall/autosetup_helpers"
 
+require "y2packager/product_spec"
 require "y2packager/product_upgrade"
 require "yast2/popup"
 
@@ -236,8 +237,8 @@ module Y2Autoinstallation
            "It can be specified in the <b>software</b>/<b>products</b> entry in the " \
            "AutoYaST configuration file.<br><br>" \
            "Following base products are available:<br>")
-          Yast::AutoinstFunctions.available_base_products_hash.each do |product|
-            msg += "#{product[:name]} (#{product[:summary]})<br>"
+          Y2Packager::ProductSpec.base_products.each do |producŧ|
+            msg += "#{product.name} (#{product.display_name})<br>"
           end
           Yast2::Popup.show(msg, richtext: true) # No timeout because we are stopping the upgrade.
           return :abort

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -237,8 +237,8 @@ module Y2Autoinstallation
            "It can be specified in the <b>software</b>/<b>products</b> entry in the " \
            "AutoYaST configuration file.<br><br>" \
            "Following base products are available:<br>")
-          Y2Packager::ProductSpec.base_products.each do |producŧ|
-            msg += "#{product.name} (#{product.display_name})<br>"
+          Y2Packager::ProductSpec.base_products.each do |prod|
+            msg += "#{prod.name} (#{prod.display_name})<br>"
           end
           Yast2::Popup.show(msg, richtext: true) # No timeout because we are stopping the upgrade.
           return :abort

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -19,6 +19,8 @@ module Yast
       Yast.import "Profile"
       Yast.import "Pkg"
 
+      # Force to read the list of products from libzypp. See {#check_result} for
+      # further details.
       @force_libzypp = false
     end
 

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -83,8 +83,7 @@ module Yast
     # 2) impllicitly according to software selection
     # 3) if not set explicitly and just one product is available on media - use it
     #
-    # @return [Y2Packager::Product|Y2Packager::ProductLocation] a base product or nil.
-    # The returned class depends on phase of installation and type of installation medium.
+    # @return [Y2Packager::ProductSpec] a base product or nil.
     def selected_product
       return @selected_product if @selected_product
 
@@ -118,8 +117,6 @@ module Yast
     # the product information has been read (libzypp, or product specs).
     # So the type could be Product or ProductSpec derived class.
     #
-    # available_base_products_hash could be an alternative for this call.
-    #
     # The behaviour of this method can be affected by the `force_libzypp` attribute.
     # Check {#reset_product} for further details.
     #
@@ -136,17 +133,6 @@ module Yast
       end
 
       @base_products
-    end
-
-    #
-    # Evaluate all available base products and returns a list of hashes which contains
-    # human readable strings only.
-    #
-    # @return [Hash] an array of product hashes
-    def available_base_products_hash
-      available_base_products.map do |product|
-        { name: product.name, summary: product.display_name }
-      end
     end
 
     # force selected product to be read from libzypp and not from product location

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -126,7 +126,9 @@ module Yast
     def available_base_products
       return @base_products if @base_products
 
-      @base_products = Y2Packager::ProductReader.new.available_base_products(force_repos: @force_libzypp)
+      @base_products = Y2Packager::ProductReader.new.available_base_products(
+        force_repos: @force_libzypp
+      )
       return @base_products if @force_libzypp
 
       libzypp_names = @base_products.map(&:name)

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -163,7 +163,6 @@ describe Yast::AutoinstFunctions do
       end
     end
 
-
     context "when the product is identified by a pattern" do
       let(:profile) do
         { "software" => { "patterns" => ["sles-base-32bit"] } }

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -119,7 +119,12 @@ describe Yast::AutoinstFunctions do
 
     let(:selected_name) { "SLES" }
 
+    let(:profile) do
+      { "software" => { "products" => [selected_name] } }
+    end
+
     before(:each) do
+      allow(Yast::Profile).to receive(:current).and_return(Yast::ProfileHash.new(profile))
       allow(Y2Packager::ProductReader)
         .to receive(:new)
         .and_return(double(available_base_products: [base_product("SLES"), base_product("SLED")]))
@@ -128,62 +133,63 @@ describe Yast::AutoinstFunctions do
       subject.reset_product
     end
 
-    it "returns proper base product when explicitly selected in the profile " \
-        "and such base product exists on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return(Yast::ProfileHash.new("software" => { "products" => [selected_name] }))
+    context "when the base product is explicitly selected in the profile" do
+      context "and the product exists on the media" do
+        it "returns the corresponding base product" do
+          expect(subject.selected_product.name).to eql selected_name
+        end
+      end
 
-      expect(subject.selected_product.name).to eql selected_name
+      context "and such a product does not exist on the media" do
+        let(:selected_name) { "Fedora" }
+
+        it "returns nil" do
+          expect(subject.selected_product).to be nil
+        end
+      end
     end
 
-    it "returns nil when product is explicitly selected in the profile and " \
-        "such base product doesn't exist on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return(
-          Yast::ProfileHash.new("software" => { "products" => { "product" => "Fedora" } })
-        )
 
-      expect(subject.selected_product).to be nil
+    context "when the product is identified by a pattern" do
+      let(:profile) do
+        { "software" => { "patterns" => ["sles-base-32bit"] } }
+      end
+
+      it "returns the corresponding product" do
+        expect(subject.selected_product.name).to eql selected_name
+      end
     end
 
-    it "returns base product identified by patterns in the profile " \
-        "if such base product exists on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return(Yast::ProfileHash.new("software" => { "patterns" => ["sles-base-32bit"] }))
+    context "when the product is identified by a package" do
+      let(:profile) do
+        { "software" => { "packages" => ["sles-release"] } }
+      end
 
-      expect(subject.selected_product.name).to eql selected_name
+      it "returns the corresponding product" do
+        expect(subject.selected_product.name).to eql selected_name
+      end
     end
 
-    it "returns base product identified by packages in the profile " \
-        "if such base product exists on media" do
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return(Yast::ProfileHash.new("software" => { "packages" => ["sles-release"] }))
+    context "when the product cannot be identified from the profile" do
+      let(:profile) do
+        { "software" => {} }
+      end
 
-      expect(subject.selected_product.name).to eql selected_name
-    end
+      context "and only one base product exists on the media" do
+        before do
+          allow(Y2Packager::ProductReader)
+            .to receive(:new)
+            .and_return(double(available_base_products: [base_product("SLED")]))
+        end
 
-    it "returns base product if there is just one on media and " \
-        "product cannot be identified from profile" do
-      allow(Y2Packager::ProductReader)
-        .to receive(:new)
-        .and_return(double(available_base_products: [base_product("SLED")]))
-      allow(Yast::Profile)
-        .to receive(:current)
-        .and_return(Yast::ProfileHash.new("software" => {}))
-
-      expect(subject.selected_product.name).to eql "SLED"
+        it "returns the existing base product" do
+          expect(subject.selected_product.name).to eql "SLED"
+        end
+      end
     end
 
     context "when there is not a valid software section" do
-      before do
-        allow(Yast::Profile)
-          .to receive(:current)
-          .and_return(Yast::ProfileHash.new("software" => nil))
-      end
+      let(:profile) { { "software" => nil } }
 
       it "returns nil" do
         expect(subject.selected_product).to be_nil

--- a/test/AutoinstFunctions_test.rb
+++ b/test/AutoinstFunctions_test.rb
@@ -117,6 +117,8 @@ describe Yast::AutoinstFunctions do
       Y2Packager::Product.new(name: name)
     end
 
+    let(:product_spec) { instance_double(Y2Packager::ProductSpec, name: "openSUSE") }
+
     let(:selected_name) { "SLES" }
 
     let(:profile) do
@@ -129,6 +131,9 @@ describe Yast::AutoinstFunctions do
         .to receive(:new)
         .and_return(double(available_base_products: [base_product("SLES"), base_product("SLED")]))
 
+      allow(Y2Packager::ProductSpec).to receive(:base_products).and_return([product_spec])
+
+      subject.main
       # reset cache between tests
       subject.reset_product
     end
@@ -136,6 +141,15 @@ describe Yast::AutoinstFunctions do
     context "when the base product is explicitly selected in the profile" do
       context "and the product exists on the media" do
         it "returns the corresponding base product" do
+          expect(subject.selected_product.name).to eql selected_name
+        end
+      end
+
+      context "and the product exists on the control file (online case)" do
+        let(:selected_name) { "openSUSE" }
+
+        it "returns the corresponding base product" do
+          subject.main
           expect(subject.selected_product.name).to eql selected_name
         end
       end

--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -26,7 +26,7 @@ require "y2packager/resolvable"
 
 describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
   let(:profile) do
-    {
+    Yast::ProfileHash.new({
       "general"  => {},
       "software" => {
         "products"        => ["sled"],
@@ -37,7 +37,7 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
         "remove-products" => ["sle-desktop"]
       },
       "upgrade"  => { "stop_on_solver_conflict" => true }
-    }
+    })
   end
 
   before do

--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -26,7 +26,7 @@ require "y2packager/resolvable"
 
 describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
   let(:profile) do
-    Yast::ProfileHash.new({
+    Yast::ProfileHash.new(
       "general"  => {},
       "software" => {
         "products"        => ["sled"],
@@ -37,7 +37,7 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
         "remove-products" => ["sle-desktop"]
       },
       "upgrade"  => { "stop_on_solver_conflict" => true }
-    })
+    )
   end
 
   before do


### PR DESCRIPTION
Adapt the module to the new `ProductSpec` API. Additionally, it reorganizes the tests of `AutoinstFunctions.selected_base` in a more RSpec-like way.

## References

* https://github.com/yast/yast-packager/pull/583
* https://github.com/yast/yast-yast2/pull/1199