### PR TITLE
New LUKS-related elements in the schema of the <partition> section

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 22 10:25:35 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added several LUKS-related elements to the partitioning schema
+  (jsc#PED-3878, jsc#PED-5518).
+- 4.6.4
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.6.3
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -62,6 +62,10 @@ y2_partition =
   | part_crypt_fs
   | part_crypt_method
   | part_crypt_key
+  | part_crypt_pbkdf
+  | part_crypt_label
+  | part_crypt_cipher
+  | part_crypt_key_size
   | part_filesystem
   | part_format
   | part_fs_options
@@ -109,6 +113,10 @@ part_crypt_fs =
 part_crypt_method =
   element crypt_method { SYMBOL }
 part_crypt_key = element crypt_key { STRING }
+part_crypt_pbkdf = element crypt_pbkdf { SYMBOL }
+part_crypt_label = element crypt_label { STRING }
+part_crypt_cipher = element crypt_cipher { STRING }
+part_crypt_key_size = element crypt_key_size { INTEGER }
 part_filesystem =
   element filesystem { SYMBOL }
 part_format =


### PR DESCRIPTION
## Problem

https://github.com/yast/yast-storage-ng/pull/1355 implements several improvements related to LUKS in AutoYaST. But adding support in the yast2-storage-ng code is not enough, the new elements also need to be added to the AutoYaST schema or they will not be accepted as part of an AutoYaST profile.

## Solution

This adds the new four elements to the schema.