### PR TITLE
Fix disks helper and rules syntax

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
-Fri Apr 29 06:34:22 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+Tue May  3 15:00:22 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix detection disk serial and size in the "disks" ERB helper
   (bsc#1199000).
+- Fix rules validation when using a dialog (bsc#1199165).
 - 4.3.102
 
 -------------------------------------------------------------------

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 29 06:34:22 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix detection disk serial and size in the "disks" ERB helper
+  (bsc#1199000).
+- 4.3.102
+
+-------------------------------------------------------------------
 Fri Apr  1 06:12:50 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Respect general/signature-handling settings during the 2nd

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.101
+Version:        4.3.102
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -28,10 +28,9 @@ rule =
 element rule {
     MAP,
     (
-      y2_match_to+ &
+      (y2_match_to | dialog)+ &
       result &
-      operator? &
-      dialog?
+      operator?
     )
 }
 
@@ -118,7 +117,7 @@ element dialog {
     element conflicts {
         LIST,
         element (element | listentry) { INTEGER }*
-    }
+    }?
 }
 
 profile =

--- a/src/lib/autoinstall/y2erb.rb
+++ b/src/lib/autoinstall/y2erb.rb
@@ -35,8 +35,8 @@ module Y2Autoinstallation
             udev_names: disk["dev_names"]
           }
           result[:model] = sys_block_value(dev_name, "device/model") || "Unknown"
-          result[:serial] = sys_block_value(dev_name, "device/serial") || "Unknown"
-          result[:size] = (sys_block_value(dev_name, "device/size") || "-1").to_i
+          result[:serial] = sys_block_value(dev_name, "serial") || "Unknown"
+          result[:size] = (sys_block_value(dev_name, "size") || "-1").to_i
 
           @disks << result
         end
@@ -111,7 +111,7 @@ module Y2Autoinstallation
         sys_path = "/sys/block/#{device}/"
         ::File.read(sys_path + path).strip
       rescue StandardError => e
-        log.warn "read of #{sys_path + path}  failed with #{e}"
+        log.warn "read of #{sys_path + path} failed with #{e}"
         nil
       end
     end


### PR DESCRIPTION
## Problems

* AutoYaST searches for "serial" and "size" disk properties in the
wrong location. It should use `/sys/block/DEVNAME` instead of `/sys/block/DEVNAME/device`.

- https://bugzilla.suse.com/1199000

* Validation of rules, when using dialogs, does not work as expected.

- https://bugzilla.suse.com/1199165

## Solution

Just fix the path to the right files and update the rules syntax.
