### PR TITLE
Add support for security policies

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov  3 16:45:52 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for security policies validation (jsc#SLE-24764).
+- 4.4.42
+
+-------------------------------------------------------------------
 Mon Oct 24 09:25:09 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow empty values in ask/default, ask/selection/label and

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -53,8 +53,10 @@ BuildRequires:  yast2-update >= 3.3.0
 BuildRequires:  yast2-network >= 3.1.145
 BuildRequires:  yast2-slp
 BuildRequires:  yast2-country
+# Support for SecurityPolicies
+BuildRequires:  yast2-security >= 4.4.14
 # Required for test suite testing one time sync
-BuildRequires:       yast2-ntp-client >= 4.0.1
+BuildRequires:  yast2-ntp-client >= 4.0.1
 # UEFI detection in Y2Storage::Arch
 BuildRequires:  yast2-storage-ng >= 4.4.22
 # %%{_unitdir} macro definition is in a separate package since 13.1
@@ -71,8 +73,8 @@ Requires:       libxslt
 Requires:       yast2 >= 4.4.38
 Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
-# Moving security module to first installation stage
-Requires:       yast2-security >= 4.1.1
+# Support for SecurityPolicies
+Requires:       yast2-security >= 4.4.14
 # Install selected network backend packages 
 Requires:       yast2-network >= 4.4.53
 Requires:       yast2-schema >= 4.0.6

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.41
+Version:        4.4.42
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -232,16 +232,14 @@ module Y2Autoinstallation
       Yast::Profile.remove_sections("firewall") if !need_second_stage_run?
     end
 
-    def validate_security_policies
+    # Check security policies
+    #
+    # If any of the rules of the enabled policies fails, it enables the confirm mode so the user has
+    # a chance to review and fix the potential issues.
+    def autosetup_security_policies
       target_config = Y2Security::SecurityPolicies::TargetConfig.new
       rules = Y2Security::SecurityPolicies::Manager.instance.failing_rules(target_config)
-      return if rules.empty?
-
-      y2issues = rules.map do |rule|
-        message = "#{rule.id} #{rule.description}"
-        Y2Issues::Issue.new(message, severity: :error)
-      end
-      Y2Issues.report(Y2Issues::List.new(y2issues))
+      Yast::AutoinstConfig.Confirm = true unless rules.empty?
     end
 
   private

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -18,6 +18,8 @@
 # find current contact information at www.suse.com.
 
 require "y2storage"
+require "y2issues"
+require "y2security/security_policies/manager"
 require "autoinstall/activate_callbacks"
 require "autoinstall/xml_checks"
 
@@ -227,6 +229,16 @@ module Y2Autoinstallation
       Yast::WFM.CallFunction("firewall_auto", ["Import", firewall_section])
 
       Yast::Profile.remove_sections("firewall") if !need_second_stage_run?
+    end
+
+    def validate_security_policies
+      issues = Y2Security::SecurityPolicies::Manager.instance.issues
+      return if issues.all.empty?
+
+      y2issues = issues.all.map do |issue|
+        Y2Issues::Issue.new(issue.message, severity: :error)
+      end
+      Y2Issues.report(Y2Issues::List.new(y2issues))
     end
 
   private

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -240,7 +240,6 @@ module Y2Autoinstallation
       target_config = Y2Security::SecurityPolicies::TargetConfig.new
       manager = Y2Security::SecurityPolicies::Manager.instance
       rules = manager.failing_rules(target_config)
-
       return if rules.empty?
 
       issues = rules.values.flatten.map do |rule|

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -232,11 +232,10 @@ module Y2Autoinstallation
       Yast::Profile.remove_sections("firewall") if !need_second_stage_run?
     end
 
-    # Check security policies
+    # Check the security policy
     #
-    # If any of the rules of the enabled policies fails, it enables the confirm mode so the user has
-    # a chance to review and fix the potential issues.
-    def autosetup_security_policies
+    # If any of the rules of the enabled policy fails, it displays a warning.
+    def autosetup_security_policy
       target_config = Y2Security::SecurityPolicies::TargetConfig.new
       manager = Y2Security::SecurityPolicies::Manager.instance
       rules = manager.failing_rules(target_config)

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -238,8 +238,17 @@ module Y2Autoinstallation
     # a chance to review and fix the potential issues.
     def autosetup_security_policies
       target_config = Y2Security::SecurityPolicies::TargetConfig.new
-      rules = Y2Security::SecurityPolicies::Manager.instance.failing_rules(target_config)
-      Yast::AutoinstConfig.Confirm = true unless rules.empty?
+      manager = Y2Security::SecurityPolicies::Manager.instance
+      rules = manager.failing_rules(target_config)
+
+      return if rules.empty?
+
+      issues = rules.values.flatten.map do |rule|
+        ids = (rule.identifiers + rule.references).join(", ")
+        Y2Issues::Issue.new("#{rule.description} (#{ids})")
+      end
+
+      Y2Issues.report(Y2Issues::List.new(issues))
     end
 
   private

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -240,11 +240,9 @@ module Y2Autoinstallation
       target_config = Y2Security::SecurityPolicies::TargetConfig.new
       manager = Y2Security::SecurityPolicies::Manager.instance
       rules = manager.failing_rules(target_config)
-      return if rules.empty?
+      return if !manager.enabled_policy || rules.empty?
 
-      # Assume that only 1 policy can be enabled
-      policy = rules.keys.first
-      items = rules.values.flatten.map do |rule|
+      items = rules.map do |rule|
         ids = (rule.identifiers + rule.references).join(", ")
         "#{rule.description} (#{ids})"
       end
@@ -252,7 +250,7 @@ module Y2Autoinstallation
       # TRANSLATORS: policy_name is the name of a SCAP policy
       message = format(
         _("The system does not comply with the %{policy_name} policy:"),
-        policy_name: policy.name
+        policy_name: manager.enabled_policy.name
       )
       Yast::Report.LongWarning(
         Yast::HTML.Para(message) + Yast::HTML.List(items)

--- a/src/lib/autoinstall/autosetup_helpers.rb
+++ b/src/lib/autoinstall/autosetup_helpers.rb
@@ -20,6 +20,7 @@
 require "y2storage"
 require "y2issues"
 require "y2security/security_policies/manager"
+require "y2security/security_policies/target_config"
 require "autoinstall/activate_callbacks"
 require "autoinstall/xml_checks"
 
@@ -232,11 +233,13 @@ module Y2Autoinstallation
     end
 
     def validate_security_policies
-      issues = Y2Security::SecurityPolicies::Manager.instance.issues
-      return if issues.all.empty?
+      target_config = Y2Security::SecurityPolicies::TargetConfig.new
+      rules = Y2Security::SecurityPolicies::Manager.instance.failing_rules(target_config)
+      return if rules.empty?
 
-      y2issues = issues.all.map do |issue|
-        Y2Issues::Issue.new(issue.message, severity: :error)
+      y2issues = rules.map do |rule|
+        message = "#{rule.id} #{rule.description}"
+        Y2Issues::Issue.new(message, severity: :error)
       end
       Y2Issues.report(Y2Issues::List.new(y2issues))
     end

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -79,7 +79,8 @@ module Y2Autoinstallation
           _("Import SSH keys/settings"),
           _("Set up user defined configuration files"),
           _("Confirm License"),
-          _("Configure firewall")
+          _("Configure firewall"),
+          _("Check security policy")
         ]
 
         @progress_descriptions = [
@@ -97,7 +98,8 @@ module Y2Autoinstallation
           _("Importing SSH keys/settings..."),
           _("Setting up user defined configuration files..."),
           _("Confirming License..."),
-          _("Configuring the firewall")
+          _("Configuring the firewall"),
+          _("Checking the security policy")
         ]
 
         Progress.New(

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -386,6 +386,11 @@ module Y2Autoinstallation
         #
         autosetup_firewall
 
+        Progress.NextStage
+
+        # Validate the security policies
+        validate_security_policies unless Yast::AutoinstConfig.Confirm
+
         # Results of imported values semantic check.
         return :abort unless AutoInstall.valid_imported_values
 

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -388,8 +388,8 @@ module Y2Autoinstallation
 
         Progress.NextStage
 
-        # Validate the security policies
-        autosetup_security_policies
+        # Validate the security policy
+        autosetup_security_policy
 
         # Results of imported values semantic check.
         return :abort unless AutoInstall.valid_imported_values

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -389,7 +389,7 @@ module Y2Autoinstallation
         Progress.NextStage
 
         # Validate the security policies
-        validate_security_policies unless Yast::AutoinstConfig.Confirm
+        autosetup_security_policies unless Yast::AutoinstConfig.Confirm
 
         # Results of imported values semantic check.
         return :abort unless AutoInstall.valid_imported_values

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -391,7 +391,7 @@ module Y2Autoinstallation
         Progress.NextStage
 
         # Validate the security policy
-        autosetup_security_policy
+        autosetup_security_policy unless AutoinstConfig.Confirm
 
         # Results of imported values semantic check.
         return :abort unless AutoInstall.valid_imported_values

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -389,7 +389,7 @@ module Y2Autoinstallation
         Progress.NextStage
 
         # Validate the security policies
-        autosetup_security_policies unless Yast::AutoinstConfig.Confirm
+        autosetup_security_policies
 
         # Results of imported values semantic check.
         return :abort unless AutoInstall.valid_imported_values

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -20,7 +20,7 @@
 
 require_relative "../test_helper"
 require "autoinstall/autosetup_helpers"
-require "y2security/security_policies/scopes"
+require "y2security/security_policies/rule"
 
 Yast.import "AutoinstConfig"
 Yast.import "Profile"
@@ -509,13 +509,16 @@ describe Y2Autoinstallation::AutosetupHelpers do
   end
 
   describe "#validate_security_policies" do
-    let(:issues) do
-      Y2Security::SecurityPolicies::IssuesCollection.new
+    let(:failing_rules) { [] }
+    let(:target_config) do
+      instance_double(Y2Security::SecurityPolicies::TargetConfig)
     end
 
     before do
       allow(Y2Security::SecurityPolicies::Manager.instance)
-        .to receive(:issues).and_return(issues)
+        .to receive(:failing_rules).and_return(failing_rules)
+      allow(Y2Security::SecurityPolicies::TargetConfig)
+        .to receive(:new).and_return(target_config)
     end
 
     context "when there are no issues" do
@@ -526,13 +529,11 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
 
     context "when there are issues" do
-      before do
-        policy = Y2Security::SecurityPolicies::Manager.instance.policies.first
-        issues.update(policy, [issue])
-      end
-
-      let(:issue) do
-        Y2Security::SecurityPolicies::Issue.new("wireless interfaces not allowed")
+      let(:failing_rules) do
+        [
+          instance_double(Y2Security::SecurityPolicies::Rule,
+            id: "SLES-15-000000", description: "Dummy rule")
+        ]
       end
 
       it "reports the issues to the user" do

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -514,7 +514,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
       instance_double(Y2Security::SecurityPolicies::TargetConfig)
     end
     let(:policy) do
-      instance_double(Y2Security::SecurityPolicies::Policy)
+      instance_double(Y2Security::SecurityPolicies::Policy, name: "DISA STIG")
     end
 
     before do
@@ -526,7 +526,8 @@ describe Y2Autoinstallation::AutosetupHelpers do
 
     context "when there are no issues" do
       it "does not report any issue" do
-        expect(Y2Issues).to_not receive(:report)
+        expect(Yast::Report).to_not receive(:LongWarning)
+          .with(/Dummy rule/)
         client.autosetup_security_policy
       end
     end
@@ -541,8 +542,9 @@ describe Y2Autoinstallation::AutosetupHelpers do
         { policy => [rule] }
       end
 
-      it "reports each rule as an installation issue" do
-        expect(Y2Issues).to receive(:report)
+      it "reports railing rules" do
+        expect(Yast::Report).to receive(:LongWarning)
+          .with(/DISA STIG.*Dummy rule \(CCE-12345, SLES-15-12345\)/)
         client.autosetup_security_policy
       end
     end

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -508,7 +508,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
   end
 
-  describe "#validate_security_policies" do
+  describe "#autosetup_security_policies" do
     let(:failing_rules) { [] }
     let(:target_config) do
       instance_double(Y2Security::SecurityPolicies::TargetConfig)
@@ -522,9 +522,9 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
 
     context "when there are no issues" do
-      it "does not try to report issues to the user" do
-        expect(Y2Issues).to_not receive(:report)
-        client.validate_security_policies
+      it "does not enable the confirm mode" do
+        expect(Yast::AutoinstConfig).to_not receive(:Confirm=)
+        client.autosetup_security_policies
       end
     end
 
@@ -536,9 +536,9 @@ describe Y2Autoinstallation::AutosetupHelpers do
         ]
       end
 
-      it "reports the issues to the user" do
-        expect(Y2Issues).to receive(:report)
-        client.validate_security_policies
+      it "enables the confirm mode" do
+        expect(Yast::AutoinstConfig).to receive(:Confirm=).with(true)
+        client.autosetup_security_policies
       end
     end
   end

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -509,15 +509,17 @@ describe Y2Autoinstallation::AutosetupHelpers do
   end
 
   describe "#autosetup_security_policy" do
-    let(:failing_rules) { {} }
     let(:target_config) do
       instance_double(Y2Security::SecurityPolicies::TargetConfig)
     end
     let(:policy) do
       instance_double(Y2Security::SecurityPolicies::Policy, name: "DISA STIG")
     end
+    let(:failing_rules) { [] }
 
     before do
+      allow(Y2Security::SecurityPolicies::Manager.instance)
+        .to receive(:enabled_policy).and_return(policy)
       allow(Y2Security::SecurityPolicies::Manager.instance)
         .to receive(:failing_rules).and_return(failing_rules)
       allow(Y2Security::SecurityPolicies::TargetConfig)
@@ -537,10 +539,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
         instance_double(Y2Security::SecurityPolicies::Rule, id: "testing",
           description: "Dummy rule", identifiers: ["CCE-12345"], references: ["SLES-15-12345"])
       end
-
-      let(:failing_rules) do
-        { policy => [rule] }
-      end
+      let(:failing_rules) { [rule] }
 
       it "reports railing rules" do
         expect(Yast::Report).to receive(:LongWarning)

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -508,7 +508,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
     end
   end
 
-  describe "#autosetup_security_policies" do
+  describe "#autosetup_security_policy" do
     let(:failing_rules) { {} }
     let(:target_config) do
       instance_double(Y2Security::SecurityPolicies::TargetConfig)
@@ -527,7 +527,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
     context "when there are no issues" do
       it "does not report any issue" do
         expect(Y2Issues).to_not receive(:report)
-        client.autosetup_security_policies
+        client.autosetup_security_policy
       end
     end
 
@@ -543,7 +543,7 @@ describe Y2Autoinstallation::AutosetupHelpers do
 
       it "reports each rule as an installation issue" do
         expect(Y2Issues).to receive(:report)
-        client.autosetup_security_policies
+        client.autosetup_security_policy
       end
     end
   end

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -306,9 +306,26 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       end
     end
 
-    it "validates security policy" do
-      expect(subject).to receive(:autosetup_security_policy)
-      subject.main
+    context "when the confirmation mode is not enabled" do
+      before do
+        allow(Yast::AutoinstConfig).to receive(:Confirm).and_return(false)
+      end
+
+      it "validates the security policy" do
+        expect(subject).to receive(:autosetup_security_policy)
+        subject.main
+      end
+    end
+
+    context "when the confirmation mode is enabled" do
+      before do
+        allow(Yast::AutoinstConfig).to receive(:Confirm).and_return(true)
+      end
+
+      it "does not validate the security policy" do
+        expect(subject).to_not receive(:autosetup_security_policy)
+        subject.main
+      end
     end
   end
 end

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -313,7 +313,7 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
 
       context "when the confirmation mode is disabled" do
         it "validates security policies" do
-          expect(subject).to receive(:validate_security_policies)
+          expect(subject).to receive(:autosetup_security_policies)
           subject.main
         end
       end
@@ -324,7 +324,7 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
         end
 
         it "does not validate security policies" do
-          expect(subject).to_not receive(:validate_security_policies)
+          expect(subject).to_not receive(:autosetup_security_policies)
           subject.main
         end
       end

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -306,28 +306,9 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       end
     end
 
-    context "security policies" do
-      before do
-        allow(Yast::AutoinstConfig).to receive(:Confirm).and_return(false)
-      end
-
-      context "when the confirmation mode is disabled" do
-        it "validates security policies" do
-          expect(subject).to receive(:autosetup_security_policies)
-          subject.main
-        end
-      end
-
-      context "when the confirmation mode is enabled" do
-        before do
-          allow(Yast::AutoinstConfig).to receive(:Confirm).and_return(true)
-        end
-
-        it "does not validate security policies" do
-          expect(subject).to_not receive(:autosetup_security_policies)
-          subject.main
-        end
-      end
+    it "validates security policy" do
+      expect(subject).to receive(:autosetup_security_policy)
+      subject.main
     end
   end
 end

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -305,5 +305,29 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
         expect(Yast::Profile.current).to_not have_key("add-on")
       end
     end
+
+    context "security policies" do
+      before do
+        allow(Yast::AutoinstConfig).to receive(:Confirm).and_return(false)
+      end
+
+      context "when the confirmation mode is disabled" do
+        it "validates security policies" do
+          expect(subject).to receive(:validate_security_policies)
+          subject.main
+        end
+      end
+
+      context "when the confirmation mode is enabled" do
+        before do
+          allow(Yast::AutoinstConfig).to receive(:Confirm).and_return(true)
+        end
+
+        it "does not validate security policies" do
+          expect(subject).to_not receive(:validate_security_policies)
+          subject.main
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Related to https://github.com/yast/yast-security/pull/128.

* Add support to check security policies in AutoYaST.
* If displays a Y2Issue for each failing rule with `:warn` severity.

## Enabling a policy

```xml
  <security>
    <security_policy>
      <action>remediate</action> <!-- none, remediate or scan -->
      <policy>stig</policy>
    </security_policy>
  </security>
```

## Screenshots

![security-policy-warning](https://user-images.githubusercontent.com/15836/199987262-e3988913-8101-4073-b5b7-fefd1dcc19fe.png)
