### PR TITLE
SLE Micro registration fix

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Jul 11 15:54:15 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Run the registration step early only on the Online installation
+  medium which does not provide any packages. On the other media
+  run the registration step later.
+  Fixes crash in the SLE Micro when the AutoYaST profile enables
+  the registration step. (bsc#1200803)
+- 4.4.38
+
+-------------------------------------------------------------------
 Tue May  3 15:00:22 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix detection disk serial and size in the "disks" ERB helper

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.37
+Version:        4.4.38
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autoinit.rb
+++ b/src/lib/autoinstall/clients/inst_autoinit.rb
@@ -4,6 +4,7 @@ require "autoinstall/autosetup_helpers"
 require "autoinstall/importer"
 require "y2packager/installation_medium"
 require "y2packager/product_spec"
+require "y2packager/medium_type"
 
 Yast.import "AutoinstConfig"
 Yast.import "AutoinstFunctions"
@@ -96,7 +97,9 @@ module Y2Autoinstallation
         autosetup_network if network_before_proposal? && !Yast::Mode.autoupgrade
 
         # register the system early to get repositories from registration server
-        if Yast::Profile.current.fetch_as_hash(REGISTER_SECTION)["do_registration"] &&
+        # when using the Online medium, for the other media the registration is done later
+        if Y2Packager::MediumType.online? &&
+            Yast::Profile.current.fetch_as_hash(REGISTER_SECTION)["do_registration"] &&
             !Yast::Mode.autoupgrade
 
           register = suse_register


### PR DESCRIPTION
## Problem

![sle_micro_failed](https://user-images.githubusercontent.com/907998/178425166-db307608-6f24-4630-b90f-15c982253930.png)

- https://bugzilla.suse.com/show_bug.cgi?id=1200803
- The problem is that at this point there is no repository configured yet and YaST sends empty product data to the SUSEConnect library. In that case it wants to run `zypper` to fetch the missing data. But because `zypper` is not available in the inst-sys it fails. (And it would fail anyway as there is no product data yet.)


## Solution

- Originally the registration step was called only when using the Online medium, this was lost during the refactoring: https://github.com/yast/yast-autoinstallation/pull/797/files#diff-4ad40bad87181af3dfd6624224aa3eba6ab369995c2056ca64ac9ae509a9d93dL97
- Just revert that behavior and run the registration step early only when using the Online medium
- On the Online medium the product data is read from the `control.xml` file, it does not need any repository available
- For the other media the registration step is executed later, when the package management is already initialized


## Testing

- Added a new unit test
- Tested manually in SLE Micro, then in SLE Full and SLE Online media for regressions - all worked fine

## Notes

Credits to @skazi0 for [debugging the problem](https://bugzilla.suse.com/show_bug.cgi?id=1200803#c30), thanks! :+1: 