### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 22 15:50:38 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.10
+
+-------------------------------------------------------------------
 Tue Nov  8 15:52:04 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Add needed packages for kdump even when kdump section is not

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.5.9
+Version:        4.5.10
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/test/AutoInstallRules_test.rb
+++ b/test/AutoInstallRules_test.rb
@@ -124,6 +124,8 @@ describe "Yast::AutoInstallRules" do
   end
 
   describe "#Read" do
+    let(:env) { { "hostaddress" => subject.hostaddress, "mac" => subject.mac } }
+
     it "Reading rules with -or- operator" do
       expect(Yast::XML).to receive(:XMLToYCPFile).and_return(
         "rules" => [{
@@ -138,7 +140,7 @@ describe "Yast::AutoInstallRules" do
       expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"),
         "if  ( [ \"$hostaddress\" = \"10.69.57.43\" ] )   ||   " \
           "( [ \"$mac\" = \"000c2903d288\" ] ); then exit 0; else exit 1; fi",
-        "hostaddress" => subject.hostaddress, "mac" => subject.mac)
+        env)
         .and_return("stdout" => "", "exit" => 0, "stderr" => "")
 
       subject.Read
@@ -158,7 +160,7 @@ describe "Yast::AutoInstallRules" do
       expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"),
         "if  ( [ \"$hostaddress\" = \"10.69.57.43\" ] )   &&   " \
           "( [ \"$mac\" = \"000c2903d288\" ] ); then exit 0; else exit 1; fi",
-        "hostaddress" => subject.hostaddress, "mac" => subject.mac)
+        env)
         .and_return("stdout" => "", "exit" => 0, "stderr" => "")
 
       subject.Read
@@ -177,7 +179,7 @@ describe "Yast::AutoInstallRules" do
       expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"),
         "if  ( [ \"$hostaddress\" = \"10.69.57.43\" ] )   &&   " \
           "( [ \"$mac\" = \"000c2903d288\" ] ); then exit 0; else exit 1; fi",
-        "hostaddress" => subject.hostaddress, "mac" => subject.mac)
+        env)
         .and_return("stdout" => "", "exit" => 0, "stderr" => "")
 
       subject.Read

--- a/test/lib/autosetup_helpers_test.rb
+++ b/test/lib/autosetup_helpers_test.rb
@@ -451,6 +451,8 @@ describe Y2Autoinstallation::AutosetupHelpers do
       Yast::Profile.current = profile
       allow(Yast::Installation).to receive(:encoding=)
       allow(Yast::Profile).to receive(:remove_sections)
+      allow(Yast::UI).to receive(:SetLanguage)
+      allow(Yast::WFM).to receive(:SetLanguage)
     end
 
     it "sets the language config based on the profile" do

--- a/test/lib/clients/ayast_setup_test.rb
+++ b/test/lib/clients/ayast_setup_test.rb
@@ -125,9 +125,8 @@ describe "Y2Autoinstall::Clients::AyastSetup" do
     end
 
     it "imports general settings" do
-      expect(Yast::AutoinstGeneral).to receive(:Import).with(
-        "mode" => { "confirm" => true }
-      )
+      settings = { "mode" => { "confirm" => true } }
+      expect(Yast::AutoinstGeneral).to receive(:Import).with(settings)
       subject.Setup
     end
   end


### PR DESCRIPTION
- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- see https://github.com/yast/yast-yast2/pull/1279 for details
