### PR TITLE
Fix unit test Stage mocking

### DIFF
--- a/test/lib/efi_detector_test.rb
+++ b/test/lib/efi_detector_test.rb
@@ -4,12 +4,14 @@ require "autoinstall/efi_detector"
 describe Y2Autoinstallation::EFIDetector do
   describe ".boot_efi?" do
     let(:efi) { true }
+    let(:initial) { true }
+
+    before do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("EFI").and_return(efi)
+      allow(Yast::Stage).to receive(:initial).and_return(initial)
+    end
 
     context "when called in the initial Stage" do
-      before do
-        allow(Yast::Linuxrc).to receive(:InstallInf).with("EFI").and_return(efi)
-      end
-
       context "and EFI is read as '1' from the Install.inf file" do
         it "returns true" do
           expect(described_class.boot_efi?)
@@ -26,6 +28,8 @@ describe Y2Autoinstallation::EFIDetector do
     end
 
     context "when called in normal Mode" do
+      let(:initial) { false }
+
       before do
         allow(Dir).to receive(:exist?)
       end


### PR DESCRIPTION
Fix for failing build:

```[  122s] Failures:
[  122s] 
[  122s]   1) Y2Autoinstallation::EFIDetector.boot_efi? when called in normal Mode returns true if '/sys/firmware/efi/efivars' exists
[  122s]      Failure/Error: expect(described_class.boot_efi?).to eq(true)
[  122s] 
[  122s]        expected: true
[  122s]             got: false
[  122s] 
[  122s]        (compared using ==)
[  122s] 
[  122s]        Diff:
[  122s]        @@ -1,2 +1,2 @@
[  122s]        -true
[  122s]        +false
[  122s]      # ./test/lib/efi_detector_test.rb:36:in `block (5 levels) in <top (required)>'
[  122s] 
[  122s]   2) Y2Autoinstallation::EFIDetector.boot_efi? when called in normal Mode returns true if '/sys/firmware/efi/vars/' exists
[  122s]      Failure/Error: expect(described_class.boot_efi?).to eq(true)
[  122s] 
[  122s]        expected: true
[  122s]             got: false
[  122s] 
[  122s]        (compared using ==)
[  122s] 
[  122s]        Diff:
[  122s]        @@ -1,2 +1,2 @@
[  122s]        -true
[  122s]        +false
[  122s]      # ./test/lib/efi_detector_test.rb:36:in `block (5 levels) in <top (required)>'
```
https://build.suse.de/package/live_build_log/Devel:YaST:Head/autoyast2/SUSE_SLE-15-SP4_GA/x86_64