### PR TITLE
fix profile location parsing and add 'repo' URL scheme

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 17 10:30:48 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- fix profile location parsing and add 'repo' URL scheme (jsc#SLE-22578,
+  jsc#SLE-24584)
+- 4.5.6
+
+-------------------------------------------------------------------
 Tue Oct  4 09:34:18 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Add needed packages for the selected network backend in order to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstConfig.rb
+++ b/src/modules/AutoinstConfig.rb
@@ -361,7 +361,7 @@ module Yast
       @user     = parsed_url["user"]   || ""
       @pass     = parsed_url["pass"]   || ""
 
-      if @scheme == "relurl" || @scheme == "file"
+      if @scheme == "relurl" || @scheme == "repo" || @scheme == "file"
         # "relurl": No host information has been given here. So a part of the path or the
         # complete path has been stored in the host variable while parsing it.
         # This will be reverted.
@@ -376,6 +376,9 @@ module Yast
           @filepath = @host unless @host.empty?
         end
         @host = ""
+        # keep in sync
+        @urltok["path"] = @filepath
+        @urltok["host"] = @host
       end
 
       @remoteProfile = !["default", "file", "floppy", "usb", "device"].include?(@scheme)

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -98,21 +98,6 @@ module Yast
         else
           log.warn("Cannot evaluate ZyppRepoURL from /etc/install.inf")
         end
-      elsif AutoinstConfig.scheme == "label"
-        # autoyast=label://my_home//autoinst.xml in linuxrc:
-        # AY is searching for a partition with the label "my_home". This partition
-        # will be mounted and the autoinst.xml will be used for installation.
-        log.info("searching label #{AutoinstConfig.host}")
-        fs = Y2Storage::StorageManager.instance.probed.filesystems.find do |f|
-          f.label == AutoinstConfig.host
-        end
-        if fs&.blk_devices&.first
-          AutoinstConfig.scheme = "device"
-          AutoinstConfig.host = fs.blk_devices.first.basename
-          log.info("found on #{AutoinstConfig.host}")
-        else
-          Report.Error(_("label not found while looking for autoyast profile"))
-        end
       end
 
       filename = basename(AutoinstConfig.filepath)


### PR DESCRIPTION
## Problem

- https://trello.com/c/CAytlL3W
- https://jira.suse.com/browse/SLE-22578
- https://jira.suse.com/browse/SLE-24584

Add the new `repo` scheme - it needs to be treated similar to `relurl`.

For `relurl`, `file`, and `repo` URL schemes the tokenization is reworked - but is not synced with the stored tokens. This discrepancy leads to issues in `Yast::Transfer::FileFromUrl.get_file_from_url` in some cases.

## Bonus

Remove `label` URL scheme handling. It's now handled in [Yast::Transfer::FileFromUrl](https://github.com/yast/yast-installation/pull/1063) directly.

## See also

- https://github.com/openSUSE/linuxrc/pull/299
- https://github.com/yast/yast-installation/pull/1063
- https://github.com/yast/yast-yast2/pull/1276