### PR TITLE
Fix addons signature handling

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 20 07:58:35 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix handling of add-on signature settings, introduced when fixing
+  bsc#1192437 (bsc#1194881).
+- 4.3.96
+
+-------------------------------------------------------------------
 Thu Jan 13 11:58:37 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Properly merge the autoupgrade workflow when using the online

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.95
+Version:        4.3.96
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoInstall.rb
+++ b/src/modules/AutoInstall.rb
@@ -22,8 +22,10 @@ module Yast
       Yast.import "Profile"
       Yast.import "Mode"
       Yast.import "Stage"
-      Yast.import "AutoinstConfig"
       Yast.import "AutoInstallRules"
+      Yast.import "AutoinstConfig"
+      Yast.import "AutoinstGeneral"
+      Yast.import "AddOnProduct"
       Yast.import "Report"
       Yast.import "TFTP"
 
@@ -331,7 +333,10 @@ module Yast
     #   a blank string is returned (so no decision is made).
     def pkg_gpg_check(data)
       log.debug("pkgGpgCheck data: #{data}")
-      accept = PkgGpgCheckHandler.new(data, Profile.current).accept?
+      checker = PkgGpgCheckHandler.new(
+        data, Yast::AutoinstGeneral.signature_handling, Yast::AddOnProduct.add_on_products
+      )
+      accept = checker.accept?
       log.info("PkgGpgCheckerHandler for #{data["Package"]} returned #{accept}")
       accept ? "I" : ""
     end

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -174,7 +174,10 @@ module Yast
       log.info "General import: #{settings.inspect}"
       @mode = settings.fetch("mode", {})
       @cio_ignore = settings.fetch("cio_ignore", true)
-      @signature_handling = settings.fetch("signature-handling", {})
+      @signature_handling = {}
+      if settings["signature-handling"].is_a?(Hash)
+        @signature_handling = settings["signature-handling"]
+      end
       @askList = settings.fetch("ask-list", [])
       @proposals = settings.fetch("proposals", [])
       AutoinstStorage.import_general_settings(settings["storage"])

--- a/test/AutoInstall_test.rb
+++ b/test/AutoInstall_test.rb
@@ -23,12 +23,14 @@ describe "Yast::AutoInstall" do
 
   describe "#pkg_gpg_check" do
     let(:data) { { "CheckPackageResult" => Yast::PkgGpgCheckHandler::CHK_OK } }
-    let(:profile) { {} }
     let(:checker) { double("checker") }
+    let(:signature_handling) { { "accept_unsigned_file" => true } }
 
     before do
-      allow(Yast::Profile).to receive(:current).and_return(profile)
-      allow(Yast::PkgGpgCheckHandler).to receive(:new).with(data, profile).and_return(checker)
+      allow(Yast::AutoinstGeneral).to receive(:signature_handling)
+        .and_return(signature_handling)
+      allow(Yast::PkgGpgCheckHandler).to receive(:new)
+        .with(data, signature_handling, []).and_return(checker)
       allow(checker).to receive(:accept?).and_return(accept?)
     end
 

--- a/test/lib/pkg_gpg_check_handler_test.rb
+++ b/test/lib/pkg_gpg_check_handler_test.rb
@@ -6,7 +6,9 @@ require_relative "../../src/lib/autoinstall/pkg_gpg_check_handler"
 require "yast"
 
 describe Yast::PkgGpgCheckHandler do
-  subject(:handler) { Yast::PkgGpgCheckHandler.new(data, profile) }
+  subject(:handler) do
+    Yast::PkgGpgCheckHandler.new(data, signature_handling, addons)
+  end
 
   let(:data) do
     { "CheckPackageResult" => result,
@@ -15,8 +17,8 @@ describe Yast::PkgGpgCheckHandler do
       "RepoMediaUrl"       => "http://dl.opensuse.org/repos/YaST:/Head" }
   end
   let(:result) { Yast::PkgGpgCheckHandler::CHK_OK }
-  let(:profile) { { "general" => { "signature-handling" => signature_handling } } }
   let(:signature_handling) { {} }
+  let(:addons) { [] }
 
   describe "#accept?" do
     context "when signature is OK" do
@@ -206,8 +208,8 @@ describe Yast::PkgGpgCheckHandler do
         end
       end
 
+      # Using '<all>' element in profile instead of just 'true'.
       context "and all packages with non trusted keys are allowed" do
-        # Using '<all>' element in profile instead of just 'true'.
         let(:signature_handling) { { "accept_non_trusted_gpg_key" => { "all" => true } } }
 
         it "returns true" do
@@ -264,20 +266,16 @@ describe Yast::PkgGpgCheckHandler do
     context "when the add-on has specific settings" do
       let(:result) { Yast::PkgGpgCheckHandler::CHK_NOTFOUND }
 
-      let(:profile) do
-        { "general" => {
-          "signature-handling" => {
-            "accept_unsigned_file"   => true,
-            "accept_unknown_gpg_key" => true
-          }
-        },
-          "add-on"  => {
-            "add_on_products" => [
-              { "media_url"          => "http://dl.opensuse.org/repos/YaST:/Head",
-                "name"               => "yast_head",
-                "signature-handling" => { "accept_unsigned_file" => false } }
-            ]
-          } }
+      let(:signature_handling) do
+        { "accept_unsigned_file" => true, "accept_unknown_gpg_key" => true }
+      end
+
+      let(:addons) do
+        [
+          { "media_url"          => "http://dl.opensuse.org/repos/YaST:/Head",
+            "name"               => "yast_head",
+            "signature-handling" => { "accept_unsigned_file" => false } }
+        ]
       end
 
       it "honors the add-on settings" do
@@ -286,7 +284,9 @@ describe Yast::PkgGpgCheckHandler do
 
       it "honors general settings which are not overridden" do
         gpg_handler = Yast::PkgGpgCheckHandler.new(
-          data.merge("CheckPackageResult" => Yast::PkgGpgCheckHandler::CHK_NOKEY), profile
+          data.merge("CheckPackageResult" => Yast::PkgGpgCheckHandler::CHK_NOKEY),
+          signature_handling,
+          addons
         )
         expect(gpg_handler.accept?).to eq(true)
       end


### PR DESCRIPTION
Fixes [bsc#1194881](https://bugzilla.suse.com/show_bug.cgi?id=1194881). The problem was originally introduced in #809 because the `add-on` section was removed once it was read. However, the `PkgGpgCheckHandler` used the `Profile.current` content when checking the signatures (which is wrong).

Now, this class gets the general signature handling settings and the add-ons list, so it does not depend on the profile anymore.

Manually tested on SLE-15-SP3.