### PR TITLE
bsc#1195631: ayast_setup imports general settings

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 14 16:30:39 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The ayast_setup client imports the general settings
+  (bsc#1195631).
+- 4.4.30
+
+-------------------------------------------------------------------
 Mon Feb  7 14:19:37 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the profile update when using an <ask/> element

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.29
+Version:        4.4.30
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/ayast_setup.rb
+++ b/src/lib/autoinstall/clients/ayast_setup.rb
@@ -27,6 +27,7 @@ Yast.import "AutoInstall"
 Yast.import "AutoinstSoftware"
 Yast.import "Package"
 Yast.import "AutoinstData"
+Yast.import "AutoinstGeneral"
 Yast.import "Lan"
 Yast.import "Pkg"
 
@@ -47,6 +48,8 @@ module Y2Autoinstall
         Yast::Wizard.CreateDialog
         Yast::Mode.SetMode("autoinstallation")
         Yast::Stage.Set("continue")
+
+        Yast::AutoinstGeneral.Import(Yast::Profile.current.fetch("general", {}))
 
         # IPv6 settings will be written despite the have been
         # changed or not. So we have to read them at first.

--- a/test/lib/clients/ayast_setup_test.rb
+++ b/test/lib/clients/ayast_setup_test.rb
@@ -34,7 +34,12 @@ Yast.import "Profile"
 
 describe "Y2Autoinstall::Clients::AyastSetup" do
   let(:subject) { Yast::DummyClient.new }
-  let(:profile) { { "software" => { "post-packages" => packages } } }
+  let(:profile) do
+    {
+      "general"  => { "mode" => { "confirm" => true } },
+      "software" => { "post-packages" => packages }
+    }
+  end
   let(:packages) { ["vim"] }
   let(:dopackages) { false }
 
@@ -52,6 +57,7 @@ describe "Y2Autoinstall::Clients::AyastSetup" do
     before do
       Yast::Profile.current = profile
       allow(Yast::AutoInstall).to receive(:Save)
+      allow(Yast::AutoinstGeneral).to receive(:Import)
       allow(Yast::WFM).to receive(:CallFunction)
       allow(Yast::Mode).to receive(:SetMode)
       allow(Yast::Stage).to receive(:Set)
@@ -109,6 +115,13 @@ describe "Y2Autoinstall::Clients::AyastSetup" do
       expect(Yast::Profile.current.keys).to_not include("networking")
       subject.Setup
       expect(Yast::Profile.current.keys).to_not include("networking")
+    end
+
+    it "imports general settings" do
+      expect(Yast::AutoinstGeneral).to receive(:Import).with(
+        "mode" => { "confirm" => true }
+      )
+      subject.Setup
     end
   end
 end


### PR DESCRIPTION
* [bsc#1195631](https://bugzilla.suse.com/show_bug.cgi?id=1195631)
* https://trello.com/c/u2PVCYsE/

`ayast_setup` does not import the `<general>` section. Although it is usually not a problem, it can affect `sap-installation-wizard`. So this PR makes `ayast_setup` client to import the general settings.

Additionally, it adapts the `ayast_setup` test to [bsc#1194886](https://bugzilla.suse.com/1194886).

**NOTE: the issue is still under investigation.**