### PR TITLE
Fix kdump software

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  8 15:52:04 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Add needed packages for kdump even when kdump section is not
+  defined if product enable kdump by default (bsc#1204180)
+- 4.4.43
+
+-------------------------------------------------------------------
 Thu Nov  3 16:45:52 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for security policies validation (jsc#SLE-24764).

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.4.42
+Version:        4.4.43
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -277,8 +277,9 @@ module Y2Autoinstallation
 
         Progress.NextStage
 
-        # SLES only. Have to be run before software to add required packages to enable kdump
-        if Builtins.haskey(Profile.current, "kdump")
+        # For kdump we respect product defaults. So even if not specified in profile
+        # import empty one to get proposal and install needed software.
+        if WFM.ClientExists("kdump_auto")
           Call.Function(
             "kdump_auto",
             ["Import", Ops.get_map(Profile.current, "kdump", {})]

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -279,7 +279,9 @@ module Y2Autoinstallation
 
         # For kdump we respect product defaults. So even if not specified in profile
         # import empty one to get proposal and install needed software.
+        log.info "checking for kdump auto"
         if WFM.ClientExists("kdump_auto")
+          log.info "calling import"
           Call.Function(
             "kdump_auto",
             ["Import", Ops.get_map(Profile.current, "kdump", {})]

--- a/test/lib/clients/inst_autosetup_test.rb
+++ b/test/lib/clients/inst_autosetup_test.rb
@@ -68,6 +68,8 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       allow(importer).to receive(:import_entry).and_call_original
       allow(Yast::ProductControl).to receive(:RunFrom).and_return(:next)
       Yast::Profile.current = Yast::ProfileHash.new(profile)
+
+      allow(Yast::Profile).to receive(:remove_sections)
     end
 
     it "sets up the network" do
@@ -297,6 +299,8 @@ describe Y2Autoinstallation::Clients::InstAutosetup do
       end
 
       it "removes the add-on section from the profile" do
+
+        allow(Yast::Profile).to receive(:remove_sections).and_call_original
         expect(Yast::Profile.current).to have_key("add-on")
         expect(Yast::WFM).to receive(:CallFunction)
           .with("add-on_auto", ["Import", profile["add-on"]])


### PR DESCRIPTION
## Problem

When kdump section is not defined and product have by default then required packages are not installed.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1204180


## Solution

Call always import to ensure that product default is used.


## Testing

- *Added a new unit test*
- *Tested manually*

During manual testing this issue occur, but it is not related to changed code:

![network_failure](https://user-images.githubusercontent.com/478871/200614087-aee06487-73d7-4471-835b-632795c04e1d.png)


