### PR TITLE
bsc#1195747

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  3 11:48:36 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider user selected packages as optional to not block the
+  installation (bsc#1195747).
+- 4.4.33
+
+-------------------------------------------------------------------
 Mon Feb 28 10:39:35 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
 
 - add yast namespace to merge.xslt to fix CDATA handling (bsc#1195910)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.32
+Version:        4.4.33
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstSoftware.rb
+++ b/src/modules/AutoinstSoftware.rb
@@ -152,7 +152,9 @@ module Yast
       )
 
       to_install = settings.fetch("packages", [])
-      PackagesProposal.AddResolvables("autoyast", :package, to_install) unless to_install.empty?
+      unless to_install.empty?
+        PackagesProposal.AddResolvables("autoyast", :package, to_install, optional: true)
+      end
       @kernel = settings.fetch("kernel", "")
 
       addPostPackages(settings.fetch("post-packages", []))
@@ -168,7 +170,9 @@ module Yast
     # @param pkglist [Array<String>] list of additional packages to be installed
     def add_additional_packages(pkglist)
       available = pkglist & @packagesAvailable
-      PackagesProposal.AddResolvables("autoyast", :package, available) unless available.empty?
+      return if available.empty?
+
+      PackagesProposal.AddResolvables("autoyast", :package, available, optional: true)
     end
 
     def AddYdepsFromProfile(entries)
@@ -207,7 +211,7 @@ module Yast
       s["kernel"] = @kernel if !@kernel.empty?
       s["patterns"] = @patterns if !@patterns.empty?
 
-      pkgs_to_install = Yast::PackagesProposal.GetResolvables("autoyast", :package)
+      pkgs_to_install = Yast::PackagesProposal.GetResolvables("autoyast", :package, optional: true)
       s["packages"] = pkgs_to_install unless pkgs_to_install.empty?
 
       pkg_post = AutoinstData.post_packages

--- a/test/AutoinstSoftware_test.rb
+++ b/test/AutoinstSoftware_test.rb
@@ -43,7 +43,7 @@ describe Yast::AutoinstSoftware do
 
     it "appends the given list to the one to be installed" do
       Yast::AutoinstSoftware.add_additional_packages(pkgs)
-      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package))
+      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package, optional: true))
         .to include("NetworkManager")
     end
 
@@ -52,7 +52,7 @@ describe Yast::AutoinstSoftware do
 
       it "the packages are not added" do
         Yast::AutoinstSoftware.add_additional_packages(pkgs)
-        expect(Yast::PackagesProposal.GetResolvables("NetworkManager", :package))
+        expect(Yast::PackagesProposal.GetResolvables("NetworkManager", :package, optional: true))
           .to_not include("NetworkManager")
       end
     end
@@ -79,7 +79,8 @@ describe Yast::AutoinstSoftware do
     it "saves the list of patterns and packages to install and remove" do
       subject.Import(software)
       expect(subject.patterns).to eq(["base", "yast2_basis"])
-      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package)).to eq(["yast2", "other"])
+      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package, optional: true))
+        .to eq(["yast2", "other"])
       expect(Yast::PackagesProposal.GetTaboos("autoyast", :package)).to eq(["dummy"])
     end
 


### PR DESCRIPTION
Consider user-selected packages as optional to not block the installation. The problem was introduced when [we got rid of PackageAI](https://github.com/yast/yast-autoinstallation/pull/820/files), which kept a separate list of packages.

If we do not consider those packages as optional (which actually are), the installation [is blocked](https://github.com/yast/yast-packager/blob/bff0d8babd17eff9951554f4607707738298181e/src/modules/Packages.rb#L2551) when checking for missing packages.

## Links

* https://trello.com/c/qSCPq5EM/
* https://bugzilla.suse.com/1195747