### PR TITLE
Online autoupgrade workflow

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 13 11:58:37 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Properly merge the autoupgrade workflow when using the online
+  medium (bsc#1192437, bsc#1194440).
+- 4.3.95
+
+-------------------------------------------------------------------
 Thu Nov 25 12:56:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - During autoupgrade merge the selected product workflow in order

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.94
+Version:        4.3.95
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -143,6 +143,8 @@ module Y2Autoinstallation
 
         return :abort if Yast::UI.PollInput == :abort && Yast::Popup.ConfirmAbort(:painless)
 
+        Yast::WorkflowManager.SetBaseWorkflow(false)
+
         :next
       end
 
@@ -408,7 +410,6 @@ module Y2Autoinstallation
           Yast::Pkg.ResolvableInstall(product.details.product, :product, "")
           # initialize addons and the workflow manager
           Yast::AddOnProduct.SetBaseProductURL(base_url)
-          Yast::WorkflowManager.SetBaseWorkflow(false)
           Yast::AutoinstFunctions.reset_product
         # report error only for installation or if autoupgrade contain addon with relative url.
         # This way autoupgrade for Full medium on registered system

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -57,12 +57,6 @@ module Y2Autoinstallation
         return :abort if UI.PollInput == :abort && Popup.ConfirmAbort(:painless)
 
         Progress.NextStage
-        #
-        # Set workflow variables
-        # Ensure that we clean product cache to avoid product from control (bsc#1156058)
-        AutoinstFunctions.reset_product
-        # Merging selected product (bsc#1192437)
-        AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
 
         # configure general settings
         general_section = Profile.current["general"] || {}
@@ -171,6 +165,12 @@ module Y2Autoinstallation
 
         Progress.NextStage
         return :abort unless suse_register
+
+        # Set workflow variables
+        # Ensure that we clean product cache to avoid product from control (bsc#1156058)
+        AutoinstFunctions.reset_product
+        # Merging selected product (bsc#1192437)
+        AutoinstSoftware.merge_product(AutoinstFunctions.selected_product)
 
         # Bootloader
         # FIXME: De-duplicate with inst_autosetup


### PR DESCRIPTION
This PR tries to fix a side effect of #811. When a user tries to autoupgrade a system using the online medium, the product is not available at the beginning of the `inst_autosetup_upgrade` client, so `AutoinstFunctions.selected_product` returns `nil`.

The product will be available after calling `suse_register`, so it makes sense to merge the workflow at that point.

*Note: autoinstallation is not affected because the registration is almost the first step, so the packages are already available.*

## Links

* [bsc#1192437](https://bugzilla.suse.com/1192437)
* [bsc#1194440](https://bugzilla.suse.com/1194440)
* https://trello.com/c/hT3653E4/

## Tasks

- [x] Decide if calling `SetBaseWorkflow` is safe or not.
- [x] Reproduce the problem in SLE-15-SP3 (not tested yet)
- [x] Try the fix in SLE-15-SP3
- [ ] Try the fix in SLE-15-SP4