### PR TITLE
bsc#1204448: allow empty values for some <ask> elements

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 24 09:25:09 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow empty values in ask/default, ask/selection/label and
+  ask/selection/value elements (bsc#1204448).
+- 4.4.41
+
+-------------------------------------------------------------------
 Tue Oct  4 09:34:18 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Add needed packages for the selected network backend in order to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.40
+Version:        4.4.41
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/autoinst_profile/ask_section.rb
+++ b/src/lib/autoinstall/autoinst_profile/ask_section.rb
@@ -41,7 +41,7 @@ module Y2Autoinstall
       def self.attributes
         [
           { name: :question },
-          { name: :default },
+          { name: :default, allow_blank: true },
           { name: :help },
           { name: :title },
           { name: :type },

--- a/src/lib/autoinstall/autoinst_profile/ask_selection_entry.rb
+++ b/src/lib/autoinstall/autoinst_profile/ask_selection_entry.rb
@@ -24,8 +24,8 @@ module Y2Autoinstall
     class AskSelectionEntry < ::Installation::AutoinstProfile::SectionWithAttributes
       def self.attributes
         [
-          { name: :value },
-          { name: :label }
+          { name: :value, allow_blank: true },
+          { name: :label, allow_blank: true }
         ]
       end
 


### PR DESCRIPTION
## Problem

[bsc#1204448](https://bugzilla.suse.com/show_bug.cgi?id=1204448)

Specifying empty values in the `<ask>/>` section is impossible.

## Solution

https://github.com/yast/yast-yast2/pull/1170 introduced the `allow_blank` option, so now we can properly handle this case.


## Testing

- *Tested manually*