### PR TITLE
Rebuild the RPM database during upgrade (--rebuilddb) (bsc#1209565)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 12 08:18:39 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Rebuild the RPM database during upgrade (--rebuilddb) (bsc#1209565)
+- 4.5.13
+
+-------------------------------------------------------------------
 Wed Dec 21 14:19:22 UTC 2022 - Ladislav Slezák <lslezak@suse.com>
 
 - Added XSLT transformation for easy conversion of the data types in the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.5.12
+Version:        4.5.13
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
@@ -134,8 +134,8 @@ Requires:       yast2-transfer >= 2.21.0
 # storage-ng based version
 Requires:       yast2-update >= 3.3.0
 Requires:       yast2-xml
-# RPM dependencies in Pkg.Resolvables
-Requires:       yast2-pkg-bindings >= 4.3.0
+# Pkg.TargetInitializeOptions with "rebuild_db" option
+Requires:       yast2-pkg-bindings >= 4.5.2
 Requires:       yast2-ruby-bindings >= 1.0.0
 # bsc#1185095
 Recommends:     (icewm if libyui-qt)

--- a/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup_upgrade.rb
@@ -309,7 +309,9 @@ module Y2Autoinstallation
         # initialize target
         PackageCallbacks.SetConvertDBCallbacks
 
-        Pkg.TargetInit(Installation.destdir, false)
+        Pkg.TargetInitializeOptions(Installation.destdir,
+          # enable DB rebuild at upgrade (bsc#1209565)
+          "rebuild_db" => true)
 
         # read old and new product
         Update.GetProductName


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1209565
- The RPM DB should be rebuilt during upgrade to ensure it is in a consistent state

## Solution

- Use the updated `Pkg.TargetInitializeOptions()` call which accepts a Hash with the rebuild DB flag (https://github.com/yast/yast-pkg-bindings/pull/172)

## Testing

- Tested manually,  during auto upgrade libzypp calls
```
[zypp::exec++] ExternalProgram.cc(start_program):260 Executing[C] 'rpm' '--root' '/' '--dbpath'
'/mnt/usr/lib/sysimage/rpm' '--rebuilddb' '-vv'
```
