### PR TITLE
Allow skipping profile fetch errors

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 20 10:50:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow skipping profile fetch errors by setting
+  YAST_SKIP_PROFILE_FETCH_ERROR=1 (see gh#agama-project/agama#2180).
+- 5.0.5
+
+-------------------------------------------------------------------
 Thu Feb 20 14:29:46 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Update the partitioning schema to support the pervasive encryption

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        5.0.4
+Version:        5.0.5
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/modules/ProfileLocation.rb
+++ b/src/modules/ProfileLocation.rb
@@ -123,7 +123,7 @@ module Yast
         if !ret
           # autoyast hit an error while fetching it's config file
           error = _("An error occurred while fetching the profile:\n")
-          Report.Error(Ops.add(error, @GET_error))
+          Report.Error(Ops.add(error, @GET_error)) if ENV["YAST_SKIP_PROFILE_FETCH_ERROR"] != "1"
           return false
         end
         tmp = SCR.Read(path(".target.string"), localfile)

--- a/test/ProfileLocation_test.rb
+++ b/test/ProfileLocation_test.rb
@@ -71,6 +71,30 @@ describe "Yast::ProfileLocation" do
       end
     end
 
+    context "when the profile does not exist" do
+      before do
+        allow(subject).to receive(:Get).and_return(false)
+      end
+
+      it "reports an error" do
+        expect(Yast::Report).to receive(:Error)
+        expect(subject.Process).to eq(false)
+      end
+
+      context "and fetch errors are disabled" do
+        around do |example|
+          ENV["YAST_SKIP_PROFILE_FETCH_ERROR"] = "1"
+          example.run
+          ENV.delete("YAST_SKIP_PROFILE_FETCH_ERROR")
+        end
+
+        it "does not report an error" do
+          expect(Yast::Report).to_not receive(:Error)
+          expect(subject.Process).to eq(false)
+        end
+      end
+    end
+
     context "when the profile is an erb file" do
       let(:filepath) { "autoinst.erb" }
 


### PR DESCRIPTION
If the environment variable `YAST_SKIP_PROFILE_FETCH_ERROR` is set to "1", the error is skipped.

## Problem

Agama tries to fetch the profiles from predefined locations if no URL is given. See https://github.com/agama-project/agama/pull/2180 for further details.

The problem is that, when the profile does not exist, the AutoYaST code reports an error and it should not do it because it is expected to search for those profiles silently.

## Solution

Allow to disable the error by setting the environment variable `YAST_SKIP_PROFILE_FETCH_ERROR`.

## Testing

- Added a new unit test