### PR TITLE
Fix empty product crash sp3

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov  1 11:23:31 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Stop autoyast installation when registration failed on online
+  medium (bsc#1188211)
+- 4.3.92
+
+-------------------------------------------------------------------
 Mon Oct 25 07:40:25 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Add the "keep_unknown_lv" element to the partitioning schema

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.91
+Version:        4.3.92
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -380,7 +380,7 @@ module Y2Autoinstallation
           return :abort
         end
 
-        suse_register
+        return :abort unless suse_register
 
         nil
       end


### PR DESCRIPTION
https://trello.com/c/nIoJgTXG/2615-3-sles15-sp3-p5-1188211-absence-of-product-in-autoyast-profile-causes-different-behavior-for-online-and-full-medium

in general stop autoinstallation on online medium if registration failed.