### PR TITLE
Allow only one dialog element in rules

### DIFF
--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -28,10 +28,11 @@ rule =
 element rule {
     MAP,
     (
-      y2_match_to* &
+      (
+        y2_match_to+ | (y2_match_to* & dialog)
+      ) &
       result &
-      operator? &
-      dialog?
+      operator?
     )
 }
 

--- a/src/autoyast-rnc/rules.rnc
+++ b/src/autoyast-rnc/rules.rnc
@@ -28,9 +28,10 @@ rule =
 element rule {
     MAP,
     (
-      (y2_match_to | dialog)+ &
+      y2_match_to* &
       result &
-      operator?
+      operator? &
+      dialog?
     )
 }
 


### PR DESCRIPTION
## Problem

The fix in #836 introduces another problem in the rules syntax. Actually, the solution was easier than the one I implemented. This PR solves this issue.

## Solution

Let's see a few examples of *valid* and *not valid* definitions.

<details>
  <summary>Just a <dialog> element (and no conflicts list), without any other matcher is VALID</summary>

```xml
<rule>
  <dialog>
    <title>Desktop selection</title>
    <question>GNOME</question>
    <element t="integer">0</element>
  </dialog>
  <result>
    <profile>gnome.xml</profile>
  </result>
</rule>
```
</details>

<details>
  <summary>A matcher (e.g., disksize)and a <dialog> element is VALID</summary>

```xml
<rule>
  <disksize>
    <match>/dev/sdb 20000</match>
    <match_type>greater</match_type>
  </disksize>
  <dialog>
    <title>Desktop selection</title>
    <question>GNOME</question>
    <element t="integer">0</element>
  </dialog>
  <result>
    <profile>gnome.xml</profile>
  </result>
  <operator>and</operator>
</rule>
```
</details>

<details>
  <summary>More than one dialog element per rule is NOT VALID</summary>

```xml
<rule>
  <dialog>
    <title>Desktop selection</title>
    <question>GNOME</question>
    <element t="integer">0</element>
  </dialog>
  <dialog>
    <title>Desktop selection</title>
    <question>GNOME</question>
    <element t="integer">0</element>
  </dialog>
  <result>
    <profile>gnome.xml</profile>
  </result>
</rule>
```
</details>

<details>
  <summary>Neither matches nor rules is NOT VALID</summary>

```xml
<rule>
  <result>
    <profile>gnome.xml</profile>
  </result>
</rule>
```

## Notes

I have not bumped the version because this SR should replace the old one. But we can do it if wanted.