### PR TITLE
Minor tweak to allow access to lvm_vg_reuse proposal via an AY profile

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 15 10:19:32 UTC 2024 - Michal Filka <mfilka@suse.com>
+
+- jsc#PED-6407
+  - enabled lvm_vg_reuse to be used in general/storage/proposal
+    section 
+- 4.6.5
+
+-------------------------------------------------------------------
 Fri Sep 22 10:25:35 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added several LUKS-related elements to the partitioning schema

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.6.4
+Version:        4.6.5
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstStorage.rb
+++ b/src/modules/AutoinstStorage.rb
@@ -320,7 +320,7 @@ module Yast
       preprocessor.run(settings)
     end
 
-    ALLOWED_OVERRIDES = [:lvm, :encryption_password].freeze
+    ALLOWED_OVERRIDES = [:lvm, :lvm_vg_reuse, :encryption_password].freeze
     private_constant :ALLOWED_OVERRIDES
     DELETE_RESIZE_OVERRIDES = [
       :windows_delete_mode, :linux_delete_mode, :other_delete_mode, :resize_windows


### PR DESCRIPTION
## Problem

See https://github.com/yast/yast-storage-ng/pull/1365

should be merged after the above one.

This change makes following snipped working (sets lvm_vg_reuse in created proposal(s) accordingly):
```
<general>
    <storage>
      <proposal>
        <lvm_vg_reuse config:type="boolean">false</lvm_vg_reuse>
      </proposal>
  </storage>
</general>
```

## Testing

- *Tested manually*

