### PR TITLE
Avoid login 

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  1 13:02:18 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Avoid login while running AutoYaST init-scripts (bsc#1196594 and
+  related to bsc#1195059).
+- 4.3.99
+
+-------------------------------------------------------------------
 Wed Feb 23 16:33:37 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
 
 - add yast namespace to merge.xslt to fix CDATA handling (bsc#1195910)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.98
+Version:        4.3.99
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/scripts/autoyast-initscripts.service
+++ b/scripts/autoyast-initscripts.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Autoyast2 Init Scripts
 After=remote-fs.target network-online.target time-sync.target mail-transfer-agent.target hwscan.service ypbind.service YaST2-Second-Stage.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
+Before=display-manager.service
 Wants=network-online.target
 
 [Service]


### PR DESCRIPTION
## Problem

When running *autoyast-initscripts.service*, the display manager or getty prompt is reached before scripts have finished.

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1195059
* See also https://bugzilla.suse.com/show_bug.cgi?id=1195910#c45

## Solution

Force *display-manager.service* and getty services to run after *autoyast-initscripts.service*.

See also https://github.com/yast/yast-installation/pull/1030.

## Testing

Manually tested.
 