### PR TITLE
Merge product workflow during autosetup_upgrade

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 25 12:56:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- During autoupgrade merge the selected product workflow in order
+  to execute 2nd stage modules (bsc#1192437)
+- 4.3.94
+
+-------------------------------------------------------------------
 Thu Nov 18 10:38:18 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not process the <add-on/> section during the 2nd stage

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.93
+Version:        4.3.94
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -57,12 +57,14 @@ module Y2Autoinstallation
         return :abort if UI.PollInput == :abort && Popup.ConfirmAbort(:painless)
 
         Progress.NextStage
-
-        # configure general settings
-
         #
         # Set workflow variables
-        #
+        # Ensure that we clean product cache to avoid product from control (bsc#1156058)
+        AutoinstFunctions.reset_product
+        # Merging selected product (bsc#1192437)
+        AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
+
+        # configure general settings
         general_section = Profile.current["general"] || {}
         AutoinstGeneral.Import(general_section)
         Builtins.y2milestone(

--- a/test/lib/clients/inst_autosetup_upgrade_test.rb
+++ b/test/lib/clients/inst_autosetup_upgrade_test.rb
@@ -25,11 +25,12 @@ require "autoinstall/clients/inst_autosetup_upgrade"
 require "y2packager/resolvable"
 
 describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
+  let(:product_name) { "sled" }
   let(:profile) do
     {
       "general"  => {},
       "software" => {
-        "products"        => ["sled"],
+        "products"        => [product_name],
         "patterns"        => ["yast-devel"],
         "packages"        => ["vim"],
         "remove-packages" => ["emacs"],
@@ -38,6 +39,10 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
       },
       "upgrade"  => { "stop_on_solver_conflict" => true }
     }
+  end
+
+  let(:product) do
+    Y2Packager::Product.new(name: product_name)
   end
 
   before do
@@ -56,6 +61,8 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
     allow(Yast::WFM).to receive(:SetLanguage)
     allow(Yast::UI).to receive(:SetLanguage)
     allow(Yast::AutoinstFunctions).to receive(:available_base_products).and_return([])
+    allow(Yast::AutoinstFunctions).to receive(:selected_product).and_return(product)
+    allow(Yast::AutoinstSoftware).to receive(:merge_product)
     allow(Yast::Product).to receive(:FindBaseProducts).and_return([])
     allow(Yast::ProductControl).to receive(:RunFrom).and_return(:next)
   end
@@ -63,6 +70,12 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
   describe "#main" do
     it "shows a progress" do
       expect(Yast::Progress).to receive(:New).at_least(:once)
+
+      subject.main
+    end
+
+    it "merges the selected product workflow" do
+      expect(Yast::AutoinstSoftware).to receive(:merge_product).with(product)
 
       subject.main
     end
@@ -96,7 +109,7 @@ describe Y2Autoinstallation::Clients::InstAutosetupUpgrade do
     end
 
     it "install/removes patterns, products anad packages according to profile" do
-      expect(Yast::Pkg).to receive(:ResolvableInstall).with("sled", :product)
+      expect(Yast::Pkg).to receive(:ResolvableInstall).with(product_name, :product)
       expect(Yast::Pkg).to receive(:ResolvableInstall).with("yast-devel", :pattern)
       expect(Yast::Pkg).to receive(:ResolvableInstall).with("vim", :package)
       expect(Yast::Pkg).to receive(:ResolvableRemove).with("emacs", :package)


### PR DESCRIPTION
## Problem

During autoupgrade the Second Stage is basically ignore because there is no workflow defined in the [installation control file](https://github.com/yast/skelcd-control-SLES/blob/master/control/installation.SLES.xml#L391) and the workflow is not merged when the product is selected during the autoupgrade setup.

- https://trello.com/c/CfwIZXMK/2750-3-sles15-sp3-p2-1192437-l3-autoyast-post-installation-scripts-not-being-executed

## Solution

Merge the workflow of the selected product as we [already do](https://github.com/yast/yast-autoinstallation/blob/master/src/lib/autoinstall/clients/inst_autosetup.rb#L121) during autosetup.