### PR TITLE
Use general/signature-handling settings in the 2nd stage (SP4)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr  1 06:12:50 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Respect general/signature-handling settings during the 2nd
+  stage (bsc#1197655).
+- 4.4.36
+
+-------------------------------------------------------------------
 Mon Mar  7 11:00:12 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Properly handle the "dopackages" option in the openFile

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.35
+Version:        4.4.36
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/clients/inst_autopost.rb
+++ b/src/clients/inst_autopost.rb
@@ -18,7 +18,6 @@ module Yast
       textdomain "autoinst"
       Yast.import "Profile"
       Yast.import "AutoInstall"
-      Yast.import "AutoinstGeneral"
       Yast.import "Call"
       Yast.import "AutoinstSoftware"
       Yast.import "AutoinstScripts"
@@ -73,12 +72,11 @@ module Yast
       Y2Autoinstall::Ask::Runner.new(
         Yast::Profile.current, stage: Y2Autoinstall::Ask::Stage::CONT
       ).run
-      # FIXME: too late here, even though it would be the better place
-      # if (Profile::current["general"]:$[] != $[])
-      #     AutoinstGeneral::Import(Profile::current["general"]:$[]);
-      # AutoinstGeneral::SetSignatureHandling();
 
       Builtins.y2milestone("Steps: %1", steps)
+
+      general_settings = Profile.current.fetch("general", {})
+      AutoinstGeneral.Import(general_settings) unless general_settings.empty?
 
       importer = Y2Autoinstallation::Importer.new(Profile.current)
       modules_to_write.each do |description|

--- a/src/modules/AutoInstall.rb
+++ b/src/modules/AutoInstall.rb
@@ -22,10 +22,10 @@ module Yast
       Yast.import "Profile"
       Yast.import "Mode"
       Yast.import "Stage"
+      Yast.import "AddOnProduct"
       Yast.import "AutoInstallRules"
       Yast.import "AutoinstConfig"
       Yast.import "AutoinstGeneral"
-      Yast.import "AddOnProduct"
       Yast.import "Report"
       Yast.import "TFTP"
 

--- a/src/modules/AutoinstGeneral.rb
+++ b/src/modules/AutoinstGeneral.rb
@@ -60,7 +60,6 @@ module Yast
 
       # default value of settings modified
       @modified = false
-      AutoinstGeneral()
     end
 
     # Function sets internal variable, which indicates, that any
@@ -453,17 +452,6 @@ module Yast
       SetSignatureHandling()
 
       NtpSync()
-
-      nil
-    end
-
-    # Constructor
-    def AutoinstGeneral
-      return unless Stage.cont
-
-      # FIXME: wrong place for this
-      general_settings = Profile.current.fetch("general", {})
-      Import(general_settings) unless general_settings.empty?
 
       nil
     end

--- a/test/AutoinstGeneral_test.rb
+++ b/test/AutoinstGeneral_test.rb
@@ -23,59 +23,6 @@ describe "Yast::AutoinstGeneral" do
     allow(Yast).to receive(:import).with("FileSystems").and_return(nil)
   end
 
-  describe "#main" do
-    let(:second_stage) { false }
-    let(:imported_profile) { { "general" => general_settings } }
-    let(:general_settings) { { "mode" => true } }
-
-    before do
-      allow(Yast::Stage).to receive(:cont).and_return(second_stage)
-    end
-
-    context "on first stage" do
-      let(:second_stage) { false }
-
-      it "does not try to import the profile" do
-        expect(subject).to_not receive(:Import)
-        subject.main
-      end
-
-      it "does not set the signatures handling callbacks" do
-        expect(subject).to_not receive(:SetSignatureHandling)
-        subject.main
-      end
-    end
-
-    context "on second stage" do
-      let(:second_stage) { true }
-
-      before do
-        allow(Yast::Profile).to receive(:current).and_return(imported_profile)
-      end
-
-      context "and the profile contains a 'general' section" do
-        it "imports the profile" do
-          expect(subject).to receive(:Import).with(general_settings)
-          subject.main
-        end
-      end
-
-      context "and the profile does not contain a 'general' section" do
-        let(:general_settings) { {} }
-
-        it "does not try to import the profile" do
-          expect(subject).to_not receive(:Import)
-          subject.main
-        end
-      end
-
-      it "sets the signatures handling callbacks" do
-        expect(subject).to receive(:SetSignatureHandling)
-        subject.main
-      end
-    end
-  end
-
   describe "#Write" do
     before do
       allow(Yast::AutoinstStorage).to receive(:Write)


### PR DESCRIPTION
## Problem

`general/signature-handling` settings are ignored in the 2nd stage.

- https://bugzilla.suse.com/show_bug.cgi?id=1197655
- https://trello.com/c/iQWIXNnG/

## Solution

**WIP: I will change the code to avoid this problem in the future again**

The [AutoinstGeneral](https://github.com/yast/yast-autoinstallation/blob/81f27da576fb263ae884d0a7835331753e8552b3/src/modules/AutoinstGeneral.rb#L461-L469) module reads the profile once is imported. That's quite unfortunate, so we postpone importing the module until it is needed.