### PR TITLE
bsc#1192185: Do not process the <add-on> section again

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 18 10:38:18 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not process the <add-on/> section during the 2nd stage
+  (bsc#1192185).
+- 4.3.93
+
+-------------------------------------------------------------------
 Mon Nov  1 11:23:31 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Stop autoyast installation when registration failed on online

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.92
+Version:        4.3.93
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -140,6 +140,8 @@ module Y2Autoinstallation
             log.warn("User has aborted the installation.")
             return :abort
           end
+          Profile.remove_sections("add-on")
+
           Call.Function("add-on_auto", ["Write"])
 
           # Recover partitioning settings that were removed by the add-on_auto client (bsc#1073548)

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -252,5 +252,26 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
         end
       end
     end
+
+    context "when the add-on section is included" do
+      let(:profile) do
+        {
+          "add-on" => {
+            "add_on_products" => [
+              { "media_url" => "relurl:///", "product_dir" => "/AddOn" }
+            ]
+          }
+        }
+      end
+
+      it "removes the add-on section from the profile" do
+        expect(Yast::Profile.current).to have_key("add-on")
+        expect(Yast::WFM).to receive(:CallFunction)
+          .with("add-on_auto", ["Import", profile["add-on"]])
+          .and_return(true)
+        subject.main
+        expect(Yast::Profile.current).to_not have_key("add-on")
+      end
+    end
   end
 end


### PR DESCRIPTION
The `<add-on>` section is processed [during the 1st stage](https://github.com/yast/yast-autoinstallation/blob/a214818656d0ad4d8cd06b89a779e177b42c2d9a/src/lib/autoinstall/clients/inst_autosetup.rb#L135-L138). So AutoYaST does not need to process it again during the 2nd stage.

Although this section is never processed during the 2nd stage (because of the specification in the profile), it may ask the user to install yast2-add-on even if it is not going to be processed.

I will ask for review and merge after some tests.