### PR TITLE
abort install if reg failed and there is no repo

### DIFF
--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -98,7 +98,9 @@ module Y2Autoinstallation
             !Yast::Mode.autoupgrade
           autosetup_network if network_before_proposal?
 
-          suse_register
+          register = suse_register
+          # abort installation if registration failed and there are no install repo
+          return :abort if !register && !Y2Packager::InstallationMedium.contain_repo?
         # report error if there are no registration and no repository on medium
         elsif !Y2Packager::InstallationMedium.contain_repo? && !Yast::Mode.autoupgrade
           report_missing_registration


### PR DESCRIPTION
fix for https://trello.com/c/nIoJgTXG/2615-3-sles15-sp3-p5-1188211-absence-of-product-in-autoyast-profile-causes-different-behavior-for-online-and-full-medium

sadly it is still shows a slighly different message, but we cannot now distinguish between reasons for failed registration.