### PR TITLE
Properly install the selected products (bsc#1202234)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 22 08:41:52 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Properly install the selected products, do not lose them after
+  resetting the package manager internally (bsc#1202234)
+- 4.3.105
+
+-------------------------------------------------------------------
 Tue Sep 27 15:23:53 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Process the <ask-list/> section in an installed system once the

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.3.104
+Version:        4.3.105
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1211154
- The product packages (`*-release`) are not installed by AutoYaST
- It turned out that the AutoYaST only restores the selected packages and patterns after calling `Pkg.PkgApplReset`

## Notes

- The original idea was to extend the [PackagesProposal](https://github.com/yast/yast-yast2/blob/master/library/general/src/modules/PackagesProposal.rb) module to also handle products (in addition to patterns and packages)
- But that turned out to be very complex, we would need to update at least 5 packages (6 if we count Agama as well)
- This could also affect manual installation or upgrade and the testing would be quite difficult

## Solution

- Just remember *all* selected products and restore them later (not just the base product as it was already done)
- This code change is isolated into a single place which affects only AutoYaST (less chance to break something, easier testing)

## Testing

- Tested manually, see the screenshots below

## Screenshots

|Original|Fixed|
|---|---|
|![ay_product_selection_broken_summary](https://github.com/yast/yast-autoinstallation/assets/907998/b5b8f40f-70c5-4e3c-9e58-1fa7fb3e421f)|![ay_product_selection_fixed_summary](https://github.com/yast/yast-autoinstallation/assets/907998/1df8dfab-a10e-4213-a1f0-d603ffc31c3b)|
|![ay_product_selection_broken](https://github.com/yast/yast-autoinstallation/assets/907998/7df65849-bb7c-459f-9e4d-c55e51e9c635)|![ay_product_selection_fixed](https://github.com/yast/yast-autoinstallation/assets/907998/4b01c9df-ebe1-4243-ad60-900dda9ff75c)|


