### PR TITLE
backport SP6

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.3
 
 -------------------------------------------------------------------
 Tue May 23 11:35:13 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.6.0
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

master has two commits in 4.6.X, but both are already backported to SP5.


## Solution

Just bump version to avoid confusion and collision.