### PR TITLE
Add XSL files for converting between the new and old profile types.

### DIFF
--- a/doc/profile_conversions.md
+++ b/doc/profile_conversions.md
@@ -1,0 +1,45 @@
+# Profile Conversions
+
+Although AutoYaST keeps backward compatibility so the old profiles should work
+in new product releases in some cases it might be useful to do some conversions.
+
+## :warning: Warning
+
+*The automatic conversions using XSLT might not produce exact 1:1 results,
+there might be minor differences in formatting, also the CDATA sections are
+converted to regular data.*
+
+*Always check the conversion result and adjust it manually if needed.*
+
+## Converting from the Old Data Types to the New Ones
+
+Since SLE15-SP3 AutoYaST simplified the data type definitions in the XML
+profiles.
+
+Instead of `config:type="boolean"` you can use a shorter form `t="boolean"`,
+for example:
+
+```xml
+<confirm t="boolean">true</confirm>
+```
+
+To convert the data types automatically you can use the [`new_types.xslt`](
+../xslt/new_types.xslt) file.
+
+```shell
+xsltproc -o profile_new.xml /usr/share/autoinstall/xslt/new_types.xslt profile.xml
+```
+
+## Converting from the New Data Types to the Old Ones
+
+This is the opposite process to the previous conversion, it converts the new
+data types to the old ones. This is useful if you want to use a new profile
+in an old system (SLE15-SP2 and older). The old AutoYaST cannot read the new
+data types and it would fail.
+
+The [`old_types.xslt`](../xslt/old_types.xslt) file converts the short
+attributes `t="boolean"` to long attributes `config:type="boolean"`.
+
+```shell
+xsltproc -o profile_old.xml /usr/share/autoinstall/xslt/old_types.xslt profile.xml
+```

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Dec 21 14:19:22 UTC 2022 - Ladislav Slezák <lslezak@suse.com>
+
+- Added XSLT transformation for easy conversion of the data types in the
+  AutoYaST XML profiles between the old and the new format. This allows to
+  convert a new profile to the format accepted in SLE15-SP2 or older
+  (bsc#1206597)
+- 4.5.12
+
+-------------------------------------------------------------------
 Thu Dec  1 09:36:51 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Avoid a potential crash when autoinst.ycp file is empty or

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.5.11
+Version:        4.5.12
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
@@ -207,6 +207,9 @@ done
 
 %dir %{yast_moduledir}
 %{yast_moduledir}/AutoinstClass.rb
+
+%dir %{_datadir}/autoinstall/xslt
+%{_datadir}/autoinstall/xslt/*_types.xslt
 
 %{yast_icondir}
 

--- a/xslt/new_types.xslt
+++ b/xslt/new_types.xslt
@@ -1,0 +1,31 @@
+<xsl:stylesheet version="1.0"
+  xmlns:n="http://www.suse.com/1.0/yast2ns"
+  xmlns:config="http://www.suse.com/1.0/configns"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.suse.com/1.0/yast2ns" exclude-result-prefixes="n">
+
+<!--
+Convert the AutoYaST scheme with the old type specification to the new format.
+It simply replaces all "config:type" attributes with simple "t" attribute.
+
+NOTE: The new format is supported in SLES15-SP3 and newer, if you need to use
+the profile in older systems you need to use the old "config:type" attributes!
+
+See the old_types.xslt file for the opposite conversion.
+-->
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="@config:type">
+    <xsl:attribute name="t">
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/old_types.xslt
+++ b/xslt/old_types.xslt
@@ -1,0 +1,31 @@
+<xsl:stylesheet version="1.0"
+  xmlns:n="http://www.suse.com/1.0/yast2ns"
+  xmlns:config="http://www.suse.com/1.0/configns"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.suse.com/1.0/yast2ns" exclude-result-prefixes="n">
+
+<!--
+Convert the AutoYaST scheme with the new type specification to the old format.
+It simply replaces all "t" attributes with "config:type" attribute.
+
+NOTE: The new format is supported in SLES15-SP3 and newer, if you need to use
+a profile in older systems this XSL file will make the profile work there.
+
+See the new_types.xslt file for the opposite conversion.
+-->
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="@t">
+    <xsl:attribute name="config:type">
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
## Problem

If you use a new data types in the XML profile like
```xml
  <confirm t="boolean">true</confirm>
```
then such profile does not work in SLE15-SP2 and older. It would be nice to provide some tools for automatic conversion to the old format which would convert it to
```xml
  <confirm config:type="boolean">true</confirm>
```

## Solution

- Provide XSL files for converting the profile
- See more details in the new `profile_conversions.md` document

## CDATA Problem

Although the XSLT conversion should work fine in most cases there is a small problem with the CDATA sections - they are not kept and the data are converted to a string literal (with proper escaping when needed). So the conversion is not exactly 1:1, converting back to the original data types results in losing the CDATA sections (although semantically it is the very same profile).

Unfortunately there is no simple solution, XSLT internally does not track whether the text data was originally a string literal or a CDATA section. We could explicitly specify in XSL which nodes should be outputted as CDATA (it is usually used for add-on URLs), but that would on the other hand add the CDATA always, even when the original file did not use it.

I found a [better solution on StackOverflow](https://stackoverflow.com/questions/15697433/xml-and-xslt-keep-cdata) but that  uses a complicated two pass conversion. In the first pass it scans the XML for the CDATA sections and generates a new XSLT for the final conversion which outputs CDATA for that found elements.

But that is too complicated IMHO and still does not cover all cases (e.g. if you once use CDATA and in other case not). So let's use a simple solution.

## Testing

- Tested manually with several testing XML profiles, both conversions work fine
