### PR TITLE
Add missing require of "cwm/rspec"

### DIFF
--- a/test/lib/autoinstall/widgets/ask/password_field_test.rb
+++ b/test/lib/autoinstall/widgets/ask/password_field_test.rb
@@ -20,6 +20,7 @@
 require_relative "../../../../test_helper"
 require "autoinstall/widgets/ask/password_field"
 require "autoinstall/ask/question"
+require "cwm/rspec"
 
 describe Y2Autoinstall::Widgets::Ask::PasswordField do
   subject { described_class.new(question) }


### PR DESCRIPTION
Depending on the order, the tests may fail because "cwm/rspec" is not properly required.

See https://build.suse.de/package/live_build_log/Devel:YaST:Head/autoyast2/SUSE_SLE-15-SP4_GA/ppc64le.