### PR TITLE
Log the profile/rules/classes file SHA1 sum (bsc#1204175)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Nov  3 13:04:26 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Log the profile/rules/classes file SHA1 sum so we can later
+  verify that a particular file was or was not used by YaST
+  (related to bsc#1204175)
+- 4.5.8
+
+-------------------------------------------------------------------
 Mon Oct 24 09:25:09 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow empty values in ask/default, ask/selection/label and

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstClass.rb
+++ b/src/modules/AutoinstClass.rb
@@ -13,6 +13,7 @@
 # $Id$
 require "yast"
 require "autoinstall/xml_checks"
+require "digest/sha1"
 
 module Yast
   class AutoinstClassClass < Module
@@ -54,6 +55,10 @@ module Yast
       if SCR.Read(path(".target.size"), @classPath) != -1 &&
           Y2Autoinstallation::XmlChecks.instance.valid_classes?(@classPath)
         begin
+          classes_sha1 = Digest::SHA1.hexdigest(File.read(@classPath))
+          # log the classes checksum so we can verify that a particular file was really used
+          log.info("Classes SHA1 checksum: #{classes_sha1}")
+
           classes_map = XML.XMLToYCPFile(@classPath)
           @Classes = (classes_map && classes_map["classes"]) || []
         rescue XMLDeserializationError => e

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -31,6 +31,7 @@ require "autoinstall/y2erb"
 require "y2storage"
 require "fileutils"
 require "yast2/popup"
+require "digest/sha1"
 
 module Yast
   class ProfileLocationClass < Module
@@ -133,6 +134,9 @@ module Yast
           return false
         end
 
+        # log the profile checksum so we can verify that a particular file was really used
+        log.info("Profile SHA1 checksum: #{Digest::SHA1.hexdigest(tmp)}")
+
         if GPG.encrypted_symmetric?(localfile)
           label = _("Encrypted AutoYaST profile.")
           begin
@@ -210,6 +214,10 @@ module Yast
 
       if ret
         AutoInstallRules.userrules = true
+
+        rules_sha1 = Digest::SHA1.hexdigest(File.read(AutoinstConfig.local_rules_file))
+        # log the rules checksum so we can verify that a particular file was really used
+        log.info("Rules SHA1 checksum: #{rules_sha1}")
       else
         AutoInstallRules.userrules = false
         SCR.Execute(path(".target.remove"), AutoinstConfig.local_rules_file)


### PR DESCRIPTION
## Problem

- Related to https://bugzilla.suse.com/show_bug.cgi?id=1204175
- We cannot easily verify that a profile attached in bugzilla really matches the attached YaST log, we cannot verify that those two belong together

## Solution

- We cannot log the full profile because it might potentially contain sensitive data like registration codes or user passwords
- But we can log a SHA1 checksum, that is safe and we can easily verify that the attached profile is exactly the file which was used by YaST
- Just run `sha1sum profile.xml`, the printed checksum must be the same as the checksum in the `y2log`, if not then the file is different
- Log also the SHA1 of the rules or classes files if they are used

## Testing

- Tested manually
