### PR TITLE
Ay needed packages

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct  4 09:34:18 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Add needed packages for the selected network backend in order to
+  prevent it is not declared in the software section (bsc#1201235,
+  bsc#1201435)
+- 4.4.40
+
+-------------------------------------------------------------------
 Fri Jul 22 11:31:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Revert the modification done in version 4.3.97 running the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.39
+Version:        4.4.40
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
@@ -73,8 +73,8 @@ Requires:       yast2-core
 Requires:       yast2-country >= 3.1.13
 # Moving security module to first installation stage
 Requires:       yast2-security >= 4.1.1
-# Modify start_immediately default value
-Requires:       yast2-network >= 4.3.59
+# Install selected network backend packages 
+Requires:       yast2-network >= 4.4.53
 Requires:       yast2-schema >= 4.0.6
 Requires:       yast2-transfer >= 2.21.0
 Requires:       yast2-xml

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -123,13 +123,13 @@ module Y2Autoinstallation
 
         # configure general settings
         general_section = Profile.current.fetch_as_hash("general")
-        networking_section = Profile.current.fetch_as_hash("networking")
-        pkg_list = networking_section["managed"] ? ["NetworkManager"] : []
         AutoinstGeneral.Import(general_section)
         log.info("general: #{general_section}")
         AutoinstGeneral.Write
 
         autosetup_network
+        # Add needed network packages depending on the selected backend (bsc#1201435)
+        pkg_list = (Call.Function("lan_auto", ["Packages"]) || {}).fetch("install", [])
 
         if Builtins.haskey(Profile.current, "add-on")
           Progress.Title(_("Handling Add-On Products..."))

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -47,6 +47,8 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       allow(Yast::AutoinstStorage).to receive(:Write).and_return(true)
 
       allow(Yast::WFM).to receive(:CallFunction).with(/_auto/, Array).and_return(true)
+      allow(Yast::WFM).to receive(:CallFunction)
+        .with("lan_auto", ["Packages"]).and_return("install" => [])
       allow(Yast::WFM).to receive(:ClientExists).with(/_auto/).and_return(true)
       allow(Yast::Popup).to receive(:ConfirmAbort).and_return(true)
 


### PR DESCRIPTION
## Problem

We are only checking needed packages for the selected backend when it is NetworkManager but not in case of wicked or netconfig.

- [bsc#1201435](https://bugzilla.suse.com/show_bug.cgi?id=1201435)

## Solution

Added needed packages for the selected backend to ensure them are installed even if not declared in the software section

## Testing

- Added a new unit test
- Tested manually


