### PR TITLE
add yast namespace to merge.xslt to fix CDATA handling (bsc#1195910)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 28 10:39:35 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- add yast namespace to merge.xslt to fix CDATA handling (bsc#1195910)
+- 4.4.32
+
+-------------------------------------------------------------------
 Mon Feb 21 15:05:50 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Modified init-scripts service dependencies fixing a root login

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.31
+Version:        4.4.32
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/xslt/merge.xslt
+++ b/xslt/merge.xslt
@@ -8,6 +8,7 @@
 -->
 
 <xslt:transform version="1.0"
+                xmlns="http://www.suse.com/1.0/yast2ns"
                 xmlns:xslt="http://www.w3.org/1999/XSL/Transform"
                 xmlns:m="http://informatik.hu-berlin.de/merge"
                 exclude-result-prefixes="m">


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-autoinstallation/pull/827 to SLE15-SP4/Factory.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1195910

AutoYaST profile XSLT processing strips CDATA.

## Analysis

The processing happens when merging class-based profile bits here: https://github.com/yast/yast-autoinstallation/blob/SLE-15-SP3/src/modules/AutoInstallRules.rb#L873-L894

Our XSLT stylesheet will actually use CDATA for certain elements: https://github.com/yast/yast-autoinstallation/blob/master/xslt/merge.xslt#L15.

The problem is that AutoYaST profiles define a default namespace and the element matching fails.

## Solution

Use the same default namespace in the XSLT stylesheet.