### PR TITLE
Move the firewall configuration between security and sotware in inst_autosetup (bsc#1243185).

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 16 17:29:09 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Move also the firewall section before software in inst_autosetup
+  (bsc#1243185).
+
+-------------------------------------------------------------------
 Thu Mar 27 17:24:54 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Load default security settings before importing the section to

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        4.7.2
+Version:        4.7.3
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only

--- a/src/lib/autoinstall/clients/inst_autosetup.rb
+++ b/src/lib/autoinstall/clients/inst_autosetup.rb
@@ -70,6 +70,7 @@ module Y2Autoinstallation
           _("Create partition plans"),
           _("Configure Bootloader"),
           _("Configure security settings"),
+          _("Configure firewall"),
           _("Set up configuration management system"),
           _("Registration"),
           _("Configure Kdump"),
@@ -79,7 +80,6 @@ module Y2Autoinstallation
           _("Import SSH keys/settings"),
           _("Set up user defined configuration files"),
           _("Confirm License"),
-          _("Configure firewall"),
           _("Check security policy")
         ]
 
@@ -89,6 +89,7 @@ module Y2Autoinstallation
           _("Creating partition plans..."),
           _("Configuring Bootloader..."),
           _("Configuring security settings"),
+          _("Configuring the firewall"),
           _("Setting up configuration management system..."),
           _("Registering the system..."),
           _("Configuring Kdump..."),
@@ -98,7 +99,6 @@ module Y2Autoinstallation
           _("Importing SSH keys/settings..."),
           _("Setting up user defined configuration files..."),
           _("Confirming License..."),
-          _("Configuring the firewall"),
           _("Checking the security policy")
         ]
 
@@ -254,6 +254,13 @@ module Y2Autoinstallation
 
         Progress.NextStage
 
+        #
+        # Run firewall configuration according to the profile
+        #
+        autosetup_firewall
+
+        Progress.NextStage
+
         # The configuration_management has to be called before software selection.
         # So the software selection is aware and can manage packages
         # needed by the configuration_management.
@@ -384,12 +391,6 @@ module Y2Autoinstallation
             return :abort if result == :abort && Yast::Popup.ConfirmAbort(:painless)
           end
         end
-
-        Progress.NextStage
-        #
-        # Run firewall configuration according to the profile
-        #
-        autosetup_firewall
 
         Progress.NextStage
 


### PR DESCRIPTION
## Problem

In #883 we instantiated the security settings before importing the profile to ensure the package selection was done before software was run but the firewall is still called later. 

As the SecuritySettings reads already the defaults for firewall it adds the firewalld package to the list of resolvables but if the firewall is disabled (follows the same logic that in the confirm dialog) it does not remove the package because PkgSolve is not called at all.

- https://bugzilla.suse.com/show_bug.cgi?id=1243185

## Solution

Move the firewall configuration after security and before software to ensure the package selection is done according to the user preferences or defaults.

The clients or setup that is run after sotware will face the same problem that exposed by security and firewalld. For example there is RemoveResolvables of ssg-apply called by security policy which is not handled by this PR.

## Testing

- *Tested manually*

**SLE-15-SP7:**
  - Without confirmation dialog
    - [x] Minimal profile without firewall section. (Firewall is installed if enabled in the control file).
    - [x] Minimal profile without firewalld section removing the package explicitly in the software section. (Firewall is removed from the package selection).
    - [x] Minimal profile with firewall section and disabling firewall (Firewall is remove from the package selection)