### PR TITLE
bsc#1195630: properly update the profile when using the  `<ask-list>` mechanism

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Feb  7 14:19:37 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the profile update when using an <ask/> element
+  (boo#1195630).
+- Run the network client when listed in the semi-automatic section.
+- 4.4.29
+
+-------------------------------------------------------------------
 Tue Jan 25 16:11:43 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use Package module instead of PackageSystem (bsc#1194886).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.28
+Version:        4.4.29
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -144,7 +144,9 @@ module Y2Autoinstallation
 
       if semi_auto?("networking")
         log.info("Networking manual setup before proposal")
-        Yast::WFM.CallFunction("inst_lan", ["enable_next" => true])
+        Yast::WFM.CallFunction(
+          "inst_lan", ["enable_next" => true, "skip_detection" => true]
+        )
         @network_before_proposal = true
       end
 

--- a/src/modules/Profile.rb
+++ b/src/modules/Profile.rb
@@ -671,7 +671,6 @@ module Yast
     # @param profile [Hash] Initial profile
     # @return [Hash] Modified profile
     def setElementByList(path, value, profile)
-      profile = Yast::ProfileHash.new(profile)
       merge_element_by_list(path, value, profile)
     end
 

--- a/test/lib/autoinstall/ask/runner_test.rb
+++ b/test/lib/autoinstall/ask/runner_test.rb
@@ -31,8 +31,9 @@ describe Y2Autoinstall::Ask::Runner do
 
   let(:profile) do
     Yast::ProfileHash.new(
-      "general" => { "ask-list" => ask_list },
-      "users"   => [{ "username" => "root", "user_password" => "ask" }]
+      "general"    => { "ask-list" => ask_list },
+      "users"      => [{ "username" => "root", "user_password" => "ask" }],
+      "networking" => { "dns" => { "hostname" => "localhost" } }
     )
   end
 
@@ -99,6 +100,20 @@ describe Y2Autoinstall::Ask::Runner do
       it "updates the profile with the value from the question" do
         runner.run
         expect(profile["users"][0]).to eq("username" => "root", "user_password" => "secret")
+      end
+
+      context "and the profile is deeper than 1 level" do
+        let(:question1) do
+          Y2Autoinstall::Ask::Question.new("Hostname").tap do |question|
+            question.paths << "networking,dns,hostname"
+            question.value = "example"
+          end
+        end
+
+        it "updates the profile with the value from the question" do
+          runner.run
+          expect(profile["networking"]["dns"]).to eq("hostname" => "example")
+        end
       end
     end
 

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -145,6 +145,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
         let(:profile_content) do
           Yast::ProfileHash.new("general" => { "semi-automatic" => ["scc"] })
         end
+
         it "shows registration screen mask and returns true" do
           # Showing registration screen mask
           expect(Yast::WFM).to receive(:CallFunction).with("inst_scc",
@@ -350,7 +351,8 @@ describe Y2Autoinstallation::AutosetupHelpers do
       let(:networking_section) { { "general" => { "semi-automatic" => ["networking"] } } }
 
       it "runs the network configuration client" do
-        expect(Yast::WFM).to receive(:CallFunction).with("inst_lan", anything)
+        expect(Yast::WFM).to receive(:CallFunction)
+          .with("inst_lan", ["enable_next" => true, "skip_detection" => true])
 
         client.autosetup_network
       end


### PR DESCRIPTION
* Trello: https://trello.com/c/3rHR1uFq
* [bsc#1195630](https://bugzilla.suse.com/show_bug.cgi?id=1195630)

When the path contains more than 1 level (for instance `network,dns,hostname`), the change is not applied (it is applied, but to a different `ProfileHash` instance). It works for simpler cases like `users,0,username`.

```ruby
# worked
{ "users" => [
    { "username" => "root" }
] }

# it did not work
{ "network" => {
    "dns" => { "hostname" => "example" }
} }
```