### PR TITLE
Replace `PackageAI` with `Package` references

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 21 12:07:59 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Replace references to PackageAI module with proper calls to
+  Package methods (bsc#1194886).
+- 4.4.27
+
+-------------------------------------------------------------------
 Thu Jan 20 07:58:35 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix handling of add-on signature settings, introduced when fixing

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -41,9 +41,8 @@ BuildRequires:  libxml2-tools
 # xsltproc for AutoinstClass
 BuildRequires:  libxslt
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
-# GPG symmetric methods and Password dialog
-# ProductSpec API
-BuildRequires:  yast2 >= 4.4.21
+# PackageProposal API to taboo resolvables
+BuildRequires:  yast2 >= 4.4.37
 # FileSystems.read_default_subvol_from_target
 BuildRequires:  yast2-xml
 BuildRequires:  yast2-transfer
@@ -68,8 +67,8 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 
 Requires:       autoyast2-installation = %{version}
 Requires:       libxslt
-# ProductSpec API
-Requires:       yast2 >= 4.4.21
+# PackageProposal API to taboo resolvables
+Requires:       yast2 >= 4.4.37
 Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
 # Moving security module to first installation stage

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.26
+Version:        4.4.27
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -41,6 +41,7 @@ Yast.import "AutoinstStorage"
 Yast.import "AutoinstScripts"
 Yast.import "AutoinstGeneral"
 Yast.import "AutoinstSoftware"
+Yast.import "PackagesProposal"
 Yast.import "Popup"
 Yast.import "Arch"
 Yast.import "Call"
@@ -291,18 +292,18 @@ module Y2Autoinstallation
         Progress.NextStage
 
         # Evaluating package and patterns selection.
-        # Selection will be stored in PackageAI.
+        # Selection will be stored in PackagesProposal.
         AutoinstSoftware.Import(Ops.get_map(Profile.current, "software", {}))
 
         # Add additional packages in order to run YAST modules which
         # have been defined in the AutoYaST configuration file.
-        # Selection will be stored in PackageAI.
+        # Selection will be stored in PackagesProposal.
         add_yast2_dependencies if AutoinstFunctions.second_stage_required?
         # Also add packages needed by some profile configuration but missing the
         # explicit declaration in the software section
-        AutoinstSoftware.add_additional_packages(pkg_list) unless pkg_list.empty?
+        Yast::PackagesProposal.AddResolvables("autoyast", :package, pkg_list) unless pkg_list.empty?
 
-        # Adding selections (defined in PackageAI) to libzypp and solving
+        # Adding selections (defined in PackagesProposal) to libzypp and solving
         # package dependencies.
         if !AutoinstSoftware.Write
           Report.Error(

--- a/src/lib/autoinstall/clients/software_auto.rb
+++ b/src/lib/autoinstall/clients/software_auto.rb
@@ -75,7 +75,7 @@ module Y2Autoinstallation
           @ret = packageSelector
         elsif @func == "GetModified"
           packages = Yast::PackagesProposal.GetResolvables("autoyast", :package) +
-            Yast::PackagesProposal.GetTaboos("autoyast")
+            Yast::PackagesProposal.GetTaboos("autoyast", :package)
           @ret = Yast::AutoinstSoftware.GetModified || !packages.empty?
         elsif @func == "SetModified"
           Yast::AutoinstSoftware.SetModified
@@ -226,7 +226,7 @@ module Y2Autoinstallation
             end
           end
 
-          pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast")
+          pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast", :package)
           if Yast::Ops.greater_than(Yast::Builtins.size(pkgs_to_remove), 0)
             Yast::Builtins.foreach(pkgs_to_remove) do |p|
               Yast::Builtins.y2milestone(
@@ -266,7 +266,7 @@ module Y2Autoinstallation
           "autoyast", :package, Yast::Pkg.FilterPackages(false, true, true, true)
         )
         Yast::PackagesProposal.SetTaboos(
-          "autoyast", Yast::Pkg.GetPackages(:taboo, true)
+          "autoyast", :package, Yast::Pkg.GetPackages(:taboo, true)
         )
         Yast::AutoinstSoftware.patterns = Yast::Convert.convert(
           Yast::Builtins.union(patadd, patadd),

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -52,7 +52,7 @@ module Yast
 
       # All shared data are in yast2.rpm to break cyclic dependencies
       Yast.import "AutoinstData"
-      Yast.import "PackageAI"
+      Yast.import "PackagesProposal"
 
       @Software = {}
 
@@ -151,12 +151,14 @@ module Yast
         to:   "list <string>"
       )
 
-      PackageAI.toinstall = settings.fetch("packages", [])
+      to_install = settings.fetch("packages", [])
+      PackagesProposal.AddResolvables("autoyast", :package, to_install) unless to_install.empty?
       @kernel = settings.fetch("kernel", "")
 
       addPostPackages(settings.fetch("post-packages", []))
       AutoinstData.post_patterns = settings.fetch("post-patterns", [])
-      PackageAI.toremove = settings.fetch("remove-packages", [])
+      to_remove = settings.fetch("remove-packages", [])
+      PackagesProposal.AddTaboos("autoyast", to_remove) unless to_remove.empty?
 
       true
     end
@@ -165,11 +167,8 @@ module Yast
     #
     # @param pkglist [Array<String>] list of additional packages to be installed
     def add_additional_packages(pkglist)
-      pkglist.each do |p|
-        if !PackageAI.toinstall.include?(p) && @packagesAvailable.include?(p)
-          PackageAI.toinstall.push(p)
-        end
-      end
+      available = pkglist & @packagesAvailable
+      PackagesProposal.AddResolvables("autoyast", :package, available) unless available.empty?
     end
 
     def AddYdepsFromProfile(entries)
@@ -208,14 +207,14 @@ module Yast
       s["kernel"] = @kernel if !@kernel.empty?
       s["patterns"] = @patterns if !@patterns.empty?
 
-      pkg_toinstall = PackageAI.toinstall
-      s["packages"] = pkg_toinstall if !pkg_toinstall.empty?
+      pkgs_to_install = Yast::PackagesProposal.GetResolvables("autoyast", :package)
+      s["packages"] = pkgs_to_install unless pkgs_to_install.empty?
 
       pkg_post = AutoinstData.post_packages
-      s["post-packages"] = pkg_post if !pkg_post.empty?
+      s["post-packages"] = pkg_post unless pkg_post.empty?
 
-      pkg_toremove = PackageAI.toremove
-      s["remove-packages"] = PackageAI.toremove if !pkg_toremove.empty?
+      pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast")
+      s["remove-packages"] = pkgs_to_remove unless pkgs_to_remove.empty?
 
       s["instsource"] = @instsource
 
@@ -254,15 +253,17 @@ module Yast
         summary = Summary.AddLine(summary, Summary.NotConfigured)
       end
       summary = Summary.AddHeader(summary, _("Individually Selected Packages"))
+      pkgs_to_install = Yast::PackagesProposal.GetResolvables("autoyast", :package)
       summary = Summary.AddLine(
         summary,
-        Builtins.sformat("%1", Builtins.size(PackageAI.toinstall))
+        Builtins.sformat("%1", Builtins.size(pkgs_to_install))
       )
 
       summary = Summary.AddHeader(summary, _("Packages to Remove"))
+      pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast")
       summary = Summary.AddLine(
         summary,
-        Builtins.sformat("%1", Builtins.size(PackageAI.toremove))
+        Builtins.sformat("%1", Builtins.size(pkgs_to_remove))
       )
 
       if @kernel != ""
@@ -280,7 +281,7 @@ module Yast
 
       # the primary list of packages
       allpackages = Convert.convert(
-        Builtins.union(allpackages, PackageAI.toinstall),
+        Builtins.union(allpackages, Yast::PackagesProposal.GetResolvables("autoyast", :package)),
         from: "list",
         to:   "list <string>"
       )
@@ -378,12 +379,13 @@ module Yast
 
       SelectPackagesForInstallation()
 
+      pkgs_to_remove = PackagesProposal.GetTaboos("autoyast").dup
       computed_packages = Packages.ComputeSystemPackageList
       Builtins.foreach(computed_packages) do |pack2|
         if Ops.greater_than(Builtins.size(@kernel), 0) && pack2 != @kernel &&
             Builtins.search(pack2, "kernel-") == 0
           Builtins.y2milestone("taboo for kernel %1", pack2)
-          PackageAI.toremove = Builtins.add(PackageAI.toremove, pack2)
+          pkgs_to_remove.push(pack2)
         end
       end
 
@@ -392,14 +394,14 @@ module Yast
       #
       # Now remove all packages listed in remove-packages
       #
-      Builtins.y2milestone("Packages to be removed: %1", PackageAI.toremove)
-      if Ops.greater_than(Builtins.size(PackageAI.toremove), 0)
-        Builtins.foreach(PackageAI.toremove) do |rp|
+      Builtins.y2milestone("Packages to be removed: %1", pkgs_to_remove)
+      if Ops.greater_than(Builtins.size(pkgs_to_remove), 0)
+        Builtins.foreach(pkgs_to_remove) do |rp|
           # Pkg::ResolvableSetSoftLock( rp, `package ); // FIXME: maybe better Pkg::PkgTaboo(rp) ?
           Pkg.PkgTaboo(rp)
         end
 
-        Pkg.DoRemove(PackageAI.toremove)
+        Pkg.DoRemove(pkgs_to_remove)
       end
 
       #

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -238,35 +238,6 @@ module Yast
       s
     end
 
-    # Add packages needed by modules, i.e. NIS, NFS etc.
-    # @param module_packages [Array<String>] list of strings packages to add
-    def AddModulePackages(module_packages)
-      module_packages = deep_copy(module_packages)
-      PackageAI.toinstall = Builtins.toset(
-        Convert.convert(
-          Builtins.union(PackageAI.toinstall, module_packages),
-          from: "list",
-          to:   "list <string>"
-        )
-      )
-      #
-      # Update profile
-      #
-      Ops.set(Profile.current, "software", Export())
-      nil
-    end
-
-    # Remove packages not needed by modules, i.e. NIS, NFS etc.
-    # @param module_packages [Array<String>] list of strings packages to add
-    def RemoveModulePackages(module_packages)
-      module_packages = deep_copy(module_packages)
-      PackageAI.toinstall = Builtins.filter(PackageAI.toinstall) do |p|
-        !Builtins.contains(module_packages, p)
-      end
-      Ops.set(Profile.current, "software", Export())
-      nil
-    end
-
     # Summary
     # @return Html formatted configuration summary
     def Summary
@@ -702,9 +673,7 @@ module Yast
     publish function: :Import, type: "boolean (map)"
     publish function: :AutoinstSoftware, type: "void ()"
     publish function: :Export, type: "map ()"
-    publish function: :AddModulePackages, type: "void (list <string>)"
     publish function: :AddYdepsFromProfile, type: "void (list <string>)"
-    publish function: :RemoveModulePackages, type: "void (list <string>)"
     publish function: :Summary, type: "string ()"
     publish function: :autoinstPackages, type: "list <string> ()"
     publish function: :Write, type: "boolean ()"

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -158,7 +158,7 @@ module Yast
       addPostPackages(settings.fetch("post-packages", []))
       AutoinstData.post_patterns = settings.fetch("post-patterns", [])
       to_remove = settings.fetch("remove-packages", [])
-      PackagesProposal.AddTaboos("autoyast", to_remove) unless to_remove.empty?
+      PackagesProposal.AddTaboos("autoyast", :package, to_remove) unless to_remove.empty?
 
       true
     end
@@ -213,7 +213,7 @@ module Yast
       pkg_post = AutoinstData.post_packages
       s["post-packages"] = pkg_post unless pkg_post.empty?
 
-      pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast")
+      pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast", :package)
       s["remove-packages"] = pkgs_to_remove unless pkgs_to_remove.empty?
 
       s["instsource"] = @instsource
@@ -260,7 +260,7 @@ module Yast
       )
 
       summary = Summary.AddHeader(summary, _("Packages to Remove"))
-      pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast")
+      pkgs_to_remove = Yast::PackagesProposal.GetTaboos("autoyast", :package)
       summary = Summary.AddLine(
         summary,
         Builtins.sformat("%1", Builtins.size(pkgs_to_remove))
@@ -379,7 +379,7 @@ module Yast
 
       SelectPackagesForInstallation()
 
-      pkgs_to_remove = PackagesProposal.GetTaboos("autoyast").dup
+      pkgs_to_remove = PackagesProposal.GetTaboos("autoyast", :package).dup
       computed_packages = Packages.ComputeSystemPackageList
       Builtins.foreach(computed_packages) do |pack2|
         if Ops.greater_than(Builtins.size(@kernel), 0) && pack2 != @kernel &&

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -13,6 +13,8 @@ describe Yast::AutoinstSoftware do
   let(:profile) { FIXTURES_PATH.join("profiles", "software.xml").to_s }
 
   before(:each) do
+    Yast::AutoinstData.main
+    subject.main
     Yast::Profile.ReadXML(profile)
   end
 
@@ -53,6 +55,43 @@ describe Yast::AutoinstSoftware do
     end
   end
 
+  describe "#Import" do
+    let(:software) do
+      {
+        "patterns"        => ["base", "yast2_basis"],
+        "packages"        => ["yast2", "other"],
+        "post-patterns"   => ["gnome"],
+        "post-packages"   => ["pkg1"],
+        "remove-packages" => ["dummy"],
+        "kernel"          => "kernel-vanilla"
+      }
+    end
+
+    let(:available_pkgs) { ["yast2"] }
+
+    before do
+      allow(Yast::Pkg).to receive(:GetPackages).with(:available, true).and_return(available_pkgs)
+    end
+
+    it "saves the list of patterns and packages to install and remove" do
+      subject.Import(software)
+      expect(subject.patterns).to eq(["base", "yast2_basis"])
+      expect(Yast::PackageAI.toinstall).to eq(["yast2", "other"])
+      expect(Yast::PackageAI.toremove).to eq(["dummy"])
+    end
+
+    it "sets the kernel package to install" do
+      subject.Import(software)
+      expect(subject.kernel).to eq("kernel-vanilla")
+    end
+
+    it "saves the list of patterns and packages to install during 2nd stage" do
+      subject.Import(software)
+      expect(Yast::AutoinstData.post_patterns).to eq(["gnome"])
+      expect(Yast::AutoinstData.post_packages).to eq(["pkg1"])
+    end
+  end
+
   describe "#Export" do
     it "puts product definition into the exported profile" do
       expect(Yast::Product)
@@ -88,6 +127,7 @@ describe Yast::AutoinstSoftware do
     end
 
     it "shows a popup if some packages have not been found" do
+      subject.Import(Yast::Profile.current["software"])
       expect(Yast::Pkg).to receive(:DoProvide).with(["a2", "a3", "a4"]).and_return({})
       expect(Yast::Report).to receive(:Error)
       subject.SelectPackagesForInstallation()
@@ -137,4 +177,103 @@ describe Yast::AutoinstSoftware do
     end
   end
 
+  describe "#Write" do
+    let(:base_product) { { "name" => "Leap" } }
+    let(:selected_product) do
+      instance_double(Y2Packager::Product, select: nil)
+    end
+    let(:storage_manager) do
+      instance_double(Y2Storage::StorageManager, staging: devicegraph)
+    end
+
+    let(:devicegraph) do
+      instance_double(Y2Storage::Devicegraph, used_features: storage_features)
+    end
+
+    let(:storage_features) do
+      instance_double(Y2Storage::StorageFeaturesList, pkg_list: storage_pkgs)
+    end
+
+    let(:storage_pkgs) { ["btrfsprogs"] }
+    let(:solver_result) { true }
+
+    let(:storage_pkg_handler) do
+      instance_double(Y2Storage::PackageHandler, set_proposal_packages: true)
+    end
+
+    let(:pkgs_to_install) { ["openSUSE-release"] }
+
+    before do
+      allow(Yast::Packages).to receive(:Init)
+      allow(Yast::Product).to receive(:FindBaseProducts).and_return([base_product])
+      allow(Yast::Pkg).to receive(:PkgApplReset)
+      allow(Yast::Pkg).to receive(:PkgSolve).and_return(solver_result)
+      allow(Y2Storage::StorageManager).to receive(:instance).and_return(storage_manager)
+      allow(Y2Storage::PackageHandler).to receive(:new).with(storage_pkgs)
+        .and_return(storage_pkg_handler)
+      allow(Yast::SpaceCalculation).to receive(:ShowPartitionWarning)
+      allow(Yast::AutoinstFunctions).to receive(:selected_product)
+        .and_return(selected_product)
+      allow(subject).to receive(:SelectPackagesForInstallation)
+      allow(Yast::Packages).to receive(:ComputeSystemPackageList).and_return(pkgs_to_install)
+      allow(Yast::Packages).to receive(:SelectSystemPatterns)
+      subject.kernel = nil
+    end
+
+    it "selects packages for installation" do
+      expect(Yast::Packages).to receive(:ComputeSystemPackageList)
+      expect(subject).to receive(:SelectPackagesForInstallation)
+      subject.Write
+    end
+
+    it "selects system patterns" do
+      expect(Yast::Packages).to receive(:SelectSystemPatterns).with(false)
+      subject.Write
+    end
+
+    it "sets base products for installation" do
+      expect(Yast::Pkg).to receive(:ResolvableInstall).with("Leap", :product)
+      expect(selected_product).to receive(:select)
+      subject.Write
+    end
+
+    it "selects required storage packages for installation" do
+      expect(storage_pkg_handler).to receive(:set_proposal_packages)
+      subject.Write
+    end
+
+    context "when a kernel package is selected" do
+      let(:pkgs_to_install) { ["kernel-default"] }
+
+      before do
+        subject.kernel = "kernel-vanilla"
+      end
+
+      it "removes other kernel packages" do
+        expect(Yast::Pkg).to receive(:PkgTaboo).with("kernel-default")
+        subject.Write
+      end
+    end
+
+    context "when packages are preselected for removal" do
+      before do
+        allow(Yast::PackageAI).to receive(:toremove).and_return(["dummy"])
+      end
+
+      it "removes the packages" do
+        expect(Yast::Pkg).to receive(:PkgTaboo).with("dummy")
+        expect(Yast::Pkg).to receive(:DoRemove).with(["dummy"])
+        subject.Write
+      end
+    end
+
+    context "when the resolver fails" do
+      let(:solver_result) { false }
+
+      it "displays an error" do
+        expect(Yast::Report).to receive(:LongError).with(/package resolver run failed/)
+        subject.Write
+      end
+    end
+  end
 end

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -80,7 +80,7 @@ describe Yast::AutoinstSoftware do
       subject.Import(software)
       expect(subject.patterns).to eq(["base", "yast2_basis"])
       expect(Yast::PackagesProposal.GetResolvables("autoyast", :package)).to eq(["yast2", "other"])
-      expect(Yast::PackagesProposal.GetTaboos("autoyast")).to eq(["dummy"])
+      expect(Yast::PackagesProposal.GetTaboos("autoyast", :package)).to eq(["dummy"])
     end
 
     it "sets the kernel package to install" do
@@ -260,7 +260,7 @@ describe Yast::AutoinstSoftware do
 
     context "when packages are preselected for removal" do
       before do
-        Yast::PackagesProposal.AddTaboos("autoyast", ["dummy"])
+        Yast::PackagesProposal.AddTaboos("autoyast", :package, ["dummy"])
       end
 
       it "removes the packages" do

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -14,6 +14,7 @@ describe Yast::AutoinstSoftware do
 
   before(:each) do
     Yast::AutoinstData.main
+    Yast::PackagesProposal.ResetAll
     subject.main
     Yast::Profile.ReadXML(profile)
   end
@@ -42,7 +43,8 @@ describe Yast::AutoinstSoftware do
 
     it "appends the given list to the one to be installed" do
       Yast::AutoinstSoftware.add_additional_packages(pkgs)
-      expect(Yast::PackageAI.toinstall).to include("NetworkManager")
+      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package))
+        .to include("NetworkManager")
     end
 
     context "when the packages given are not available" do
@@ -50,7 +52,8 @@ describe Yast::AutoinstSoftware do
 
       it "the packages are not added" do
         Yast::AutoinstSoftware.add_additional_packages(pkgs)
-        expect(Yast::PackageAI.toinstall).to_not include("NetworkManager")
+        expect(Yast::PackagesProposal.GetResolvables("NetworkManager", :package))
+          .to_not include("NetworkManager")
       end
     end
   end
@@ -76,8 +79,8 @@ describe Yast::AutoinstSoftware do
     it "saves the list of patterns and packages to install and remove" do
       subject.Import(software)
       expect(subject.patterns).to eq(["base", "yast2_basis"])
-      expect(Yast::PackageAI.toinstall).to eq(["yast2", "other"])
-      expect(Yast::PackageAI.toremove).to eq(["dummy"])
+      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package)).to eq(["yast2", "other"])
+      expect(Yast::PackagesProposal.GetTaboos("autoyast")).to eq(["dummy"])
     end
 
     it "sets the kernel package to install" do
@@ -257,7 +260,7 @@ describe Yast::AutoinstSoftware do
 
     context "when packages are preselected for removal" do
       before do
-        allow(Yast::PackageAI).to receive(:toremove).and_return(["dummy"])
+        Yast::PackagesProposal.AddTaboos("autoyast", ["dummy"])
       end
 
       it "removes the packages" do

--- a/test/lib/clients/software_auto_test.rb
+++ b/test/lib/clients/software_auto_test.rb
@@ -28,7 +28,7 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
 
   before do
     Yast::AutoinstSoftware.main
-    Yast::PackageAI.main
+    Yast::PackagesProposal.ResetAll
   end
 
   describe "#main" do
@@ -126,7 +126,7 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
 
       context "when the packages proposal includes packages to install" do
         before do
-          Yast::PackageAI.toinstall = ["yast2"]
+          Yast::PackagesProposal.AddResolvables("autoyast", :package, ["yast2"])
         end
 
         it "selects the packages" do
@@ -137,7 +137,7 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
 
       context "when the packages proposal includes packages to remove" do
         before do
-          Yast::PackageAI.toremove = ["dummy"]
+          Yast::PackagesProposal.AddTaboos("autoyast", ["dummy"])
         end
 
         it "deselects the packages" do
@@ -171,8 +171,9 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
         it "updates the proposal and the list of patterns" do
           client.main
           expect(Yast::AutoinstSoftware.patterns).to eq([base_pattern.name, yast2_pattern.name])
-          expect(Yast::PackageAI.toinstall).to eq(["yast2", "git"])
-          expect(Yast::PackageAI.toremove).to eq(["dummy"])
+          expect(Yast::PackagesProposal.GetResolvables("autoyast", :package))
+            .to eq(["yast2", "git"])
+          expect(Yast::PackagesProposal.GetTaboos("autoyast")).to eq(["dummy"])
         end
       end
 
@@ -210,9 +211,9 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
         end
       end
 
-      context "when the PackageAI module is modified" do
+      context "when some packages are selected" do
         before do
-          Yast::PackageAI.SetModified
+          Yast::PackagesProposal.AddResolvables("autoyast", :package, ["yast2"])
         end
 
         it "returns true" do
@@ -220,7 +221,17 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
         end
       end
 
-      context "when AutoinstSofware and PackageAI are not modified" do
+      context "when some packages are unselected" do
+        before do
+          Yast::PackagesProposal.AddTaboos("autoyast", ["yast2"])
+        end
+
+        it "returns true" do
+          expect(client.main).to eq(true)
+        end
+      end
+
+      context "when AutoinstSofware and no packages are selected/unselected" do
         it "returns false" do
           expect(client.main).to eq(false)
         end

--- a/test/lib/clients/software_auto_test.rb
+++ b/test/lib/clients/software_auto_test.rb
@@ -137,7 +137,7 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
 
       context "when the packages proposal includes packages to remove" do
         before do
-          Yast::PackagesProposal.AddTaboos("autoyast", ["dummy"])
+          Yast::PackagesProposal.AddTaboos("autoyast", :package, ["dummy"])
         end
 
         it "deselects the packages" do
@@ -173,7 +173,7 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
           expect(Yast::AutoinstSoftware.patterns).to eq([base_pattern.name, yast2_pattern.name])
           expect(Yast::PackagesProposal.GetResolvables("autoyast", :package))
             .to eq(["yast2", "git"])
-          expect(Yast::PackagesProposal.GetTaboos("autoyast")).to eq(["dummy"])
+          expect(Yast::PackagesProposal.GetTaboos("autoyast", :package)).to eq(["dummy"])
         end
       end
 
@@ -223,7 +223,7 @@ describe Y2Autoinstallation::Clients::SoftwareAuto do
 
       context "when some packages are unselected" do
         before do
-          Yast::PackagesProposal.AddTaboos("autoyast", ["yast2"])
+          Yast::PackagesProposal.AddTaboos("autoyast", :package, ["yast2"])
         end
 
         it "returns true" do


### PR DESCRIPTION
Adapt AutoYaST to do not use the `PackageAI` module anymore. It should use the generic `Package` instead. See https://github.com/yast/yast-yast2/pull/1219.

**NOTE: tests are expected to fail until the https://github.com/yast/yast-yast2/pull/1219 is merged.**