### PR TITLE
Drop the libyui dependency (related to bsc#1254978)

### DIFF
--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 15 08:26:47 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Drop libyui dependency in SLES (related to bsc#1254978)
+- 5.0.8
+
+-------------------------------------------------------------------
 Fri May 16 17:29:09 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Move also the firewall section before software in inst_autosetup

--- a/package/autoyast2.changes
+++ b/package/autoyast2.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Jan 15 08:26:47 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
-- Drop libyui dependency in SLES (related to bsc#1254978)
+- Drop the libyui dependency (related to bsc#1254978)
 - 5.0.8
 
 -------------------------------------------------------------------

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package autoyast2
 #
-# Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2026 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -27,7 +27,7 @@ Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
 Group:          System/YaST
-Url:            https://github.com/yast/yast-autoinstallation
+URL:            https://github.com/yast/yast-autoinstallation
 
 Source0:        autoyast2-%{version}.tar.bz2
 Source1:        autoyast_en_html.tar.bz2
@@ -45,14 +45,14 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  yast2 >= 4.4.38
 # FileSystems.read_default_subvol_from_target
 BuildRequires:  yast2-xml
-BuildRequires:  yast2-transfer
 BuildRequires:  yast2-services-manager
+BuildRequires:  yast2-transfer
 # ProductSpec API
 BuildRequires:  yast2-packager >= 4.4.13
-BuildRequires:  yast2-update >= 3.3.0
+BuildRequires:  yast2-country
 BuildRequires:  yast2-network >= 3.1.145
 BuildRequires:  yast2-slp
-BuildRequires:  yast2-country
+BuildRequires:  yast2-update >= 3.3.0
 # Support for SecurityPolicies
 BuildRequires:  yast2-security >= 4.5.3
 # Required for test suite testing one time sync
@@ -87,12 +87,12 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 Conflicts:      yast2-installation < 3.1.166
 
 Provides:       yast2-config-autoinst
-Provides:       yast2-module-autoinst
 Provides:       yast2-lib-autoinst
+Provides:       yast2-module-autoinst
 
 Obsoletes:      yast2-config-autoinst
-Obsoletes:      yast2-module-autoinst
 Obsoletes:      yast2-lib-autoinst
+Obsoletes:      yast2-module-autoinst
 
 BuildArch:      noarch
 
@@ -122,7 +122,6 @@ Requires:       yast2
 Requires:       yast2-bootloader
 Requires:       yast2-core
 Requires:       yast2-country
-
 # ProductSpec API
 Requires:       yast2-packager >= 4.4.13
 # ServicesManagerTargetClass::BaseTargets

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -22,7 +22,7 @@
 %endif
 
 Name:           autoyast2
-Version:        5.0.7
+Version:        5.0.8
 Release:        0
 Summary:        YaST2 - Automated Installation
 License:        GPL-2.0-only
@@ -122,7 +122,12 @@ Requires:       yast2
 Requires:       yast2-bootloader
 Requires:       yast2-core
 Requires:       yast2-country
+
+# require the ncurses UI only in openSUSE Tumbleweed or Leap
+%if 0%{?suse_version} == 1699 || 0%{?is_opensuse}
 Requires:       yast2-ncurses
+%endif
+
 # ProductSpec API
 Requires:       yast2-packager >= 4.4.13
 # ServicesManagerTargetClass::BaseTargets

--- a/package/autoyast2.spec
+++ b/package/autoyast2.spec
@@ -123,11 +123,6 @@ Requires:       yast2-bootloader
 Requires:       yast2-core
 Requires:       yast2-country
 
-# require the ncurses UI only in openSUSE Tumbleweed or Leap
-%if 0%{?suse_version} == 1699 || 0%{?is_opensuse}
-Requires:       yast2-ncurses
-%endif
-
 # ProductSpec API
 Requires:       yast2-packager >= 4.4.13
 # ServicesManagerTargetClass::BaseTargets


### PR DESCRIPTION
## Problem

- The YaST packages used by Agama still require libyui libraries, that means we have to maintain them in the SLES16 product
- Related PR https://github.com/yast/yast-ycp-ui-bindings-dummy/pull/1

## Solution

- Update the dependencies so in SLES the yast2-ycp-ui-bindings-dummy package is used instead of the regular bindings.

## Testing

- Tested manually
  - https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:dummy-ui project builds the Agama installer ISO for openSUSE Tumbleweed ([build log](https://build.opensuse.org/build/systemsmanagement:Agama:branches:dummy-ui/images/x86_64/agama-installer:openSUSE/_log)) and openSUSE Leap([build log](https://build.opensuse.org/build/systemsmanagement:Agama:branches:dummy-ui/images_Leap_16.0/x86_64/agama-installer-Leap:Leap_16.0/_log)), both logs show that the libyui is installed in the images (that's expected as both contain full YaST so we cannot drop the UI there)

  - https://build.suse.de/project/show/Devel:YaST:Agama:dummy-ui project (internal link) builds the SLES image, the libyui packages are not included in the image