### PR TITLE
[SLE15-SP6] Install plain SLES instead of SLE_HPC (jsc#PED-7841)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 15 09:09:59 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Install standard SLES when the AY XML profile selects SLE_HPC,
+  it has been dropped in SP6 (jsc#PED-7841)
+- 4.6.5
+
+-------------------------------------------------------------------
 Fri Sep 22 10:25:35 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added several LUKS-related elements to the partitioning schema

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.6.4
+Version:        4.6.5
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/AutoinstFunctions.rb
+++ b/src/modules/AutoinstFunctions.rb
@@ -8,6 +8,13 @@ module Yast
   class AutoinstFunctionsClass < Module
     include Yast::Logger
 
+    # special mapping for handling dropped or renamed products,
+    # a map with <old product name> => <new_product name> values
+    PRODUCT_MAPPING = {
+      # the SLE_HPC product was dropped and replaced by standard SLES in SP6
+      "SLE_HPC" => "SLES"
+    }.freeze
+
     def main
       textdomain "installation"
 
@@ -220,7 +227,7 @@ module Yast
     # FIXME: Currently it returns first found product name. It should be no
     # problem since this section was unused in AY installation so far.
     # However, it might be needed to add a special handling for multiple
-    # poducts in the future. At least we can filter out products which are
+    # products in the future. At least we can filter out products which are
     # not base products.
     #
     # @param profile [Hash] AutoYaST profile
@@ -234,7 +241,15 @@ module Yast
         return nil
       end
 
-      software.fetch_as_array("products").first
+      product = software.fetch_as_array("products").first
+      new_product = PRODUCT_MAPPING[product]
+
+      if new_product
+        log.info "Replacing requested product #{product.inspect} with #{new_product.inspect}"
+        return new_product
+      end
+
+      product
     end
   end
 


### PR DESCRIPTION
## Problem

- The HPC product (+ the HPC module) will be replaced by plain SLES + HPC module in SP6
- https://jira.suse.com/browse/PED-7841
- When the AutoYaST XML profile requests installing the `SLE_HPC` then it would display an error:
![hpc_ay_install_sp6_broken](https://github.com/yast/yast-autoinstallation/assets/907998/b5da64a7-dd46-4ec0-88a4-9419932bfbcd)

Note: The HPC product is still defined in the latest ISO. For testing I used a manually tweaked installation repository with removed `/Product-HPC` directory and updated `/media.1/products` file.

## Comments

- If this change was in SLE15 -> SLE16 (or SLE12 -> SLE15) I'd avoid adding hacks to YaST and prefer to solve that on the documentation level and in the release notes.
- On the other hand  we should not break the SP6 installations with profiles that worked fine in SP5 and earlier. That would be a nasty surprise for the users. 
- This allows using the same AY profile for both SP5 and SP6, less maintenance for users
- Note: Technically the HPC product is actually a SLES, the only difference is in the installed `*-release` package. (Plus HPC by default selects the HPC module.)

## Testing

- Tested manually, now the AutoYaST installs the standard SLES and does not report any error
![hpc_ay_install_sp6_fixed](https://github.com/yast/yast-autoinstallation/assets/907998/b642a3b9-7740-4fd4-8437-12cbfac2091b)
