### PR TITLE
AutoYaST initscripts: bring back the Before=systemd-user-sessions dependency (master) 

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul 22 11:31:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Revert the modification done in version 4.3.97 running the
+  initscripts before systed-user-sessions service again once
+  systemd fixed logind (bsc#1195059, bsc#1200780)
+- 4.5.3
+
+-------------------------------------------------------------------
 Mon Jul 11 15:54:15 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Run the registration step early only on the Online installation

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/scripts/autoyast-initscripts.service
+++ b/scripts/autoyast-initscripts.service
@@ -3,16 +3,14 @@ Description=Autoyast2 Init Scripts
 After=remote-fs.target network-online.target time-sync.target mail-transfer-agent.target hwscan.service ypbind.service YaST2-Second-Stage.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
-Before=display-manager.service
+Before=display-manager.service systemd-user-sessions.service
 Wants=network-online.target
 
 [Service]
 Type=oneshot
 Environment=TERM=linux
-ExecStartPre=-/usr/bin/touch /run/nologin
 ExecStartPre=-/usr/bin/plymouth --hide-splash
 ExecStart=/usr/lib/YaST2/bin/autoyast-initscripts.sh
-ExecStartPost=-/usr/bin/rm -f /run/nologin
 RemainAfterExit=yes
 TimeoutSec=0
 


### PR DESCRIPTION
It merges https://github.com/yast/yast-autoinstallation/pull/842 into 'master' (see also https://github.com/yast/yast-installation/pull/1055)

It also depends on this systemd SR (https://build.suse.de/request/show/276156)

