### PR TITLE
Instantiate the default security settings before importing the profile (bsc#1231490)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar 27 17:24:54 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Load default security settings before importing the section to
+  ensure the settings are set in case there is no security section 
+  defined and run without confirmation dialog (bsc#1231490)
+- 4.7.2
+
+-------------------------------------------------------------------
 Thu Feb 20 14:29:46 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Update the partitioning schema to support the pervasive encryption

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.7.1
+Version:        4.7.2
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -430,6 +430,10 @@ module Y2Autoinstallation
       #
       # @return [Boolean] Determine whether the import was successful
       def autosetup_security
+        require "installation/security_settings"
+        # Force to propose defaults for security and security policy configuration
+        @settings ||= ::Installation::SecuritySettings.instance
+
         result = importer.import_entry("security")
         result.sections.each { |e| Profile.remove_sections(e) }
         result.success?


### PR DESCRIPTION
## Problem

An unattended installation with a minimal profile and without a confirmation dialog does not select the security default settings and the required packages.

- https://bugzilla.suse.com/show_bug.cgi?id=1231490
- https://trello.com/c/AV5gwC6i/3970-already-late-1231490-selinux-packages-in-autoyast

## Solution

Instantiate the default security settings before importing the profile to ensure them are set even without a security section or without running the confirmation dialog.


## Testing

Tested manually the scenarios described below with:

**Tumbleweed:**

  - **Without confirmation dialog**
    - [x] Minimal profile without security section.
    - [x] Minimal profile with security section and selecting apparmor.
    - [x] Minimal profile with security section and selecting a different selinux mode.
 
  - **With confirmation dialog**
    - [x] Minimal profile without security section.
    - [x] Minimal profile with security section and selecting apparmor.
    - [x] Minimal profile with security section and selecting a different selinux mode.
   
**SLE-15-SP7:**

  - **Without confirmation dialog**
    - [x] Minimal profile without security section.
 
  - **With confirmation dialog**
    - [x] Minimal profile without security section.
