### PR TITLE
Added pervasive encryption fields

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 20 14:29:46 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Update the partitioning schema to support the pervasive encryption
+  apqns and key type elements (jsc#PED-10950).
+- 4.7.1
+
+-------------------------------------------------------------------
 Fri Sep 06 07:14:32 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Branch package for SP7 (bsc#1230201)

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.7.0
+Version:        4.7.1
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/partitioning.rnc
+++ b/src/autoyast-rnc/partitioning.rnc
@@ -66,6 +66,8 @@ y2_partition =
   | part_crypt_label
   | part_crypt_cipher
   | part_crypt_key_size
+  | part_crypt_pervasive_apqns
+  | part_crypt_pervasive_key_type
   | part_filesystem
   | part_format
   | part_fs_options
@@ -117,6 +119,12 @@ part_crypt_pbkdf = element crypt_pbkdf { SYMBOL }
 part_crypt_label = element crypt_label { STRING }
 part_crypt_cipher = element crypt_cipher { STRING }
 part_crypt_key_size = element crypt_key_size { INTEGER }
+part_crypt_pervasive_apqns =
+  element crypt_pervasive_apqns {
+    LIST,
+    element crypt_pervasive_apqn { STRING }
+  }
+part_crypt_pervasive_key_type = element crypt_pervasive_key_type { STRING_ATTR, ("CCA-AESCIPHER" | "CCA-AESDATA") }
 part_filesystem =
   element filesystem { SYMBOL }
 part_format =

--- a/src/include/autoinstall/xml.rb
+++ b/src/include/autoinstall/xml.rb
@@ -28,6 +28,7 @@ module Yast
         "children"                 => "child",
         "chroot-scripts"           => "script",
         "classes"                  => "class",
+        "crypt_pervasive_apqns"    => "crypt_pervasive_apqn",
         "denyusers"                => "denyuser",
         "device_map"               => "device_map_entry",
         "device_map_entry"         => "device",


### PR DESCRIPTION
Add partitioning pervasive encryption fields to the schema (see https://github.com/yast/yast-storage-ng/pull/1402)

- https://trello.com/c/Ffc1JCwe


